### PR TITLE
Fix and cleanup flash message styles

### DIFF
--- a/app/styles/_alerts.scss
+++ b/app/styles/_alerts.scss
@@ -1,41 +1,53 @@
 .flash {
-  .container {
-    margin-bottom: 10px;
 
-    .alert {
+  .alert {
+    @mixin alert-whitespace {
+      margin-bottom: 10px;
       padding: 5px 0;
-      &.alert-success {
-        background: $success-background;
-        color: white;
+    }
+
+    &.alert-success .container,
+    &.alert-success .fixed-flash-inner {
+      background: $success-background;
+      color: white;
+    }
+
+    &.alert-danger .container,
+    &.alert-danger .fixed-flash-inner {
+      background: $red;
+      color: white;
+    }
+
+    // regular flash message container, displayed full width
+    // almost on top of the page
+    .container {
+      margin-bottom: 10px;
+      padding: 5px 0 5px 10px;
+    }
+
+    // fixed positioned flash message container, displayed at the very top of the page
+    // as wide as the text, centered
+    .fixed-flash {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      text-align: center;
+
+      .fixed-flash-inner {
+        border-radius: 4px;
+        cursor: pointer;
+        display: inline-block;
+        padding: 5px 20px;
+        margin-top: 15px;
+
+        @include fadeInDown(0.6s);
+
+        p {
+          margin: 5px 0;
+        }
       }
     }
   }
 }
 
-.fixed-flash {
-  position: fixed;
-  top: 0; left: 0; right: 0;
-  text-align: center;
-}
 
-.fixed-flash-inner {
-  border-radius: 4px;
-  color: white;
-  cursor: pointer;
-  display: inline-block;
-  padding: 5px 20px;
-  margin-top: 15px;
 
-  @include fadeInDown(0.6s);
-
-  p {
-    margin: 5px 0;
-  }
-}
-
-.alert-danger {
-  .fixed-flash-inner {
-    background: $red;
-    color: white;
-  }
-}


### PR DESCRIPTION
Closes #221 

I reorganized the style a bit there, so It's easier to figure out in the future.

I also added a left padding to the regular flash message container, since as it was, the text was at the far left edge of the page and looked weird.

Fixed look:

![image](https://cloud.githubusercontent.com/assets/1925540/16187803/93b34c58-36d2-11e6-87d1-3d7b8835f60d.png)
