### PR TITLE
Remove flashes on transitions; no tests

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,6 +5,7 @@ const { service } = Ember.inject;
 
 export default Ember.Route.extend(ApplicationRouteMixin, {
   currentUser: service(),
+  flashMessages: service(),
   onboarding: service(),
 
   beforeModel() {
@@ -57,6 +58,12 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
     error(e) {
       console.error(e);
       this.intermediateTransitionTo('application_error', e);
+    },
+
+    didTransition: function() {
+      // Clear flash messages on every transition
+      this.get('flashMessages').clearMessages();
+      return true; // Bubble the event
     },
 
     willTransition(transition) {

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,0 +1,23 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('route:application', 'Unit | Route | application', {
+  // Specify the other units that are required for this test.
+  needs: ['service:session', 'service:flash-messages']
+});
+
+test('it clears flash messages on transition', function(assert) {
+  assert.expect(2);
+
+  const typesUsed = ['success'];
+  const flashMessages = Ember.getOwner(this).lookup('service:flash-messages');
+  flashMessages.registerTypes(typesUsed);
+
+  let route = this.subject();
+
+  flashMessages.success('Success!');
+  assert.equal(flashMessages.get('queue.length'), 1);
+
+  route.send('didTransition');
+  assert.equal(flashMessages.get('queue.length'), 0);
+});


### PR DESCRIPTION
This removes flash messages on any transition to avoid persisting irrelevant UI.

We should write some acceptance tests for this.