### PR TITLE
Add ability to open and close posts

### DIFF
--- a/app/abilities/post.js
+++ b/app/abilities/post.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+export default Ability.extend({
+  credentials: Ember.inject.service(),
+  currentUser: Ember.inject.service(),
+
+  post: Ember.computed.alias('model'),
+
+  userIsAuthor: Ember.computed('post', 'currentUser.user', function() {
+    let postUserId = this.get('post.user.id');
+    let currentUserId = this.get('currentUser.user.id');
+
+    return postUserId === currentUserId;
+  }),
+
+  membership: Ember.computed.alias('credentials.currentUserMembership'),
+  userIsAtLeastAdmin: Ember.computed.or('membership.isAdmin', 'membership.isOwner'),
+
+  canEdit: Ember.computed.or('userIsAuthor', 'userIsAtLeastAdmin')
+});

--- a/app/components/post-status-button.js
+++ b/app/components/post-status-button.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['post-status-button'],
+  tagName: 'span',
+
+  isOpen: Ember.computed.equal('post.status', 'open'),
+
+  actions: {
+    closePost() {
+      let post = this.get('post');
+      post.set('status', 'closed');
+      return post.save();
+    },
+
+    reopenPost() {
+      let post = this.get('post');
+      post.set('status', 'open');
+      return post.save();
+    },
+  }
+});

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -8,9 +8,14 @@ export default ApplicationSerializer.extend({
     } else {
       // for updating existing records, we have 2 cases
       // 1. we're editing the title. In that case, we only push the title
-      // 2. We're outright editing the post body - we only send markdown
+      // 2. we're opening/closing the post. We only push the status
+      // 3. We're outright editing the post body - we only send markdown
       if (snapshot.changedAttributes().title) {
         if (attribute.name === 'title') {
+          this._super(snapshot, json, key, attribute);
+        }
+      } else if (snapshot.changedAttributes().status) {
+        if (attribute.name === 'status') {
           this._super(snapshot, json, key, attribute);
         }
       } else {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -51,6 +51,7 @@
 @import "components/post-meta";
 @import "components/post-new-form";
 @import "components/post-title";
+@import "components/post-status-button";
 @import "components/progress-bar";
 @import "components/project-details";
 @import "components/project-grid-item";

--- a/app/styles/components/post-status-button.scss
+++ b/app/styles/components/post-status-button.scss
@@ -1,0 +1,3 @@
+.post-status-button {
+  float: right;
+}

--- a/app/templates/components/create-comment-form.hbs
+++ b/app/templates/components/create-comment-form.hbs
@@ -14,6 +14,7 @@
     </div>
     <div class="input-group">
       <button class="default right {{if comment.isSaving "disabled"}}" name="save" {{action 'saveComment'}}>Comment</button>
+      {{yield}}
     </div>
   </div>
 {{else}}

--- a/app/templates/components/post-status-button.hbs
+++ b/app/templates/components/post-status-button.hbs
@@ -1,0 +1,5 @@
+{{#if isOpen}}
+  <button class="button clear" name="close" {{action 'closePost'}}>Close post</button>
+{{else}}
+  <button class="button clear" name="open" {{action 'reopenPost'}}>Reopen post</button>
+{{/if}}

--- a/app/templates/project/posts/post.hbs
+++ b/app/templates/project/posts/post.hbs
@@ -4,7 +4,9 @@
   {{post-details post=post}}
   {{post-comment-list comments=comments}}
   <div>
-    {{create-comment-form comment=newComment saveComment='saveComment'}}
+    {{#create-comment-form comment=newComment saveComment='saveComment'}}
+      {{#if (can "edit post" post)}}{{post-status-button post=post}}{{/if}}
+    {{/create-comment-form}}
     {{#if error}}
       {{error-formatter error=error}}
     {{/if}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -252,26 +252,12 @@ export default function() {
   });
 
   // PATCH /posts/:id
-  this.patch('/posts/:id', (schema, request) => {
-    let requestBody = JSON.parse(request.requestBody);
-    let attributes = requestBody.data.attributes;
-    let postId = request.params.id;
-    let post = schema.posts.find(postId);
+  this.patch('/posts/:id', function(schema, request) {
     // the API takes takes markdown and renders body
-    let markdown = attributes.markdown;
-    let body = `<p>${markdown}</p>`;
+    let attrs = this.normalizedRequestAttrs();
+    attrs.body = `<p>${attrs.markdown}</p>`
 
-    let attrs = {
-      id: postId,
-      markdown: markdown,
-      body: body,
-      title: attributes.title,
-      postType: attributes.post_type
-    };
-
-    // for some reason, post.update(key, value) updates post properties, but
-    // doesn't touch the post.attrs object, which is what is used in response
-    // serialization
+    let post = schema.posts.find(attrs.id);
     post.attrs = attrs;
 
     post.postUserMentions.models.forEach((mention) => mention.destroy());

--- a/tests/integration/components/create-comment-form-test.js
+++ b/tests/integration/components/create-comment-form-test.js
@@ -27,6 +27,16 @@ test('it renders', function(assert) {
   assert.equal(this.$('form.create-comment-form').length, 1, 'The component\'s element is rendered');
 });
 
+test('it yelds to content', function(assert) {
+  assert.expect(1);
+
+  this.register('service:session', mockSession);
+
+  this.render(hbs`{{#create-comment-form}}Random content{{/create-comment-form}}`);
+  let componentTextContent = this.$('form.create-comment-form').text().trim();
+  assert.ok(componentTextContent.indexOf('Random content') > -1, 'The provided content is yielded to');
+});
+
 test('it renders the proper elements', function(assert) {
   assert.expect(2);
 

--- a/tests/integration/components/post-status-button-test.js
+++ b/tests/integration/components/post-status-button-test.js
@@ -1,0 +1,57 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('post-status-button', 'Integration | Component | post status button', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{post-status-button}}`);
+
+  assert.equal(this.$('.post-status-button').length, 1, 'The element renders');
+});
+
+
+test('when post is open, it renders the button to close it', function(assert) {
+  assert.expect(4);
+
+  let mockPost = Ember.Object.create({
+    status: 'open',
+    set(property, value) {
+      assert.equal(property, 'status', 'Status is set to closed');
+      assert.equal(value, 'closed', 'Status is set to closed');
+    },
+    save() {
+      assert.ok(true, 'Save is called');
+    }
+  });
+
+  this.set('post', mockPost);
+  this.render(hbs`{{post-status-button post=post}}`);
+
+  assert.equal(this.$('.post-status-button [name=close]').length, 1, 'The element renders');
+  this.$('.post-status-button [name=close]').click();
+});
+
+test('when post is closed, it renders the button to open it', function(assert) {
+  assert.expect(4);
+
+  let mockPost = Ember.Object.create({
+    status: 'closed',
+    set(property, value) {
+      assert.equal(property, 'status', 'Status is set to open');
+      assert.equal(value, 'open', 'Status is set to open');
+    },
+    save() {
+      assert.ok(true, 'Save is called');
+    }
+  });
+
+  this.set('post', mockPost);
+  this.render(hbs`{{post-status-button post=post}}`);
+
+  assert.equal(this.$('.post-status-button [name=open]').length, 1, 'The element renders');
+  this.$('.post-status-button [name=open]').click();
+});

--- a/tests/unit/abilities/post-test.js
+++ b/tests/unit/abilities/post-test.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('ability:post', 'Unit | Ability | post', {
+});
+
+test('it can edit post if user is the post author', function(assert) {
+  let ability = this.subject({
+    model: Ember.Object.create({ user: Ember.Object.create({ id: 1 }) }),
+    currentUser: Ember.Object.create({ user: Ember.Object.create({ id: 1 }) })
+  });
+  assert.ok(ability.get('canEdit'));
+});
+
+test('it cannot edit post if user is not the post author', function(assert) {
+  let ability = this.subject({
+    model: Ember.Object.create({ user: Ember.Object.create({ id: 1 }) }),
+    currentUser: Ember.Object.create({ user: Ember.Object.create({ id: 2 }) })
+  });
+  assert.notOk(ability.get('canEdit'));
+});
+
+test('it can edit post if user is at least admin in organization', function(assert) {
+  let ability = this.subject({
+    credentials: Ember.Object.create({
+      currentUserMembership: Ember.Object.create({ isAdmin: true })
+    }),
+  });
+  assert.ok(ability.get('canEdit'));
+});
+
+test('it can edit post if user is at least admin in organization', function(assert) {
+  let ability = this.subject({
+    credentials: Ember.Object.create({
+      currentUserMembership: Ember.Object.create({ isAdmin: false })
+    }),
+  });
+  assert.notOk(ability.get('canEdit'));
+});
+


### PR DESCRIPTION
Closes #213 

The button is put next to the "create comment" button on the post page. I made the `create-comment-form` component yield to it, so it can be placed from the `post.hbs` template directly, since that's the level that's more related to it.

Test's cover this behavior completely.

I also added a new, `post` ability, which allows us to quickly access other posts permissions. While doing this, I realized we can simply inject services into our ability class, meaning we don't have to do stuff like:

```Handlebars
{{#if (can "manage organization" organization membership=credentials.currentUserMembership) }}
```

Instead, we simply inject the `credentials` service into our `organization` ability and we get access to  `credentials.currentUserMembership` directly.

Then, our template code becomes:

```Handlebars
{{#if (can "manage organization" organization) }}
```

We can even go a step further and do 

```Handlebars
{{#if (can "manage organization") }}
```

since our `credentials` service also provides the current organization.

I'll create an issue for this suggested change/refactor.