### PR TITLE
Add yuidoc, and example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ You should refer to our [style guide](STYLEGUIDE.md) for writing Ember.js, HTML/
 
 The app uses Circle for continuous integration and deploys automatically to a staging server when merging into `develop` and to production when merging into `master`.
 
+## Documentation
+
+The Code Corps Ember application uses [YUIDoc](http://yui.github.io/yuidoc/) for documentation. When contributing to the documentation please follow the [YUIDoc syntax](http://yui.github.io/yuidoc/syntax/index.html) and our [style guide](STYLEGUIDE.md) for application specific documenation standards.
+
+### Generating Documentation
+
+* `npm install -g yuidocjs`
+* `yuidoc -c yuidoc.json`
+
+The documentation will be generated in the `/docs` folder.
+
+### Serving Documentation
+
+* Generate the docs
+* `yuidoc --server [your port of choice]`
+* Visit `localhost:[your port of choice]` in your browser.
+
 ## Further Reading / Useful Links
 
 * [ember.js](http://emberjs.com/)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -10,6 +10,7 @@
 
 + [Ember models](#ember-models)
 + [Ember modules](#ember-modules)
++ [Documentation](#documentation)
 
 ### Ember models
 
@@ -129,6 +130,34 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+### Documentation
+
+Follow the syntax outlined on the [YUIDoc Syntax Page](http://yui.github.io/yuidoc/syntax/index.html). As YUIDoc was built for `Javascript`, not for `Ember` specifically, we've set our own rough guidelines for this `Ember` project.
+
+* `Components/Services/Routes/Models` will each be a module. All extensions of them should define which `@module` it belongs to.
+* All extensions of these modules are defined as `@class`
+* Actions are defined as `@method`, but should be specified that they are actions in the description.
+* Properties & Computed Properties should be defined as `@property`
+* Components should have an example of default usage
+
+
+        // some-component.js
+        
+        /**
+          @module Components
+          @extends Ember.Component
+          @class some-component
+        
+          Component description
+        
+          ## default usage
+          ```handlebars
+          {{some-component attrs=attrs}}
+          ```
+         */
+        export default Ember.Component.extend({
+
 
 ## HTML and Handlebars
 

--- a/app/components/user-menu.js
+++ b/app/components/user-menu.js
@@ -1,5 +1,19 @@
 import Ember from 'ember';
 
+/**
+  The user-menu component is used to show/hide the user-dropdown menu
+
+  ## default usage
+
+  ```handlebars
+    {{user-menu user=current}}
+  ```
+
+  @module Component
+  @class user-menu
+  @extends Ember.Component
+  @public
+ */
 export default Ember.Component.extend({
   classNames: ['user-menu', 'dropdown'],
   classNameBindings: ['hidden:menu-hidden:menu-visible'],
@@ -10,9 +24,20 @@ export default Ember.Component.extend({
   },
 
   actions: {
+    /**
+     * Action that sets the hidden attribute to true
+     *
+     * @method hide
+     */
     hide: function() {
       this.set('hidden', true);
     },
+
+    /**
+     * Action that toggles the hidden property
+     *
+     * @method toggle
+     */
     toggle: function() {
       this.toggleProperty('hidden');
     },

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,0 +1,15 @@
+{
+  "name": "code-corps-ember",
+  "description": "Small description for code-corps-ember goes here",
+  "version": "0.0.0",
+  "options": {
+    "exclude": "vendor",
+    "linkNatives": true,
+    "lint": false,
+    "outdir": "docs",
+    "parseOnly": false,
+    "paths": [
+      "app"
+    ]
+  }
+}


### PR DESCRIPTION
# What's in this PR?
- This adds a `yuidoc.json` configuration file for documenting the ember app. See instructions for generating and serving the docs below. I am new to using yuidoc, but I think I covered the required bases in this configuration file.
- This also includes some basic documentation for one of the components `user-menu`
<img width="584" alt="screen shot 2016-07-11 at 12 08 50 am" src="https://cloud.githubusercontent.com/assets/5448834/16721335/bb5fa42a-46fb-11e6-9820-1e4c6f8d58da.png">

## Reasons for decisions
- I decided to go with plain `yuidoc` rather than the ember add-on, as I don't feel the add-on really gives you much more. The benefit to using the `ember-cli-yuidoc` add-on is that you can run `ember ember-cli-yuidoc` to generate the docs without installing `yuidoc` globally. Also, there is a nifty flag `--docs` on `ember s` but I found it wasn't always reliable between environments. That being said, I am open to suggestions/feedback on this decision.
- What we use for documenting things in ember wasn't *clear* to me, and that comes from most ember apps not needing/or simply not using docs. I decided to label each component as a `class` that has `properties` & `methods` rather than using yuidocs `element`, as I found it wasn't as nice for documenting each method within (I think it pretty much only lets you document attributes within elements). Once again, open to feedback on this. See example docs.

# How to get set-up
- pull down this branch
- `npm install -g yuidocjs`
- To compile a new set of docs run `yuidoc -c yuidoc.json` (using the projects configuration file)
- To serve docs run `yuidoc --server [your port of choice]` and visit `localhost:[your port of choice]/`

# References
- #223 
- [yuidoc](http://yui.github.io/yuidoc/)