### PR TITLE
ignores vim cruft: undo and file buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ testem.log
 .env.deploy.production
 
 .DS_Store
+
+# editor cruft
+.*~
+.*swp
+.*swo


### PR DESCRIPTION
simple update to `.gitignore` so us vim users don't see messy staging area.