### PR TITLE
add the rest of the post component docs

### DIFF
--- a/app/components/post-comment-list.js
+++ b/app/components/post-comment-list.js
@@ -1,5 +1,18 @@
 import Ember from 'ember';
 
+/**
+  The post-comment-list component composes the list of comments for a post.
+
+  ## default usage
+
+  ```handlebars
+  {{post-comment-list comments=comments}}
+  ```
+
+  @class post-comment-list
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-comment-list']
 });

--- a/app/components/post-details.js
+++ b/app/components/post-details.js
@@ -1,15 +1,67 @@
 import Ember from 'ember';
 
+/**
+  The post-details component composes a post object, it's author, info,
+  and body.
+
+  ## default usage
+
+  ```handlebars
+  {{post-details post=post}}
+  ```
+
+  @class post-details
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-details'],
 
+  /**
+    @property currentUser
+    @type Ember.Service
+   */
   currentUser: Ember.inject.service(),
+
+  /**
+    A service that is used for fetching mentions within a body of text.
+
+    @property mentionFetcher
+    @type Ember.Service
+   */
   mentionFetcher: Ember.inject.service(),
 
+  /**
+    Returns whether or not the current user can edit the current post.
+
+    @property canEdit
+    @type Boolean
+   */
   canEdit: Ember.computed.alias('currentUserIsPostAuthor'),
+
+  /**
+    Returns the current user's ID.
+
+    @property currentUserId
+    @type Number
+   */
   currentUserId: Ember.computed.alias('currentUser.user.id'),
+
+  /**
+    Returns the post author's ID.
+
+    @property postAuthorId
+    @type Number
+   */
   postAuthorId: Ember.computed.alias('post.user.id'),
 
+  /**
+    Consumes `currentUserId` and `postAuthorId` and returns if the current user
+    is the post author.
+
+    @property currentUserIsPostAuthor
+    @type Boolean
+   */
   currentUserIsPostAuthor: Ember.computed('currentUserId', 'postAuthorId', function() {
     let userId = parseInt(this.get('currentUserId'), 10);
     let authorId = parseInt(this.get('postAuthorId'), 10);
@@ -23,17 +75,36 @@ export default Ember.Component.extend({
   },
 
   actions: {
+
+    /**
+      Action that stops the editing of the corresponding post.
+
+      @method cancelEditingPostBody
+     */
     cancelEditingPostBody() {
       this.set('isEditingBody', false);
     },
 
+
+    /**
+      Action that sets the corresponding post to edit mode.
+
+      @method editPostBody
+     */
     editPostBody() {
       this.set('isEditingBody', true);
     },
 
+    /**
+      Action that saves the corresponding post, turns off edit mode, and
+      refetches the mentions.
+
+      @method savePostBody
+     */
     savePostBody() {
-      let component = this;
-      let post = this.get('post');
+      const component = this;
+      const post = this.get('post');
+
       post.save().then((post) => {
         component.set('isEditingBody', false);
         this._fetchMentions(post);
@@ -41,14 +112,30 @@ export default Ember.Component.extend({
     }
   },
 
+  /**
+    Queries the store for body of text with mentions.
+
+    @method _fetchMentions
+    @param {Object} post
+    @private
+   */
   _fetchMentions(post) {
     this.get('mentionFetcher').fetchBodyWithMentions(post, 'post').then((body) => {
       this.set('postBodyWithMentions', body);
     });
   },
 
+
+  /**
+    Parses the body of text and prefetches mentions.
+
+    @method _prefetchMentions
+    @param {Object} post
+    @private
+   */
   _prefetchMentions(post) {
-    let body = this.get('mentionFetcher').prefetchBodyWithMentions(post, 'post');
+    const body = this.get('mentionFetcher').prefetchBodyWithMentions(post, 'post');
+
     this.set('postBodyWithMentions', body);
   },
 });

--- a/app/components/post-filter-dropdown.js
+++ b/app/components/post-filter-dropdown.js
@@ -1,18 +1,52 @@
 import Ember from 'ember';
 
+/**
+  The post-filter-dropdown component composes the filter dropdown list that is
+  used for selecting filters for the list of posts.
+
+  ## default usage
+
+  ```handlebars
+  {{post-filter-dropdown field=filterField selectedFilters=listOfFilters
+      hide="hideAction" filterBy="filterAction"}}
+  ```
+
+  @class post-filter-dropdown
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['dropdown-menu'],
   tagName: 'ul',
 
+  /**
+    Sends the `hide` action when a filter is clicked.
+
+    @method click
+   */
   click() {
     this.sendAction('hide');
   },
 
   actions: {
+
+    /**
+      Action that sends the `filterBy` action to it's parent with the selected
+      filter.
+
+      @method filterBy
+      @param {String} filter
+     */
     filterBy(filter) {
       this.sendAction('filterBy', filter);
     },
 
+    /**
+      Action that sends the `hide` action to it's parent to hide the dropdown
+      list.
+
+      @method hide
+     */
     hide() {
       this.sendAction('hide');
     },

--- a/app/components/post-filter-type.js
+++ b/app/components/post-filter-type.js
@@ -1,20 +1,59 @@
 import Ember from 'ember';
 
+/**
+  The post-filter-type component composes the selected filter and dropdown
+  list of selectable filters. It takes in a list of selectable filter types
+  (`selectedTypes`), and a `filterByType` action.
+
+  ## default usage
+  ```handlebars
+  {{post-filter-type selectedTypes=filters filterByType="filterAction"}}
+  ```
+
+  @class post-filter-type
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['button-group', 'dropdown'],
   classNameBindings: ['active:menu-visible:menu-hidden'],
 
+  /**
+    Boolean that reflects whether or not the filter dropdown should be shown
+
+    @property active
+    @type Boolean
+   */
   active: false,
 
   actions: {
+
+    /**
+      Action that sends an action to filter the corresponding list by
+      given type.
+
+      @method filterByType
+      @param {String} type
+     */
     filterByType(type) {
       this.sendAction('filterByType', type);
     },
 
+    /**
+      Action that hides the filter dropdown list.
+
+      @method hide
+     */
     hide() {
       this.set('active', false);
     },
 
+    /**
+      Action that toggles the `active` property, hiding/showing the filter
+      dropdown list.
+
+      @method toggle
+     */
     toggle() {
       this.toggleProperty('active');
     },

--- a/app/components/post-header.js
+++ b/app/components/post-header.js
@@ -1,5 +1,19 @@
 import Ember from 'ember';
 
+/**
+  The post-header component represents the header of a post. It is composed of
+  the post icon & title.
+
+  ## default usage
+
+  ```handlebars
+  {{post-header post=post saveTitle="savePostTitleAction"}}
+  ```
+
+  @class post-header
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-header'],
   classNameBindings: ['post.postType']

--- a/app/components/post-item.js
+++ b/app/components/post-item.js
@@ -1,5 +1,18 @@
 import Ember from 'ember';
 
+/**
+  The post-item component is used to present a post in the list of posts.
+
+  ## default usage
+
+  ```handlebars
+  {{post-item post=post}}
+  ```
+
+  @class post-item
+  @module Component
+  @extends Ember.Component
+ */
 export default Ember.Component.extend({
   classNames: ['post-item'],
   classNameBindings: ['post.postType']


### PR DESCRIPTION
# What's in this PR?
Added documentation for the rest of the `post-` components. 

## Notes
I realized while doing this that some of the post logic is duplicated between a few components. I'm thinking it might be a good idea to separate that logic into a mixin. I can do that in a separate PR.

Also, I noticed we are doing some saving of models directly from components. It may be more DDAU to move that save logic into something like the route. 