### PR TITLE
Hide pagination when less than 2 pages

### DIFF
--- a/app/components/pager-control.js
+++ b/app/components/pager-control.js
@@ -10,6 +10,9 @@ export default Ember.Component.extend({
   totalRecords: Ember.computed.alias('options.totalRecords'),
   pageSize: Ember.computed.alias('options.pageSize'),
 
+  hasOnePage: Ember.computed.equal('totalPages', 1),
+  canShowPages: Ember.computed.gt('totalPages', 1),
+
   centerPage: Ember.computed('currentPage', 'pagesToShow', function() {
     let currentPage = this.get('currentPage');
     let pagesToShow = this.get('pagesToShow');
@@ -62,8 +65,8 @@ export default Ember.Component.extend({
     return this.get('currentPage') === 1;
   }),
 
-  onLastPage: Ember.computed('currentPage', 'totalPages', function() {
+  onLastPage: Ember.computed('currentPage', 'totalPages', 'hasOnePage', function() {
     return this.get('currentPage') === this.get('totalPages') ||
-      this.get('totalPages') === 0;
+      this.get('hasOnePage');
   })
 });

--- a/app/templates/components/pager-control.hbs
+++ b/app/templates/components/pager-control.hbs
@@ -1,25 +1,27 @@
-<div class="pagination">
-  {{#unless onFirstPage}}
-    {{#scroll-top}}
-      {{link-to "Previous" 'project.posts.index' (query-params page=previousPage) class="previous-page clear"}}
-    {{/scroll-top}}
-  {{else}}
-    <div>
-      <div class="clear first disabled">Previous</div>
-    </div>
-  {{/unless}}
-  {{#each pages as |page|}}
-    {{#scroll-top}}
-      {{link-to page 'project.posts.index' (query-params page=page) classNameBindings="page :page :clear"}}
-    {{/scroll-top}}
-  {{/each}}
-  {{#unless onLastPage}}
-    {{#scroll-top}}
-      {{link-to "Next" 'project.posts.index' (query-params page=nextPage) class="next-page clear"}}
-    {{/scroll-top}}
-  {{else}}
-    <div>
-      <div class="clear last disabled">Next</div>
-    </div>
-  {{/unless}}
-</div>
+{{#if canShowPages}}
+  <div class="pagination">
+    {{#unless onFirstPage}}
+      {{#scroll-top}}
+        {{link-to "Previous" 'project.posts.index' (query-params page=previousPage) class="previous-page clear"}}
+      {{/scroll-top}}
+    {{else}}
+      <div>
+        <div class="clear first disabled">Previous</div>
+      </div>
+    {{/unless}}
+    {{#each pages as |page|}}
+      {{#scroll-top}}
+        {{link-to page 'project.posts.index' (query-params page=page) classNameBindings="page :page :clear"}}
+      {{/scroll-top}}
+    {{/each}}
+    {{#unless onLastPage}}
+      {{#scroll-top}}
+        {{link-to "Next" 'project.posts.index' (query-params page=nextPage) class="next-page clear"}}
+      {{/scroll-top}}
+    {{else}}
+      <div>
+        <div class="clear last disabled">Next</div>
+      </div>
+    {{/unless}}
+  </div>
+{{/if}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -258,8 +258,8 @@ export default function() {
     // hacky, but the only way I could find to pass in a mocked meta object
     // for our pagination tests
     postsPage.meta = {
-      total_records: posts.length,
-      total_pages: Math.ceil(posts.length / pageSize),
+      total_records: posts.models.length,
+      total_pages: Math.ceil(posts.models.length / pageSize),
       page_size: pageSize,
       current_page: pageNumber || 1
     };

--- a/tests/integration/components/pager-control-test.js
+++ b/tests/integration/components/pager-control-test.js
@@ -56,7 +56,20 @@ test('If we are currently on the first page, the previous page button does not r
   assert.equal(this.$('.previous-page').length, 0, 'The button does not render');
 });
 
-test('If we are currently on the first and only page, the next page button does not render', function(assert) {
+test('If we are currently on the only page with some records, nothing renders', function(assert) {
+  this.set('options', {
+    pageSize: 5,
+    totalRecords: 5,
+    currentPage: 1,
+    totalPages: 1
+  });
+
+  this.render(hbs`{{pager-control options=options}}`);
+
+  assert.equal(this.$('.pagination').length, 0, 'Nothing renders');
+});
+
+test('If we are currently on the only page with no records, nothing renders', function(assert) {
   this.set('options', {
     pageSize: 5,
     totalRecords: 0,
@@ -66,7 +79,7 @@ test('If we are currently on the first and only page, the next page button does 
 
   this.render(hbs`{{pager-control options=options}}`);
 
-  assert.equal(this.$('.next-page').length, 0, 'The button does not render');
+  assert.equal(this.$('.pagination').length, 0, 'Nothing renders');
 });
 
 test('If we are currently on the last page, the next page button does not render', function(assert) {


### PR DESCRIPTION
We want to hide the pagination when there's only a single page. Makes no sense to have it in that case.