### PR TITLE
Added ember-exam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ testem.log
 .*swp
 .*swo
 .idea
+.vscodeignore
+jsconfig.json
+/typings/*/*

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Running Tests
 
-* `ember test`
-* `ember test --server`
+We use [ember-exam](https://github.com/trentmwillis/ember-exam) for running tests since it allows for parallel testing, randomized orders, and other neat configurations. You can check out the repository readme there to see the available options. A few handy ones to use when running tests locally are outlined below.
+
+* `ember exam` will run the tests
+* `ember exam --split=3 --weighted --parallel` will run tests in 3 PhantomJS instances in parallel with an equal split
+* `ember exam --random` will run the tests in a random order
+* `ember exam --filter='acceptance'` will only run acceptance tests. The same sytax can be used for other types of tests, such as `ember exam --filter='unit'` and `ember exam --filter='integration'`
 
 ### Building
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember test"
+    "test": "ember exam"
   },
   "repository": "",
   "engines": {
@@ -66,6 +66,8 @@
     "ember-concurrency": "0.7.9",
     "ember-data": "^2.8.0",
     "ember-deferred-content": "0.2.0",
+    "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-exam": "0.5.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.3",

--- a/testem.json
+++ b/testem.json
@@ -2,6 +2,7 @@
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
+  "parallel": 3,
   "launch_in_ci": [
     "PhantomJS"
   ],


### PR DESCRIPTION
# What's in this PR?

This adds `ember-exam` and runs tests through that package, which wraps `ember test` and enhances the process and allowing for parallelism, randomization, etc.

Originally this PR included changes to enable ember exam parallelism in circle ci, but that has been postponed for a later PR for the sake of getting ember exam tooling to everyone for local use.

## References
Progress on: #419 

