### PR TITLE
Adds documentation for project-long-description

### DIFF
--- a/app/components/project-long-description.js
+++ b/app/components/project-long-description.js
@@ -1,13 +1,53 @@
 import Ember from 'ember';
 
+/**
+  `project-long-description` displays and allows editing of the long
+  description for the project.
+
+  ## Default usage
+  ```handlebars
+    {{project-long-description project=project}}
+  ```
+
+  @module Component
+  @extends Ember.Component
+  @class project-long-description
+ */
+
 export default Ember.Component.extend({
   classNames: ['project-long-description'],
 
+  /**
+    A service that returns the users credentials.
+
+    @property credentials
+    @type Ember.Service
+   */
   credentials: Ember.inject.service(),
 
+  /**
+    Property that holds the edit mode status.
+
+    @property inEditMode
+    @type Boolean
+   */
   inEditMode: false,
+
+  /**
+    Property that holds whether the project has a description or not.
+
+    @property descriptionIsBlank
+    @type Boolean
+   */
   descriptionIsBlank: false,
 
+  /**
+    Returns whether the editor should be displayed or not based on having no
+    description or being toggled into edit mode.
+
+    @property shouldDisplayEditor
+    @type Boolean
+   */
   shouldDisplayEditor: Ember.computed.or('inEditMode', 'descriptionIsBlank'),
 
   didReceiveAttrs() {
@@ -16,14 +56,30 @@ export default Ember.Component.extend({
   },
 
   actions: {
+
+    /**
+      Action that toggles edit mode.
+
+      @method edit
+     */
     edit() {
       this._enterEditMode();
     },
 
+    /**
+      Action that leaves edit mode without saving changes.
+
+      @method cancel
+     */
     cancel() {
       this._enterReadMode();
     },
 
+    /**
+      Action that saves changes and leaves edit mode.
+
+      @method save
+     */
     save() {
       this.get('project').save().then(() => {
         this._enterReadMode();


### PR DESCRIPTION
## What's in this PR?

This adds documentation for the `project-long-description` component.

### Notes

I'm assuming we don't want to document the private methods, but I can add that if desired.

### References

Closes #390 