### PR TITLE
Circle CI script changes for faster build times

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - bower_components
   override:
     - npm install -g bower
-    - npm install
+    - npm install --cache-min Infinity
     - bower install
     - npm rebuild node-sass
 deployment:


### PR DESCRIPTION
# What's in this PR?

This modifies the `npm install` part of our Circle CI to reduce build times (slightly)

## Changes

`npm install --cache-min Infinity` forces npm to check the cache first and compares it to project.json, then it will download any packages that have been updated. npm doesn't do this be default. It queries all packages listed in project.json with http and then uses the returned information to download or not download. Those http requests take a lot of time, so reducing how many are made makes a HUGE difference.

## Benefits

`npm install` has been an average of 30 seconds. The new command reduces this down to 12 seconds as long as there aren't many packages to update.

## References

Work on #419 