### PR TITLE
Add Padding to Body to Prevent Nav From Butting Against Edge of Screen 

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -11,6 +11,7 @@ html {
 
 body {
   margin: 0;
+  padding: 0 10px;
 
   > .ember-view:first-of-type {
     height: 100%;


### PR DESCRIPTION
# What's in This PR?
- Add 15px padding to body element to prevent nav from sitting on the edge of the screen on a small-resolution device

# References
- Closes issue #288