### PR TITLE
Add light gray background to footer

### DIFF
--- a/app/styles/components/site-footer.scss
+++ b/app/styles/components/site-footer.scss
@@ -1,5 +1,7 @@
 .site-footer {
-  margin: 50px 0 20px 0;
+  background: #f8f8f8;
+  margin: 50px -10px 0;
+  padding: 20px 0 30px;
 
   h4 {
     margin: 7px 0;


### PR DESCRIPTION
# What's in this PR?

Added a light gray background to the site footer. It's a small change, but it really differentiates the footer, especially on mobile.

![screen shot 2016-09-04 at 8 43 19 pm](https://cloud.githubusercontent.com/assets/13618860/18236997/13678ee2-72e1-11e6-8177-717853c72ffe.png)

Here it is on mobile (note: this screenshot is from a different branch that has a responsive layout):

![screen shot 2016-09-04 at 11 36 31 pm](https://cloud.githubusercontent.com/assets/13618860/18239213/936687e4-72f8-11e6-808a-d5c92e7cf42a.png)


