### PR TITLE
add code-theme-selector component documentation

### DIFF
--- a/app/components/code-theme-selector.js
+++ b/app/components/code-theme-selector.js
@@ -1,14 +1,46 @@
 import Ember from 'ember';
+import { alias } from 'ember-computed';
 
-export default Ember.Component.extend({
+const {
+  Component,
+  get,
+  inject,
+} = Ember;
+
+const { service } = inject;
+
+/**
+ * The `code-theme-selector` component is used to toggle code themes on
+ * posts/comments/etc.
+ *
+ * @class code-theme-selector
+ * @module Component
+ * @extends Ember.Component
+ */
+export default Component.extend({
   classNames: ['code-theme-selector'],
   classNameBindings: ['themeClass'],
 
-  codeTheme: Ember.inject.service(),
+  /**
+   * @property codeTheme
+   * @type Ember.Service
+   */
+  codeTheme: service(),
 
-  themeClass: Ember.computed.alias('codeTheme.className'),
+  /**
+   * Returns the current code theme's class name.
+   *
+   * @property themeClass
+   * @type String
+   */
+  themeClass: alias('codeTheme.className'),
 
+  /**
+   * Fires on click. Toggles the code theme.
+   *
+   * @method click
+   */
   click() {
-    this.get('codeTheme').toggle();
+    get(this, 'codeTheme').toggle();
   },
 });


### PR DESCRIPTION
# What's in this PR?
- adds documentation for the `code-theme-selector` component
- minor refactors

## References
Issue: #223 