### PR TITLE
update SQUASHING.md with forking rebase instructions

### DIFF
--- a/docs/SQUASHING.md
+++ b/docs/SQUASHING.md
@@ -8,13 +8,32 @@ Then update your refs to be sure you have the latest code:
  git fetch --all
 ```
 
-To start your rebase run:
+## Rebase
+
+Rather than merge develop into your branch, we prefer to rebase off of develop. Depending on how you are working with the repo, this step may be different.
+
+If you are working from a forked copy on a branch other than develop (i.e. you created a feature branch) run:
+
+```shell
+git rebase -i develop
+```
+
+If you are working from a forked copy on the develop branch run:
+
+```shell
+git rebase -i HEAD~X
+```
+With `X` being the number of commits you have added.
+
+If you are working from the main repo run:
 
 ```shell
 git rebase -i origin/develop
 ```
 
 This says to rebase your work onto develop.
+
+## Squash
 
 From here, you'll see something like:
 


### PR DESCRIPTION
# What's in this PR?

This adds more detailed instructions to the squashing documentation to make rebase's easier for those working off of forks instead of on the main repo.

## References
Progress on: #423 

