### PR TITLE
Update ember-moment to 7.0.0.beta3. Get rid of redundant dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-meta-tags": "2.0.2",
     "ember-cli-mirage": "^0.2.1",
-    "ember-cli-moment-shim": "2.0.0",
+    "ember-cli-moment-shim": "2.1.0",
     "ember-cli-neat": "0.0.5",
     "ember-cli-pace": "0.1.0",
     "ember-cli-page-object": "1.6.0",
@@ -64,7 +64,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.2",
     "ember-modal-dialog": "0.8.8",
-    "ember-moment": "6.1.0",
+    "ember-moment": "7.0.0-beta.3",
     "ember-resolver": "^2.0.3",
     "ember-simple-auth": "1.1.0",
     "ember-simple-auth-token": "git@github.com:digia/ember-simple-auth-token.git",
@@ -74,8 +74,6 @@
     "ember-truth-helpers": "1.2.0",
     "ember-typed": "0.1.3",
     "ember-welcome-page": "^1.0.1",
-    "loader.js": "^4.0.1",
-    "moment": "2.13.0",
-    "moment-timezone": "0.5.5"
+    "loader.js": "^4.0.1"
   }
 }


### PR DESCRIPTION
# What's in this PR?

#304 and #457  should be made reduntand by this.

We are using the `ember-moment` addon, which, upon installing, also pulls the `ember-cli-moment-shim` addon into the dependencies. However, the actual `moment` libraries they internally wrap should not be part of our base `package.json`, as far as I can tell. This updates our `ember-moment` package and removes the rendundant packages.