### PR TITLE
add documentation for progress-bar-container

### DIFF
--- a/app/components/progress-bar-container.js
+++ b/app/components/progress-bar-container.js
@@ -1,5 +1,22 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {
+  Component,
+} = Ember;
+
+/**
+  `progress-bar-container` is the container for a progress-bar.
+
+  ## default usage
+
+  ```Handlebars
+  {{progress-bar-container percentage=percentage}}
+  ```
+
+  @class progress-bar-container
+  @module Component
+  @extends Ember.Component
+*/
+export default Component.extend({
   classNames: ['progress-bar-container'],
 });


### PR DESCRIPTION
This adds documentation for the `progress-bar-container` component, which essentially wraps a progress bar in a div with the `progress-bar-container` class. This is a really simply component, and sometimes simple things are really odd to document. So I just stated the obvious that it is a container for a progress-bar, leaving the implementation details out of it. 

This makes progress on #223 