### PR TITLE
Added filtering by post status

### DIFF
--- a/app/adapters/post.js
+++ b/app/adapters/post.js
@@ -20,6 +20,12 @@ export default ApplicationAdapter.extend({
       delete query.postType;
     }
 
+    // we don't want to send the status parameter to the API if it does not
+    // have a proper value
+    if (Ember.isEmpty(query.status)) {
+      delete query.status;
+    }
+
     // projectId is part of the url in `projects/:projectId/posts`, so we
     // do not want to see it in the query as well
     if (query.projectId) {

--- a/app/components/post-filter-dropdown.js
+++ b/app/components/post-filter-dropdown.js
@@ -4,16 +4,16 @@ export default Ember.Component.extend({
   classNames: ['dropdown-menu'],
   tagName: 'ul',
 
-  click: function() {
+  click() {
     this.sendAction('hide');
   },
 
   actions: {
-    filterByType: function(type) {
-      this.sendAction('filterByType', type);
+    filterBy(filter) {
+      this.sendAction('filterBy', filter);
     },
 
-    hide: function() {
+    hide() {
       this.sendAction('hide');
     },
   }

--- a/app/components/post-filter-type.js
+++ b/app/components/post-filter-type.js
@@ -7,13 +7,15 @@ export default Ember.Component.extend({
   active: false,
 
   actions: {
-    filterByType: function(type) {
+    filterByType(type) {
       this.sendAction('filterByType', type);
     },
-    hide: function() {
+
+    hide() {
       this.set('active', false);
     },
-    toggle: function() {
+
+    toggle() {
       this.toggleProperty('active');
     },
   },

--- a/app/components/project-post-list.js
+++ b/app/components/project-post-list.js
@@ -23,10 +23,6 @@ export default Ember.Component.extend({
     filterByStatus(status) {
       this.sendAction('filterByStatus', status);
     },
-
-    removeStatusFilter(status) {
-      this.sendAction('removeStatusFilter', status);
-    }
   },
 
   _normalizeMeta(meta) {

--- a/app/components/project-post-list.js
+++ b/app/components/project-post-list.js
@@ -12,13 +12,21 @@ export default Ember.Component.extend({
   }),
 
   actions: {
-    filterByType: function(type) {
+    filterByType(type) {
       this.sendAction('filterByType', type);
     },
 
-    removeTypeFilter: function(type) {
+    removeTypeFilter(type) {
       this.sendAction('removeTypeFilter', type);
     },
+
+    filterByStatus(status) {
+      this.sendAction('filterByStatus', status);
+    },
+
+    removeStatusFilter(status) {
+      this.sendAction('removeStatusFilter', status);
+    }
   },
 
   _normalizeMeta(meta) {

--- a/app/controllers/project/posts/index.js
+++ b/app/controllers/project/posts/index.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   page: 1,
+  postStatus: 'open',
   postType: null,
   types: [
     Ember.Object.create({
@@ -24,13 +25,18 @@ export default Ember.Controller.extend({
     }),
   ],
 
-  isFiltered: Ember.computed.notEmpty('postTypes'),
+  status: Ember.computed.alias('postStatus'),
+
+  isFilteringClosedPosts: Ember.computed.equal('status', 'closed'),
+  isFilteringOpenPosts: Ember.computed.equal('status', 'open'),
+  isFilteredByType: Ember.computed.notEmpty('postTypes'),
+  isFiltered: Ember.computed.or('isFilteredByType'),
 
   postTypes: Ember.computed('postType', function() {
     var postTypes;
     let array = this.get('postType');
 
-    if(array) {
+    if (array) {
       postTypes = array.split(',');
     } else {
       postTypes = [];
@@ -59,7 +65,7 @@ export default Ember.Controller.extend({
   },
 
   actions: {
-    filterByType: function(type) {
+    filterByType(type) {
       let postTypes = this.get('postTypes');
       let typeParam = type.get('param');
 
@@ -79,7 +85,7 @@ export default Ember.Controller.extend({
       this.resetPage();
     },
 
-    removeTypeFilter: function(type) {
+    removeTypeFilter(type) {
       let postTypes = this.get('postTypes');
       let typeParam = type.get('param');
 
@@ -94,6 +100,15 @@ export default Ember.Controller.extend({
         this.set('postType', types);
       }
 
+      this.resetPage();
+    },
+
+    filterByStatus(status) {
+      this.set('postStatus', status);
+    },
+
+    removeStatusFilter() {
+      this.set('postStatus', null);
       this.resetPage();
     }
   }

--- a/app/controllers/project/posts/index.js
+++ b/app/controllers/project/posts/index.js
@@ -106,10 +106,5 @@ export default Ember.Controller.extend({
     filterByStatus(status) {
       this.set('postStatus', status);
     },
-
-    removeStatusFilter() {
-      this.set('postStatus', null);
-      this.resetPage();
-    }
   }
 });

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -5,11 +5,13 @@ import Ember from 'ember';
 
 export default Model.extend({
   base64IconData: attr(),
+  closedPostsCount: attr('number'),
   description: attr(),
   iconLargeUrl: attr(),
   iconThumbUrl: attr(),
   longDescriptionBody: attr(),
   longDescriptionMarkdown: attr(),
+  openPostsCount: attr('number'),
   slug: attr(),
   title: attr(),
 
@@ -17,6 +19,7 @@ export default Model.extend({
   organization: belongsTo('organization', { async: true }),
   posts: hasMany('posts', { async: true }),
 
+  hasOpenPosts: Ember.computed.gt('openPostsCount', 0),
   hasPendingMembers: Ember.computed.alias('organization.hasPendingMembers'),
   pendingMembersCount: Ember.computed.alias('organization.pendingMembersCount'),
 });

--- a/app/routes/project/posts/index.js
+++ b/app/routes/project/posts/index.js
@@ -3,14 +3,29 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   queryParams: {
     page: { refreshModel: true, scope: 'controller' },
-    postType: { refreshModel: true, scope: 'controller' }
+    postType: { refreshModel: true, scope: 'controller' },
+    status: { refreshModel: true, scope: 'controller' }
   },
 
   model(params) {
     let project = this.modelFor('project');
-    let fullParams = Ember.merge(params, {
-      projectId: project.get('id')
-    });
+    let fullParams = Ember.merge(params, { projectId: project.get('id') });
     return this.get('store').query('post', fullParams);
+  },
+
+  setupController(controller) {
+    controller.set('project', this.modelFor('project'));
+    this._super(...arguments);
+  },
+
+  // there is a semi-known ember bug, where a query parameter with an initial value not set to null
+  // and then later set to null, will have its value serialized as "null" (string)
+  // we fix this here
+  deserializeQueryParam(value, urlKey, defaultValueType) {
+    if (urlKey === 'status' && value === "null") {
+      return null;
+    } else {
+      return this._super(value, urlKey, defaultValueType);
+    }
   },
 });

--- a/app/styles/components/project-menu.scss
+++ b/app/styles/components/project-menu.scss
@@ -24,23 +24,31 @@
       border-bottom-color: $primary-color;
       color: $primary-color;
       font-weight: 700;
+
+      span.info {
+        background: $dark-blue;
+      }
     }
 
     &:hover {
       border-bottom-color: $primary-color;
       color: $primary-color;
       transition: border-bottom-color ease 0.3s;
+
+      span.info {
+        background: $dark-blue;
+      }
     }
 
     span.info {
-      background: $dark-blue;
+      background: $extra-light-text;
       border-radius: 4px;
       color: white;
       font-size: 12px;
       font-weight: 300;
-      padding: 2px 7px 4px 7px;
+      padding: 2px 7px 3px 7px;
       margin-left: 5px;
-      vertical-align: 2px;
+      vertical-align: 1px;
 
       strong {
         font-weight: 700;

--- a/app/styles/components/project-post-list.scss
+++ b/app/styles/components/project-post-list.scss
@@ -8,6 +8,41 @@
       padding: 1px 0;
     }
   }
+
+  .statuses {
+    margin: 0 20px;
+
+    li {
+      display: inline-block;
+      font-size: 14px;
+      padding: 7px 0;
+
+      &:first-child {
+        margin-right: 10px;
+      }
+    }
+
+    a {
+      color: $extra-light-text;
+      font-weight: 300;
+
+      &.active {
+        font-weight: 700;
+      }
+
+      &.closed {
+        &:hover, &.active {
+          color: $danger-color;
+        }
+      }
+
+      &.open {
+        &:hover, &.active {
+          color: $default-color;
+        }
+      }
+    }
+  }
 }
 
 @mixin postTypeFilter($type) {

--- a/app/styles/components/project-post-list.scss
+++ b/app/styles/components/project-post-list.scss
@@ -2,6 +2,47 @@
   @include clearfix;
 
   margin: 10px 0;
+
+  .dropdown-menu {
+    li {
+      padding: 1px 0;
+    }
+  }
+
+  .statuses {
+    margin: 0 20px;
+
+    li {
+      display: inline-block;
+      font-size: 14px;
+      padding: 7px 0;
+
+      &:first-child {
+        margin-right: 10px;
+      }
+    }
+
+    a {
+      color: $extra-light-text;
+      font-weight: 300;
+
+      &.active {
+        font-weight: 700;
+      }
+
+      &.closed {
+        &:hover, &.active {
+          color: $danger-color;
+        }
+      }
+
+      &.open {
+        &:hover, &.active {
+          color: $default-color;
+        }
+      }
+    }
+  }
 }
 
 @mixin postTypeFilter($type) {
@@ -23,14 +64,6 @@
     color: white;
     &:before {
       @include sprite(map-get($postTypeIconHovers, $type));
-    }
-  }
-}
-
-.posts-menu {
-  .dropdown-menu {
-    li {
-      padding: 1px 0;
     }
   }
 }

--- a/app/styles/components/project-post-list.scss
+++ b/app/styles/components/project-post-list.scss
@@ -8,41 +8,6 @@
       padding: 1px 0;
     }
   }
-
-  .statuses {
-    margin: 0 20px;
-
-    li {
-      display: inline-block;
-      font-size: 14px;
-      padding: 7px 0;
-
-      &:first-child {
-        margin-right: 10px;
-      }
-    }
-
-    a {
-      color: $extra-light-text;
-      font-weight: 300;
-
-      &.active {
-        font-weight: 700;
-      }
-
-      &.closed {
-        &:hover, &.active {
-          color: $danger-color;
-        }
-      }
-
-      &.open {
-        &:hover, &.active {
-          color: $default-color;
-        }
-      }
-    }
-  }
 }
 
 @mixin postTypeFilter($type) {

--- a/app/templates/components/post-filter-dropdown.hbs
+++ b/app/templates/components/post-filter-dropdown.hbs
@@ -1,8 +1,8 @@
 <div class="dropdown-header">
-  <p>Filter by type <a class="right close" {{action "hide"}}>&times;</a></p>
+  <p>Filter by {{field}} <a class="right close" {{action "hide"}}>&times;</a></p>
 </div>
-{{#each selectedTypes as |type|}}
+{{#each selectedFilters as |filter|}}
 <li>
-  <a class="filter {{type.slug}} {{if type.selected "selected"}}" {{action "filterByType" type}}>{{type.name}}</a>
+  <a class="filter {{field}} {{filter.slug}} {{if filter.selected "selected"}}" {{action "filterBy" filter}}>{{filter.name}}</a>
 </li>
 {{/each}}

--- a/app/templates/components/post-filter-status.hbs
+++ b/app/templates/components/post-filter-status.hbs
@@ -1,0 +1,4 @@
+{{#click-outside action=(action "hide")}}
+  <button class="clear small {{if active "active"}}" {{action 'toggle'}}>Status</button>
+  {{post-filter-dropdown field="status" selectedFilters=selectedStatuses hide="hide" filterBy="filterByStatus"}}
+{{/click-outside}}

--- a/app/templates/components/post-filter-type.hbs
+++ b/app/templates/components/post-filter-type.hbs
@@ -1,4 +1,4 @@
 {{#click-outside action=(action "hide")}}
   <button class="clear small {{if active "active"}}" {{action 'toggle'}}>Type</button>
-  {{post-filter-dropdown selectedTypes=selectedTypes hide="hide" filterByType="filterByType"}}
+  {{post-filter-dropdown selectedFilters=selectedTypes hide="hide" filterBy="filterByType"}}
 {{/click-outside}}

--- a/app/templates/components/project-menu.hbs
+++ b/app/templates/components/project-menu.hbs
@@ -1,5 +1,5 @@
 <li>{{#link-to 'project.index' project}}About{{/link-to}}</li>
-<li>{{#link-to 'project.posts' project}}Posts{{/link-to}}</li>
+<li>{{#link-to 'project.posts' project}}Posts {{#if project.hasOpenPosts}}<span class="info">{{project.openPostsCount}}</span>{{/if}}{{/link-to}}</li>
 {{#if session.isAuthenticated}}
   {{#if (can "manage organization" project.organization membership=credentials.currentUserMembership)}}
     <li class="contributors">

--- a/app/templates/components/project-post-list.hbs
+++ b/app/templates/components/project-post-list.hbs
@@ -1,6 +1,16 @@
 <div class="posts-menu">
   <div class="left">
-    {{post-filter-type project=project selectedTypes=selectedTypes filterByType="filterByType"}}
+    {{post-filter-type selectedTypes=selectedTypes filterByType="filterByType"}}
+  </div>
+  <div class="left statuses">
+    <ul>
+      <li>
+        <a class="open {{if isFilteringOpenPosts "active"}}" {{action "filterByStatus" "open"}}>{{project.openPostsCount}} Open</a>
+      </li>
+      <li>
+        <a class="closed {{if isFilteringClosedPosts "active"}}" {{action "filterByStatus" "closed"}}>{{project.closedPostsCount}} Closed</a>
+      </li>
+    </ul>
   </div>
   <div class="right">
     {{link-to 'New post' 'project.posts.new' tagName='button' class="default small new-post"}}

--- a/app/templates/project/posts/index.hbs
+++ b/app/templates/project/posts/index.hbs
@@ -1,1 +1,12 @@
-{{project-post-list posts=model pageNumber=page selectedTypes=selectedTypes isFiltered=isFiltered filterByType="filterByType" removeTypeFilter="removeTypeFilter"}}
+{{project-post-list
+  isFiltered=isFiltered
+  isFilteringClosedPosts=isFilteringClosedPosts
+  isFilteringOpenPosts=isFilteringOpenPosts
+  filterByStatus="filterByStatus"
+  filterByType="filterByType"
+  pageNumber=page
+  posts=model
+  project=project
+  removeTypeFilter="removeTypeFilter"
+  selectedTypes=selectedTypes
+}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -326,22 +326,25 @@ export default function() {
   // GET /projects/:id
   this.get('/projects/:id');
 
-  // GET project/posts
+  // GET project/:id/posts
   this.get("/projects/:projectId/posts", (schema, request) => {
     let projectId = request.params.projectId;
     let postType = request.queryParams.post_type;
+    let postStatus = request.queryParams.status;
 
     let pageNumber = request.queryParams['page[number]'];
     let pageSize = request.queryParams['page[size]'] || 10;
 
     let project = schema.projects.find(projectId);
 
-    let posts;
+    let posts = project.posts;
 
     if (postType) {
-      posts = project.posts.filter((p) =>  p.postType === postType );
-    } else {
-      posts = project.posts;
+      posts = posts.filter((p) =>  p.postType === postType );
+    }
+
+    if (postStatus) {
+      posts = posts.filter((p) => p.status === postStatus);
     }
 
     let postsPage = posts.filter((p, index) => {

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -2,10 +2,12 @@ import { Factory, faker } from 'ember-cli-mirage';
 import Ember from 'ember';
 
 export default Factory.extend({
-  title: faker.name.title,
+  closedPostsCount: 0,
   description: faker.lorem.sentence,
-  iconThumbUrl: faker.image.imageUrl,
   iconLargeUrl: faker.image.imageUrl,
+  iconThumbUrl: faker.image.imageUrl,
+  openPostsCount: 0,
+  title: faker.name.title,
 
   slug(i) {
     if(this.title) {

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -128,6 +128,42 @@ test('Post filtering by type works', (assert) => {
   });
 });
 
+test('Post filtering by status works', (assert) => {
+  assert.expect(8);
+
+  let project = createProject();
+  project.closedPostsCount = 2;
+  project.openPostsCount = 4;
+  project.save();
+
+  server.createList('post', 2, { postType: 'issue', status: 'closed', projectId: project.id });
+  server.createList('post', 4, { postType: 'issue', status: 'open', projectId: project.id });
+
+  let postsURL = `${project.organization.slug}/${project.slug}/posts`;
+
+  visit(postsURL);
+
+  andThen(() => {
+    assert.equal(find('.statuses .open').text().trim(), '4 Open', 'open count is rendered');
+    assert.equal(find('.statuses .closed').text().trim(), '2 Closed', 'closed count is rendered');
+
+    assert.equal(find('.statuses .open').hasClass('active'), true, 'open count has the active class');
+    assert.equal(find('.project-post-list .post-item').length, 4, 'open posts are rendered by default');
+    click('.statuses .closed');
+  });
+
+  andThen(() => {
+    assert.equal(find('.statuses .closed').hasClass('active'), true, 'closed count has the active class');
+    assert.equal(find('.project-post-list .post-item').length, 2, 'only closed posts are rendered');
+    click('.statuses .open');
+  });
+
+  andThen(() => {
+    assert.equal(find('.statuses .open').hasClass('active'), true, 'open count has the active class');
+    assert.equal(find('.project-post-list .post-item').length, 4, 'open posts are rendered');
+  });
+});
+
 test('Post paging links are correct', (assert) =>  {
   assert.expect(10);
 

--- a/tests/integration/components/post-filter-dropdown-test.js
+++ b/tests/integration/components/post-filter-dropdown-test.js
@@ -33,8 +33,8 @@ test('it renders', function(assert) {
 });
 
 test('it renders all required elements', function(assert) {
-  this.render(hbs`{{post-filter-dropdown selectedTypes=selectedTypes}}`);
   this.set('selectedTypes', types);
+  this.render(hbs`{{post-filter-dropdown field='type' selectedFilters=selectedTypes}}`);
 
   let firstType = types[0];
 
@@ -49,7 +49,7 @@ test('it renders all required elements', function(assert) {
 test('it sends filterByType action with the right type when clicking a link', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{post-filter-dropdown selectedTypes=selectedTypes filterByType="filterByType"}}`);
+  this.render(hbs`{{post-filter-dropdown selectedFilters=selectedTypes filterBy="filterByType"}}`);
   this.set('selectedTypes', types);
 
   let firstType = types[0];
@@ -76,7 +76,7 @@ test('it sends the hide action when clicking close', function(assert) {
 test('it sends the hide action when clicking an item', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{post-filter-dropdown selectedTypes=selectedTypes hide="hide"}}`);
+  this.render(hbs`{{post-filter-dropdown selectedFilters=selectedTypes hide="hide"}}`);
   this.set('selectedTypes', types);
 
   this.on('hide', function() {

--- a/tests/integration/components/project-menu-test.js
+++ b/tests/integration/components/project-menu-test.js
@@ -25,6 +25,34 @@ test('when not authenticated, it renders properly', function(assert) {
 
 });
 
+test('it renders the post count when it has posts', function(assert) {
+  assert.expect(1);
+
+  this.register('service:session', Ember.Service.extend({ isAuthenticated: false }));
+  this.set('project', {
+    hasOpenPosts: true,
+    openPostsCount: 7
+  });
+
+  this.render(hbs`{{project-menu project=project}}`);
+
+  assert.equal(this.$('.project-menu li a span.info').text().trim(), '7', 'The number of open posts are rendered');
+});
+
+test('it does not render the post count when it has no posts', function(assert) {
+  assert.expect(1);
+
+  this.register('service:session', Ember.Service.extend({ isAuthenticated: false }));
+  this.set('project', {
+    hasOpenPosts: false,
+    openPostsCount: 0
+  });
+
+  this.render(hbs`{{project-menu project=project}}`);
+
+  assert.equal(this.$('.project-menu li a span.info').length, 0, 'The number of open posts are not rendered');
+});
+
 test('when authenticated, and user cannot manage organization, it renders properly', function(assert) {
   assert.expect(5);
 


### PR DESCRIPTION
Closes #214 

I generalized the `post-filter-dropdown` component a bit, so we can use it both for type and status filters. The filter behavior itself, though, which is defined at controller level is semi-exclusive, meaning that the filter can be either open or closed (or neither). It cannot be both open and closed at the same time. Considering that, there is no "all" button to remove status filters from the page. Instead, we simply select another filter, or click to dismiss the current filter.