### PR TITLE
Update link to contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Contributing
 
 We'd love to have you contribute to Code Corps directly!
 
-To do so, please read the guidelines in our [`CONTRIBUTING.md`](CONTRIBUTING.md).
+To do so, please read the guidelines in our [`CONTRIBUTING.md`](./github/CONTRIBUTING.md).
 
 Then check out some GitHub issues to see where you can help out.
 


### PR DESCRIPTION
This PR changes the 'Contributing' link in README.md to point to .github/CONTRIBUTING.md

