### PR TITLE
Make footer sticky by adding flexbox container around nav, body, and …

### DIFF
--- a/app/styles/components/login-form.scss
+++ b/app/styles/components/login-form.scss
@@ -1,4 +1,5 @@
 .login-form {
   @include span-columns(5);
   @include shift(3.5);
+  padding-top: 10vh;
 }

--- a/app/styles/components/signup-form.scss
+++ b/app/styles/components/signup-form.scss
@@ -1,6 +1,7 @@
 .signup-form {
   @include span-columns(5);
   @include shift(3.5);
+  padding-top: 10vh;
 
   input[type="submit"] {
     width: 100%;

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -23,6 +23,17 @@ html, body {
   height: 100%;
 }
 
+.flexbox-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 100vh;
+}
+
+.flexbox-spacer {
+  flex: auto;
+}
+
 p {
   font-size: $body-font-size-normal;
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,12 +1,15 @@
 {{title "Code Corps"}}
 
 {{#drag-zone}}
-  {{navigation-menu}}
-  {{flash-messages}}
-  <div class="main container {{codeTheme.className}}">
-    {{outlet}}
+  <div class="flexbox-container">
+    {{navigation-menu}}
+    {{flash-messages}}
+    <div class="main container {{codeTheme.className}}">
+      {{outlet}}
+    </div>
+    <div class="flexbox-spacer"></div>
+    {{#unless isOnboarding}}
+      {{site-footer}}
+    {{/unless}}
   </div>
-  {{#unless isOnboarding}}
-    {{site-footer}}
-  {{/unless}}
 {{/drag-zone}}


### PR DESCRIPTION
# What's in this PR?

Adds a .flexbox-container div around the nav, body, and footer to make footer stick to bottom of screen.

Also adds a .flexbox-spacer div beween the body and footer to make the body appear as normal (without the spacer, the body is centered between the nav and footer, leaving more space between the nav and body)

Styles for .flexbox-container:
- flex-direction: column
- justify-content: space-between
- min-height: 100vh

Styles for .flexbox-spacer:
- flex-grow: 2

Before:

![screen shot 2016-09-18 at 6 45 17 pm](https://cloud.githubusercontent.com/assets/13618860/18621162/4c1c9306-7dd4-11e6-90d8-7a2c4d54f157.png)

After:

![screen shot 2016-09-18 at 7 05 16 pm](https://cloud.githubusercontent.com/assets/13618860/18621168/541b6492-7dd4-11e6-89b5-b539f940da4b.png)

Alternate option without spacer (NOT PART OF THIS PR, SHOWN ONLY FOR COMPARISON):

![screen shot 2016-09-18 at 6 43 02 pm](https://cloud.githubusercontent.com/assets/13618860/18621192/8f37b4f4-7dd4-11e6-90dd-9d553e40eacf.png)


