### PR TITLE
Add mention prefetching and coalesce find requests

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -9,7 +9,7 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   // TODO: Fix this once many-to-many lands in ember-cli-mirage
   // but as of right now there is no way to make this work for
   // all possible cases
-  // coalesceFindRequests: true,
+  coalesceFindRequests: true,
 
   host: ENV.API_BASE_URL,
 

--- a/app/components/comment-item.js
+++ b/app/components/comment-item.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
 
   init() {
     this.set('isEditing', false);
-    this._fetchMentions(this.get('comment'));
+    this._prefetchMentions(this.get('comment'));
     return this._super(...arguments);
   },
 
@@ -45,5 +45,10 @@ export default Ember.Component.extend({
     this.get('mentionFetcher').fetchBodyWithMentions(comment, 'comment').then((body) => {
       this.set('commentBodyWithMentions', body);
     });
-  }
+  },
+
+  _prefetchMentions(comment) {
+    let body = this.get('mentionFetcher').prefetchBodyWithMentions(comment, 'comment');
+    this.set('commentBodyWithMentions', body);
+  },
 });

--- a/app/components/post-details.js
+++ b/app/components/post-details.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
 
   init() {
     this.set('isEditingBody', false);
-    this._fetchMentions(this.get('post'));
+    this._prefetchMentions(this.get('post'));
     return this._super(...arguments);
   },
 
@@ -45,5 +45,10 @@ export default Ember.Component.extend({
     this.get('mentionFetcher').fetchBodyWithMentions(post, 'post').then((body) => {
       this.set('postBodyWithMentions', body);
     });
-  }
+  },
+
+  _prefetchMentions(post) {
+    let body = this.get('mentionFetcher').prefetchBodyWithMentions(post, 'post');
+    this.set('postBodyWithMentions', body);
+  },
 });

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -8,7 +8,7 @@ export default Model.extend({
   createdAt: attr('date'),
   markdown: attr('string'),
 
-  commentUserMentions: hasMany('commentUserMention', { async: true }),
+  commentUserMentions: hasMany('comment-user-mention', { async: true }),
   post: belongsTo('post', { async: true }),
   user: belongsTo('user', { async: true }),
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -14,6 +14,7 @@ export default Model.extend({
   title: attr(),
 
   comments: hasMany('comment', { async: true }),
+  commentUserMentions: hasMany('comment-user-mention', { asnyc: true }),
   postUserMentions: hasMany('post-user-mention', { asnyc: true }),
   project: belongsTo('project', { async: true }),
   user: belongsTo('user', { async: true }),

--- a/app/services/mention-fetcher.js
+++ b/app/services/mention-fetcher.js
@@ -4,6 +4,13 @@ import { parse } from 'code-corps-ember/utils/mention-parser';
 export default Ember.Service.extend({
   store: Ember.inject.service(),
 
+  prefetchBodyWithMentions(record, type) {
+    let relationshipType = `${type}UserMentions`;
+    let body = record.get('body');
+    let mentions = record.get(relationshipType);
+    return parse(body, mentions);
+  },
+
   fetchBodyWithMentions(record, type) {
     let store = this.get('store');
 

--- a/app/styles/templates/project/index.scss
+++ b/app/styles/templates/project/index.scss
@@ -1,3 +1,3 @@
 .project-main {
-  @include span-columns(9);
+  @include span-columns(8);
 }

--- a/app/utils/mention-parser.js
+++ b/app/utils/mention-parser.js
@@ -14,7 +14,6 @@ function _generateLink(mention) {
 }
 
 function _parseMentions(body, mentions) {
-
   let parsedBody = '';
   let currentPosition = 0;
 

--- a/mirage/models/post.js
+++ b/mirage/models/post.js
@@ -4,5 +4,6 @@ export default Model.extend({
   user: belongsTo(),
   project: belongsTo(),
   comments: hasMany(),
-  postUserMentions: hasMany()
+  commentUserMentions: hasMany(),
+  postUserMentions: hasMany(),
 });

--- a/mirage/serializers/comment.js
+++ b/mirage/serializers/comment.js
@@ -1,0 +1,5 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+  include: ['comment-user-mentions'],
+});

--- a/mirage/serializers/post.js
+++ b/mirage/serializers/post.js
@@ -1,6 +1,7 @@
 import MirageApplicationSerializer from './application';
 
 export default MirageApplicationSerializer.extend({
+  include: ['comments', 'comment-user-mentions', 'post-user-mentions'],
   serialize(modelOrCollection) {
     let response = MirageApplicationSerializer.prototype.serialize.call(this, ...arguments);
 

--- a/tests/integration/components/comment-item-test.js
+++ b/tests/integration/components/comment-item-test.js
@@ -2,18 +2,14 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
+let mockMentionFetcher = Ember.Service.extend({
+  fetchBodyWithMentions: Ember.RSVP.resolve,
+  prefetchBodyWithMentions: Ember.K
+});
+
 let mockStore = Ember.Service.extend({
   query () {
     return Ember.RSVP.resolve([]);
-  }
-});
-
-let mockStoreReturningMentions = Ember.Service.extend({
-  query () {
-    return Ember.RSVP.resolve([
-      Ember.Object.create({ indices: [14, 19], username: 'user1', user: { id: 1 } }),
-      Ember.Object.create({ indices: [25, 30], username: 'user2', user: { id: 2 } })
-    ]);
   }
 });
 
@@ -36,7 +32,11 @@ let mockCommentWithMentions = Ember.Object.create({
   user: { id: 1 },
   save() {
     return Ember.RSVP.resolve();
-  }
+  },
+  commentUserMentions: [
+    Ember.Object.create({ indices: [14, 19], username: 'user1', user: { id: 1 } }),
+    Ember.Object.create({ indices: [25, 30], username: 'user2', user: { id: 2 } })
+  ]
 });
 
 moduleForComponent('comment-item', 'Integration | Component | comment item', {
@@ -49,12 +49,10 @@ moduleForComponent('comment-item', 'Integration | Component | comment item', {
 test('it renders', function(assert) {
   assert.expect(1);
 
-  let mockMentionFetcher = Ember.Service.extend({
-    fetchBodyWithMentions: Ember.RSVP.resolve
-  });
   this.register('service:mention-fetcher', mockMentionFetcher);
 
-  this.render(hbs`{{comment-item}}`);
+  this.set('comment', mockComment);
+  this.render(hbs`{{comment-item comment=comment}}`);
 
   assert.equal(this .$('.comment-item').length, 1, 'Component\' element is rendered');
 });
@@ -77,12 +75,7 @@ test('it renders all required comment elements properly', function(assert) {
 test('it switches between editing and viewing mode', function(assert) {
   assert.expect(3);
 
-  let mockMentionFetcher = Ember.Service.extend({
-    fetchBodyWithMentions: Ember.RSVP.resolve
-  });
-
   this.register('service:mention-fetcher', mockMentionFetcher);
-
   this.register('service:current-user', mockCurrentUser);
 
   this.set('comment', mockComment);
@@ -99,8 +92,6 @@ test('it switches between editing and viewing mode', function(assert) {
 
 test('mentions are rendered on comment body in read-only mode', function(assert) {
   assert.expect(1);
-
-  this.register('service:store', mockStoreReturningMentions);
 
   this.set('comment', mockCommentWithMentions);
 

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -6,6 +6,7 @@ moduleForModel('post', 'Unit | Model | post', {
     'model:project',
     'model:user',
     'model:comment',
+    'model:comment-user-mention',
     'model:post-user-mention'
   ]
 });

--- a/tests/unit/serializers/post-test.js
+++ b/tests/unit/serializers/post-test.js
@@ -7,6 +7,7 @@ moduleForModel('post', 'Unit | Serializer | post', {
     'model:project',
     'model:user',
     'model:comment',
+    'model:comment-user-mention',
     'model:post-user-mention'
   ]
 });

--- a/tests/unit/services/mention-fetcher-test.js
+++ b/tests/unit/services/mention-fetcher-test.js
@@ -4,7 +4,7 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('service:mention-fetcher', 'Unit | Service | mention fetcher', {
 });
 
-test('it queries store for proper type of mentions, with a proper type of parameter', function(assert) {
+test('when fetching, it queries store for proper type of mentions, with a proper type of parameter', function(assert) {
   assert.expect(2);
 
   let service = this.subject();
@@ -26,7 +26,7 @@ test('it queries store for proper type of mentions, with a proper type of parame
   service.fetchBodyWithMentions(mockFooRecord, 'foo');
 });
 
-test('if there are no mentions, it just returns the record body', function(assert) {
+test('when fetching, if there are no mentions, it just returns the record body', function(assert) {
   assert.expect(1);
 
   let service = this.subject();
@@ -52,7 +52,7 @@ test('if there are no mentions, it just returns the record body', function(asser
   });
 });
 
-test('if there are mentions, it just the record body, with those mentions inserted', function(assert) {
+test('when fetching, if there are mentions, it returns the record body, with those mentions inserted', function(assert) {
   assert.expect(1);
 
   let service = this.subject();
@@ -85,3 +85,34 @@ test('if there are mentions, it just the record body, with those mentions insert
   });
 });
 
+test('when prefetching, if there are no mentions, it just returns the record body', function(assert) {
+  assert.expect(1);
+
+  let service = this.subject();
+
+  let mockFooRecord = Ember.Object.create({
+    id: 'nope',
+    body: 'Foo body'
+  });
+
+  let body = service.prefetchBodyWithMentions(mockFooRecord, 'foo');
+  assert.equal(body, 'Foo body');
+});
+
+test('when prefetching, if there are mentions, it returns the record body, with those mentions inserted', function(assert) {
+  assert.expect(1);
+
+  let service = this.subject();
+
+  let mockFooWithMentions = Ember.Object.create({
+    body: '<p>Mentioning @user1 and @user2</p>',
+    fooUserMentions: [
+      Ember.Object.create({ indices: [14, 19], username: 'user1', user: { id: 1 } }),
+      Ember.Object.create({ indices: [25, 30], username: 'user2', user: { id: 2 } })
+    ]
+  });
+
+  let expectedOutput = '<p>Mentioning <a href="/user1" class="username">@user1</a> and <a href="/user2" class="username">@user2</a></p>';
+  let body = service.prefetchBodyWithMentions(mockFooWithMentions, 'foo');
+  assert.equal(body, expectedOutput);
+});


### PR DESCRIPTION
This adds mention prefetching to remove N+1 requests for comments when loading a post. This assumes comment mentions are included in the response from the server.