### PR TITLE
Fix margin/padding on alerts to make them full screen

### DIFF
--- a/app/styles/_alerts.scss
+++ b/app/styles/_alerts.scss
@@ -21,8 +21,8 @@
     // regular flash message full-width-container, displayed full width
     // almost on top of the page
     .full-width-container {
-      margin-bottom: 10px;
-      padding: 5px 0 5px 10px;
+      margin: 0 -10px 10px;
+      padding: 5px 10px 5px 35px;
     }
 
     // fixed positioned flash message container, displayed at the very top of the page


### PR DESCRIPTION
# What's in this PR?

Fixed margin and padding on container for alert messages so they appear full-screen.

Specifically:
- Added -10px horizontal margin to .full-width-container to counteract body padding
- Added 10px right padding to counteract the negative margin
- Added 25px left padding to counteract the negative margin and prevent alert text from touching the left border of the screen

Before:

![screen shot 2016-09-18 at 2 49 25 pm](https://cloud.githubusercontent.com/assets/13618860/18619356/1be3866a-7daf-11e6-86f5-86af6dd80b7f.png)

After:

![screen shot 2016-09-18 at 2 41 46 pm](https://cloud.githubusercontent.com/assets/13618860/18619345/deff5b0c-7dae-11e6-8748-b8a8c88de7a6.png)

