### PR TITLE
Add way to use Mirage in development and without redis

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -50,6 +50,14 @@ module.exports = function(environment) {
     }
   };
 
+  if (environment === 'mirage') {
+    ENV.OAUTH_SERVER_TOKEN_ENDPOINT = '/oauth/token/';
+
+    ENV['ember-cli-mirage'] = {
+      enabled: true
+    };
+  }
+
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;

--- a/mirage/factories/organization.js
+++ b/mirage/factories/organization.js
@@ -9,10 +9,10 @@ export default Factory.extend({
     return faker.lorem.paragraph();
   },
   iconThumbUrl() {
-    return faker.image.avatar();
+    return faker.image.cats();
   },
   iconLargeUrl() {
-    return faker.image.avatar();
+    return faker.image.cats();
   },
   slug(i) {
     if(this.name) {

--- a/mirage/factories/post.js
+++ b/mirage/factories/post.js
@@ -1,12 +1,12 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  title: faker.lorem.sentence,
+  title: faker.hacker.phrase,
   body: faker.lorem.paragraph,
   likesCount: faker.random.number,
   status: 'open',
   postType: faker.list.random('task', 'idea', 'issue', 'progress'),
   number(i) {
-    return i;
+    return i + 1;
   }
 });

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -2,10 +2,18 @@ import { Factory, faker } from 'ember-cli-mirage';
 import Ember from 'ember';
 
 export default Factory.extend({
-  title: faker.name.title,
-  description: faker.lorem.sentence,
-  iconThumbUrl: faker.image.imageUrl,
-  iconLargeUrl: faker.image.imageUrl,
+  title() {
+    return faker.name.title();
+  },
+  description() {
+    return faker.lorem.sentence();
+  },
+  iconThumbUrl() {
+    return faker.image.nature();
+  },
+  iconLargeUrl() {
+    return faker.image.nature();
+  },
 
   slug(i) {
     if(this.title) {

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,12 +1,26 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  biography: faker.lorem.paragraph,
-  email: faker.internet.email,
-  photoLargeUrl: faker.image.avatar,
-  photoThumbUrl: faker.image.avatar,
-  twitter: faker.internet.domainWord,
-  username: faker.internet.domainWord,
-  website: faker.internet.url,
+  biography() {
+    return faker.lorem.paragraph();
+  },
   base64PhotoData: null,
+  email() {
+    return faker.internet.email();
+  },
+  photoLargeUrl() {
+    return faker.image.avatar();
+  },
+  photoThumbUrl() {
+    return faker.image.avatar();
+  },
+  twitter() {
+    return faker.internet.domainWord();
+  },
+  username() {
+    return faker.internet.domainWord();
+  },
+  website() {
+    return faker.internet.url();
+  },
 });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,7 +1,74 @@
-export default function(/* server */) {
+export default function(server) {
+  let usersToPopulate = [
+    {
+      username: "joshsmith"
+    },
+    {
+      username: "begedin"
+    },
+    {
+      username: "caligoanimus"
+    },
+    {
+      username: "cstyles"
+    }
+  ];
 
-  // Seed your development database using your factories. This
-  // data will not be loaded in your tests.
+  for(var i = 0; i < usersToPopulate.length; i++) {
+    let user = server.create('user', { username: usersToPopulate[i].username });
+    let userRoute = server.create('slugged-route', {
+      ownerType: 'user',
+      slug: user.username
+    });
+    userRoute.owner = user;
+    userRoute.save();
+  }
 
-  // server.createList('contact', 10);
+  let users = server.db.users;
+
+  let organizations = [
+    {
+      name: "Code Corps",
+      slug: "code_corps"
+    },
+    {
+      name: "Movement",
+      slug: "movement"
+    },
+    {
+      name: "Watsi",
+      slug: "watsi"
+    },
+    {
+      name: "Really Very Long Name Intended to Break UI Some",
+      slug: "really_very_long_name_intended_to_break_ui_some"
+    }
+  ];
+
+  for(var i = 0; i < organizations.length; i++) {
+    let sluggedRoute = server.create('slugged-route', {
+      ownerType: 'organization',
+      slug: organizations[i].slug
+    });
+
+    let organization = server.create('organization', {
+      name: organizations[i].name,
+      slug: organizations[i].slug
+    });
+
+    debugger;
+
+    sluggedRoute.owner = organization;
+    sluggedRoute.save();
+
+    let project = server.create('project', {
+      organization: organization,
+      title: organizations[i].name
+    });
+
+    let posts = server.createList('post', 33, {
+      project: project,
+      userId: users[Math.floor(Math.random()*users.length)].id
+    });
+  }
 }


### PR DESCRIPTION
Attempt to close #74 and close #94.

I'm not sure how big a fan I am of this approach. While it technically works, a good amount of work would required to keep it up to date. It may be easier to give our Ember developers a packaged Rails app API that they can hit. Alternatively, we could have a flag that sets the API endpoint and they hit some non-staging development server.

Certain things, like syntax highlighting, simply _require_ a working API.

I'm actually more inclined to say Mirage is not appropriate for this use case, and that I would probably vote in favor of closing this PR unmerged. #94 specifically would then be closed, and #74 would be addressed by not having a deploy step, but instead hitting the API endpoint in a different environment, circumventing `ember-cli-deploy` altogether.