### PR TITLE
Add post types based on permissions

### DIFF
--- a/app/abilities/organization.js
+++ b/app/abilities/organization.js
@@ -7,6 +7,13 @@ export default Ability.extend({
   userCanLeaveOrganization: Ember.computed.or('membership.isContributor', 'membership.isAdmin'),
   userIsMemberInOrganization: Ember.computed.notEmpty('membership'),
 
+  isAtLeastContributor: Ember.computed.or('membership.isContributor', 'membership.isAdmin', 'membership.isOwner'),
+
   canJoin: Ember.computed.alias('userCanJoinOrganization'),
   canManage: Ember.computed.alias('isAtLeastAdmin'),
+
+  canCreateIssuePost: true,
+  canCreateIdeaPost: true,
+  canCreateProgressPost: Ember.computed.alias('isAtLeastContributor'),
+  canCreateTaskPost: Ember.computed.alias('isAtLeastContributor')
 });

--- a/app/components/post-new-form.js
+++ b/app/components/post-new-form.js
@@ -23,12 +23,8 @@ export default Ember.Component.extend(PostMentionFetcherMixin, {
     },
   ],
   tagName: 'form',
-  types: [
-    {label: "Task",  slug: "task"},
-    {label: "Issue", slug: "issue"},
-    {label: "Progress", slug: "progress"},
-    {label: "Idea", slug: "idea"}
-  ],
+
+  credentials: Ember.inject.service(),
 
   placeholder: Ember.computed('post.postType', function() {
     let postType = this.get('post.postType');

--- a/app/templates/components/post-new-form.hbs
+++ b/app/templates/components/post-new-form.hbs
@@ -1,12 +1,20 @@
 <img class="icon" src={{post.user.photoThumbUrl}} />
 <div class="post-new-form-body">
   <div class="input-group post-type {{post.postType}}">
-    {{select-dropdown
-      name='post-type'
-      items=types
-      selectedItem=post.postType
-      optionValuePath='slug'
-      optionLabelPath='label'}}
+    <select name="post-type" value={{post.postType}}>
+      {{#if (can "create task post in organization" organization membership=credentials.currentUserMembership)}}
+        <option value="task" selected={{eq post.postType 'task'}}>Task</option>
+      {{/if}}
+      {{#if (can "create issue post in organization" organization membership=credentials.currentUserMembership)}}
+        <option value="issue" selected={{eq post.postType 'issue'}}>Issue</option>
+      {{/if}}
+      {{#if (can "create progress post in organization" organization membership=credentials.currentUserMembership)}}
+        <option value="progress" selected={{eq post.postType 'progress'}}>Progress</option>
+      {{/if}}
+      {{#if (can "create idea post in organization" organization membership=credentials.currentUserMembership)}}
+        <option value="idea" selected={{eq post.postType 'idea'}}>Idea</option>
+      {{/if}}
+    </select>
     {{#each post.errors.postType as |error|}}
       <p class="error">{{error.message}}</p>
     {{/each}}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ember-sinon": "0.5.1",
     "ember-tether": "0.3.1",
     "ember-tooltips": "1.0.0",
+    "ember-truth-helpers": "1.2.0",
     "ember-typed": "0.1.3",
     "loader.js": "^4.0.1",
     "moment": "2.11.2",

--- a/tests/integration/components/post-new-form-test.js
+++ b/tests/integration/components/post-new-form-test.js
@@ -68,8 +68,23 @@ test('it has a loading indicator when previewing and post is saving', function(a
   assert.equal(this.$('.editor-with-preview .spinner').length, 1);
 });
 
-test('it renders option to create task or progress if user is at least contributor in organization', function(assert) {
-  assert.expect(2);
+test('it renders only idea and issue post type options if user is not at least a contributor to the organization', function(assert) {
+  assert.expect(4);
+
+  this.register('service:credentials', Ember.Service.extend({
+    currentUserMembership: { isContributor: false, isAdmin: false, isOwner: false }
+  }));
+
+  this.render(hbs`{{post-new-form post=post placeholder=placeholder}}`);
+
+  assert.equal(this.$('option[value=idea]').length, 1, 'idea option is rendered');
+  assert.equal(this.$('option[value=issue]').length, 1, 'issue option is rendered');
+  assert.equal(this.$('option[value=task]').length, 0, 'task option is rendered');
+  assert.equal(this.$('option[value=progress]').length, 0, 'progress option is rendered');
+});
+
+test('it renders all post type options if user is at least contributor', function(assert) {
+  assert.expect(4);
 
   this.register('service:credentials', Ember.Service.extend({
     currentUserMembership: { isContributor: true }
@@ -77,6 +92,8 @@ test('it renders option to create task or progress if user is at least contribut
 
   this.render(hbs`{{post-new-form post=post placeholder=placeholder}}`);
 
+  assert.equal(this.$('option[value=idea]').length, 1, 'idea option is rendered');
+  assert.equal(this.$('option[value=issue]').length, 1, 'issue option is rendered');
   assert.equal(this.$('option[value=task]').length, 1, 'task option is rendered');
   assert.equal(this.$('option[value=progress]').length, 1, 'progress option is rendered');
 });

--- a/tests/integration/components/post-new-form-test.js
+++ b/tests/integration/components/post-new-form-test.js
@@ -3,7 +3,10 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
 moduleForComponent('post-new-form', 'Integration | Component | post new form', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.register('service:credentials', Ember.Service.extend({ currentUserMembership: null }));
+  }
 });
 
 test('it renders', function(assert) {
@@ -20,7 +23,7 @@ test('it renders proper ui elements, properly bound', function(assert) {
   let post = {
     title: 'A post',
     markdownPreview: 'A body',
-    postType: 'task'
+    postType: 'idea'
   };
 
   let placeholder = "Test placeholder";
@@ -31,11 +34,11 @@ test('it renders proper ui elements, properly bound', function(assert) {
 
   assert.equal(this.$('[name=title]').val(), 'A post', 'Title is properly bound and rendered');
   assert.equal(this.$('[name=markdown]').val(), 'A body', 'Markdown content is properly bound and rendered');
-  assert.equal(this.$('[name=post-type]').val(), 'task', 'Post type is properly bound and rendered');
+  assert.equal(this.$('[name=post-type]').val(), 'idea', 'Post type is properly bound and rendered');
   assert.equal(this.$('textarea').attr('placeholder'), placeholder);
-  assert.equal(this.$('.input-group.post-type').hasClass('task'), true);
-  assert.equal(this.$('input[name=submit]').hasClass('task'), true);
-  assert.equal(this.$('input[name=submit]').val(), 'Submit new task');
+  assert.equal(this.$('.input-group.post-type').hasClass('idea'), true);
+  assert.equal(this.$('input[name=submit]').hasClass('idea'), true);
+  assert.equal(this.$('input[name=submit]').val(), 'Submit new idea');
   assert.equal(this.$('.editor-with-preview .spinner').length, 0);
 });
 
@@ -63,4 +66,17 @@ test('it has a loading indicator when previewing and post is saving', function(a
   this.render(hbs`{{post-new-form post=post}}`);
 
   assert.equal(this.$('.editor-with-preview .spinner').length, 1);
+});
+
+test('it renders option to create task or progress if user is at least contributor in organization', function(assert) {
+  assert.expect(2);
+
+  this.register('service:credentials', Ember.Service.extend({
+    currentUserMembership: { isContributor: true }
+  }));
+
+  this.render(hbs`{{post-new-form post=post placeholder=placeholder}}`);
+
+  assert.equal(this.$('option[value=task]').length, 1, 'task option is rendered');
+  assert.equal(this.$('option[value=progress]').length, 1, 'progress option is rendered');
 });


### PR DESCRIPTION
Closes #174 

I used the existing ember-can `organization` ability, since permissions are organization based.

All of this simply removes the option from the select dropdown if the user has no ability. Technically, the HTML could still be edited to create an invalid selection, but we have API checks in place for that.