### PR TITLE
Remove organization from project header

### DIFF
--- a/app/styles/components/project-details.scss
+++ b/app/styles/components/project-details.scss
@@ -11,21 +11,26 @@
     @include span-columns(4);
   }
 
+  .join-project {
+    font-size: 14px;
+    margin: 7px 0;
+  }
+
   h2 {
     margin: 7px 0;
     font-size: 26px;
+
+    a {
+      color: $hidden-link-color;
+      &:hover {
+        color: $link-color;
+      }
+    }
   }
 
   p {
     margin: 3px 0;
     font-size: 16px;
-  }
-
-  a {
-    color: $hidden-link-color;
-    &:hover {
-      color: $link-hover-color;
-    }
   }
 
   .icon-container {

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -22,12 +22,12 @@
     <li class="step">
       <div class="fund-icon"></div>
       <h4>Fund Projects</h4>
-      <p>We're building a crowdunfing platform to support ongoing work. We aim to keep funders engaged in projects and connected to the teams they're supporting.</p>
+      <p>We're building a crowdfunding platform to support ongoing work. We aim to keep funders engaged in projects and connected to the teams they're supporting.</p>
     </li>
     <li class="step">
       <div class="develop-icon"></div>
       <h4>Develop New Tools</h4>
-      <p>We're developing tools to help people collaborate on, organize, and even distribute their work. We're listening closely to hear what needs to built, and then building it.</p>
+      <p>We're developing tools to help people collaborate on, organize, and even distribute their work. We're listening closely to hear what needs built, and then building it.</p>
     </li>
   </ul>
   <div class="help">

--- a/app/templates/components/project-details.hbs
+++ b/app/templates/components/project-details.hbs
@@ -6,25 +6,22 @@
     <h2 class="title">{{#link-to 'project.index' project}}{{project.title}}{{/link-to}}</h2>
     {{#if expanded}}
       <p class="description">{{project.description}}</p>
-      <p class="organization">
-        {{#link-to 'slugged-route' project.organization.slug}}
-          <img class="icon tiny description-icon" src={{project.organization.iconThumbUrl}} />{{project.organization.name}}
-        {{/link-to}}
-      </p>
     {{/if}}
   </div>
 </div>
 <div class="more-details">
   <div class="right">
+    <p class="join-project">
     {{#if session.isAuthenticated}}
       {{#if (can "join organization" project.organization membership=credentials.currentUserMembership)}}
-        <button class="join-project btn-default" {{action 'joinProject'}}>Join Project</button>
+        <button class="default small" {{action 'joinProject'}}>Join project</button>
       {{/if}}
       {{#if credentials.userMembershipIsPending}}
-        <button class="clear" disabled>Membership pending</button>
+        <button class="clear small" disabled>Membership pending</button>
       {{/if}}
     {{else}}
-      <span class="join-project">You need to be logged in to join this project</span>
+      {{link-to "Sign up" "signup" class="button default small"}} to join this project.
     {{/if}}
+    </p>
   </div>
 </div>

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -287,7 +287,7 @@ test('A user can join the organization of the project', (assert) => {
   visit(projectURL);
 
   andThen(() => {
-    assert.equal(find('.join-project button').text().trim(), 'Sign up', 'The link to sign up is present when logged out');
+    assert.equal(find('.join-project a').text().trim(), 'Sign up', 'The link to sign up is present when logged out');
 
     authenticateSession(application, { user_id: user.id });
     visit(projectURL);
@@ -295,7 +295,7 @@ test('A user can join the organization of the project', (assert) => {
 
 
   andThen(() => {
-    assert.equal(find('.join-project button').text().trim(), 'Join project', 'The link to sign up is present when logged out');
+    assert.equal(find('.join-project button').text().trim(), 'Join project', 'The button to join is present when logged in');
     click('.join-project button');
   });
 

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -278,7 +278,7 @@ test('Paging and filtering uses query parameters', (assert) => {
 });
 
 test('A user can join the organization of the project', (assert) => {
-  assert.expect(7);
+  assert.expect(5);
 
   let project = createProject();
   let projectURL = `/${project.organization.slug}/${project.slug}/`;
@@ -287,8 +287,7 @@ test('A user can join the organization of the project', (assert) => {
   visit(projectURL);
 
   andThen(() => {
-    assert.equal(find('button.join-project').length, 0, 'The link to join project is missing when logged out');
-    assert.equal(find('span.join-project').length, 1, 'The helper indicating user must login to join project is present when logged out');
+    assert.equal(find('.join-project button').text().trim(), 'Sign up', 'The link to sign up is present when logged out');
 
     authenticateSession(application, { user_id: user.id });
     visit(projectURL);
@@ -296,9 +295,8 @@ test('A user can join the organization of the project', (assert) => {
 
 
   andThen(() => {
-    assert.equal(find('button.join-project').length, 1, 'The link to join the project is present when logged in');
-    assert.equal(find('span.join-project').length, 0, 'The helper indicating user must login to join project is missing when logged in.');
-    click('button.join-project');
+    assert.equal(find('.join-project button').text().trim(), 'Join project', 'The link to sign up is present when logged out');
+    click('.join-project button');
   });
 
   let done = assert.async();

--- a/tests/integration/components/project-details-test.js
+++ b/tests/integration/components/project-details-test.js
@@ -26,7 +26,6 @@ test('when expanded', function(assert) {
 
   assert.equal(this.$('.title').text().trim(), project.title, 'Title is rendered');
   assert.equal(this.$('.description').text().trim(), project.description, 'Description is rendered');
-  assert.equal(this.$('.icon').attr('src'), project.iconLargeUrl, 'Image element is rendered');
 });
 
 test('when not expanded', function(assert) {
@@ -37,5 +36,4 @@ test('when not expanded', function(assert) {
 
   assert.equal(this.$('.title').text().trim(), project.title, 'Title is rendered');
   assert.equal(this.$('.description').length, 0, 'Hides description');
-  assert.equal(this.$('.icon').attr('src'), project.iconLargeUrl, 'Image element is rendered');
 });


### PR DESCRIPTION
This also does some design cleanup on buttons for joining projects.