### PR TITLE
Add Documentation for a few post components

### DIFF
--- a/app/components/post-meta.js
+++ b/app/components/post-meta.js
@@ -1,5 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-  classNames: ['post-meta']
-});

--- a/app/components/post-new-form.js
+++ b/app/components/post-new-form.js
@@ -1,18 +1,49 @@
 import Ember from 'ember';
 
+/**
+  The post-new-form component is used for creating new posts. It includes the
+  post type, title, editor and preview
+
+  ## default usage
+
+  ```handlebars
+  {{post-new-form post=newPost savePost='savePostMethod'}}
+  ```
+
+  @class post-new-form
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-new-form'],
   classNameBindings: ['post.postType'],
   tagName: 'form',
 
+  /**
+    @property credentials
+    @type Ember.Service
+   */
   credentials: Ember.inject.service(),
 
+  /**
+    Holds the placeholder messages for each post type: task, issue, idea.
+
+    @property placeholders
+    @type Object
+   */
   placeholders: {
     task: "How can you describe the steps to complete the task so anyone can work on it?",
     issue: "What issue needs resolved? If it's a bug, how can anyone reproduce it?",
     idea: "What's your idea? Be specific so people can give more accurate feedback.",
   },
 
+  /**
+    Returns which placeholder message to use from the placeholders property
+    based on the post type.
+
+    @property placeholder
+    @type String
+   */
   placeholder: Ember.computed('post.postType', function() {
     let postType = this.get('post.postType');
     if (postType) {
@@ -21,6 +52,13 @@ export default Ember.Component.extend({
   }),
 
   actions: {
+
+    /**
+      Action that is fired on form submit. Sends the `savePost` action that
+      was passed into the component.
+
+      @method submit
+     */
     submit() {
       let post = this.get('post');
       this.sendAction('savePost', post);

--- a/app/components/post-status-button.js
+++ b/app/components/post-status-button.js
@@ -1,18 +1,43 @@
 import Ember from 'ember';
 
+/**
+  The post-status-button component is a button that is used for closing and
+  re-opening posts.
+
+  @class post-status-button
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-status-button'],
   tagName: 'span',
 
+  /**
+    Computed property that checks if the post is open.
+
+    @property isOpen
+    @type Boolean
+   */
   isOpen: Ember.computed.equal('post.status', 'open'),
 
   actions: {
+
+    /**
+      Action that sets the posts status to `closed` and saves the post.
+
+      @method closePost
+     */
     closePost() {
       let post = this.get('post');
       post.set('status', 'closed');
       return post.save();
     },
 
+    /**
+      Action that sets the posts status to `open` and saves the post.
+
+      @method reopenPost
+     */
     reopenPost() {
       let post = this.get('post');
       post.set('status', 'open');

--- a/app/components/post-status.js
+++ b/app/components/post-status.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const {
+  computed,
+} = Ember;
+
+/**
+  A badge that presents a post's status
+
+  ## default usage
+
+  ```handlebars
+  {{post-status post=post}}
+  ```
+
+  @class post-status
+  @module Component
+  @extends Ember.Component
+ */
+export default Ember.Component.extend({
+  classNames: ['post-status-badge'],
+
+  status: computed.alias('post.status'),
+});

--- a/app/components/post-title.js
+++ b/app/components/post-title.js
@@ -1,15 +1,51 @@
 import Ember from 'ember';
 
+/**
+  @class post-title
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-title'],
   classNameBindings: ['isEditing:editing'],
 
+  /**
+    @property currentUser
+    @type Ember.Service
+   */
   currentUser: Ember.inject.service(),
 
+  /**
+    Returns whether or not the current user can edit the current post.
+
+    @property canEdit
+    @type Boolean
+   */
   canEdit: Ember.computed.alias('currentUserIsPostAuthor'),
+
+  /**
+    Returns the current user's ID.
+
+    @property currentUserId
+    @type Number
+   */
   currentUserId: Ember.computed.alias('currentUser.user.id'),
+
+  /**
+    Returns the post author's ID.
+
+    @property postAuthorId
+    @type Number
+   */
   postAuthorId: Ember.computed.alias('post.user.id'),
 
+  /**
+    Consumes `currentUserId` and `postAuthorId` and returns if the current user
+    is the post author.
+
+    @property currentUserIsPostAuthor
+    @type Boolean
+   */
   currentUserIsPostAuthor: Ember.computed('currentUserId', 'postAuthorId', function() {
     let userId = parseInt(this.get('currentUserId'), 10);
     let authorId = parseInt(this.get('postAuthorId'), 10);
@@ -24,15 +60,33 @@ export default Ember.Component.extend({
   },
 
   actions: {
+    /**
+      Action that sets the `isEditing` property to `false`
+
+      @method cancel
+     */
     cancel() {
       this.set('isEditing', false);
     },
 
+    /**
+      Action that set the `isEditing` property to true and sets the `newTitle`
+      property to the current title.
+
+      @method edit
+     */
     edit() {
       this.set('newTitle', this.get('post.title'));
       this.set('isEditing', true);
     },
 
+    /**
+      Action that sets the `title` property to the `newTitle` and calls save on
+      the post. If the post successfully saves, the `isEditing` property is set
+      to `false`.
+
+      @method save
+     */
     save() {
       let component = this;
       let post = this.get('post');

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -48,7 +48,7 @@
 @import "components/post-details";
 @import "components/post-header";
 @import "components/post-item";
-@import "components/post-meta";
+@import "components/post-status";
 @import "components/post-new-form";
 @import "components/post-title";
 @import "components/post-status-button";

--- a/app/styles/components/post-status.scss
+++ b/app/styles/components/post-status.scss
@@ -1,4 +1,4 @@
-.post-meta {
+.post-status-badge {
   @include span-columns(12);
 
   margin-bottom: 10px;

--- a/app/templates/components/post-meta.hbs
+++ b/app/templates/components/post-meta.hbs
@@ -1,1 +1,0 @@
-<div class="post-status {{post.status}}">{{capitalize post.status}}</div>

--- a/app/templates/components/post-status.hbs
+++ b/app/templates/components/post-status.hbs
@@ -1,0 +1,1 @@
+<div class="post-status {{status}}">{{capitalize status}}</div>

--- a/app/templates/project/posts/post.hbs
+++ b/app/templates/project/posts/post.hbs
@@ -1,5 +1,5 @@
 {{post-header post=post saveTitle="savePostTitle"}}
-{{post-meta post=post}}
+{{post-status post=post}}
 <div class="post-timeline">
   {{post-details post=post}}
   {{post-comment-list comments=comments}}

--- a/tests/integration/components/post-status-test.js
+++ b/tests/integration/components/post-status-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('post-meta', 'Integration | Component | post meta', {
+moduleForComponent('post-status', 'Integration | Component | post status', {
   integration: true
 });
 
@@ -10,7 +10,7 @@ test('it renders closed status', function(assert) {
 
   let post = { status: 'closed' };
   this.set('post', post);
-  this.render(hbs`{{post-meta post=post}}`);
+  this.render(hbs`{{post-status post=post}}`);
 
   assert.equal(this.$('.post-status').hasClass('closed'), true);
   assert.equal(this.$('.post-status').text().trim(), 'Closed');
@@ -21,7 +21,7 @@ test('it renders open status', function(assert) {
 
   let post = { status: 'open' };
   this.set('post', post);
-  this.render(hbs`{{post-meta post=post}}`);
+  this.render(hbs`{{post-status post=post}}`);
 
   assert.equal(this.$('.post-status').hasClass('open'), true);
   assert.equal(this.$('.post-status').text().trim(), 'Open');


### PR DESCRIPTION
Added some documentation for a few of the `post-` components. 
- `post-meta`
- `post-new-form`
- `post-title`
- `post-status-button`


Apparently I still haven't got this rebase thing right yet... There are a bunch of merge commits I must have pulled in.