### PR TITLE
Add inch.json config file

### DIFF
--- a/inch.json
+++ b/inch.json
@@ -1,0 +1,15 @@
+{
+  "files": {
+    "included": [
+      "app/**/*.js"
+    ],
+    "excluded": [
+      "app/app.js",
+      "app/resolver.js",
+      "app/router.js",
+      "app/services/ajax.js",
+      "app/services/raven.js",
+      "app/services/session.js"
+    ]
+  }
+}


### PR DESCRIPTION
# What's in this PR?

This adds the inch.json configuration file

## Why was this created?

Inch doesn't know how to locate files in our repo. This adds the app/ directory and excludes some third-party and ember specific config/scaffolding files (such as router.js) from being evaluated for comments.

## Notes

It seems Inch CI has trouble displaying YUIDoc syntax (it isn't fully supported yet). 

> Inch is build to parse JSDoc, AtomDoc and TomDoc style documentation comments, but works reasonably well with unstructured comments.

It knows its there and that its good, but doesn't display it all the time. But the js part of Inch CI is pretty new so we will likely want to contribute a bit to get YUIDoc working properly. (It's possible we may need to add `*` to **all** lines in our comments to get it to work display properly in Inch, but I haven't looked into it yet)

## References
Work on #400. We will still need to configure the badge and CI web hook to finish that issue.

Check out the preview of what Inch picks up here: https://inch-ci.org/github/code-corps/code-corps-ember?branch=inch-ci-integration&pending_build=271995