### PR TITLE
Update squashing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,43 +35,4 @@ Before We Can Merge
 
 If you've had a pull request reviewed and accepted, congratulations! Before we can merge your changes, we'll need you to rebase off `origin/develop` and squash your commits into one. This will give us a cleaner git history.
 
-Never done this before? No problem. We'll walk you through it, and you can read [a deeper guide about rewriting history to understand more](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
-
-On your command line you'll want to do:
-
-```
-git rebase -i origin/develop
-```
-
-This says to rebase your work off of develop. If you use an editor like Sublime Text, you'll want to [be sure your editor doesn't close without a response](https://gist.github.com/geekmanager/9939cf67598efd409bc7).
-
-From here, you'll see something like:
-
-```
-pick f48d47c The first commit I did
-pick fd4e046 The second commit I did
-```
-
-You'll want to change everything after your first commit from `pick` to `squash`. This tells git you want to squash these commits into the first one.
-
-From here, you'll get an editor that will let you change the commit messages.
-
-```
-# This is a combination of 2 commits.
-# The first commit's message is:
-The first commit I did
-
-# This is the 2nd commit message:
-
-The second commit I did
-```
-
-You'll want to remove or comment out everything except for the first message, which you can edit to be a more complete summary of your changes.
-
-To finish, you'll force push this new commit with the following command:
-
-```
-git push origin [my-feature-branch] --force-with-lease
-```
-
-The `--force-with-lease` flag will refuse to update a branch if someone else has updated it upstream, making your force push a little safer.
+Never done this before? No problem. [We'll walk you through it in our guide](docs/SQUASHING.md), and you can read [a deeper guide about rewriting history to understand more](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).

--- a/docs/SQUASHING.md
+++ b/docs/SQUASHING.md
@@ -1,0 +1,48 @@
+# How do I "squash" my commits?
+
+Before you start, [make sure your text editor is associated with Git](https://help.github.com/articles/associating-text-editors-with-git/) to not close without a response, otherwise you'll see some weird behavior.
+
+Then update your refs to be sure you have the latest code:
+
+```shell
+ git fetch --all
+```
+
+To start your rebase run:
+
+```shell
+git rebase -i origin/develop
+```
+
+This says to rebase your work onto develop.
+
+From here, you'll see something like:
+
+```
+pick f48d47c The first commit I did
+pick fd4e046 The second commit I did
+```
+
+You'll want to change everything after your first commit from `pick` to `squash`. This tells git you want to squash these commits into the first one.
+
+From here, you'll get an editor that will let you change the commit messages.
+
+```
+# This is a combination of 2 commits.
+# The first commit's message is:
+The first commit I did
+
+# This is the 2nd commit message:
+
+The second commit I did
+```
+
+You'll want to remove or comment out everything except for the first message, which you can edit to be a more complete summary of your changes.
+
+To finish, you'll force push this new commit with the following command:
+
+```shell
+git push origin [my-feature-branch] --force-with-lease
+```
+
+The `--force-with-lease` flag will refuse to update a branch if someone else has updated it upstream, making your force push a little safer.


### PR DESCRIPTION
This updates the squashing docs to reference any editor, not just Sublime. Also breaks them out into their own separate area.