### PR TITLE
Move Saving Logic for 'post-title' from Component to Route

### DIFF
--- a/app/components/task-title.js
+++ b/app/components/task-title.js
@@ -93,21 +93,15 @@ export default Component.extend({
 
       @method save
      */
-    save() {
+    applyEdit() {
       let component = this;
       let task = this.get('task');
       let newTitle = this.get('newTitle');
 
       task.set('title', newTitle);
-      task.save().then(() => {
+      this.get('saveTask')(task).then(() => {
         component.set('isEditing', false);
-      }).catch((error) => {
-        let payloadContainsValidationErrors = error.errors.some((error) => error.status === 422 );
-
-        if (!payloadContainsValidationErrors) {
-          this.controllerFor('project.tasks.task').set('error', error);
-        }
       });
-    },
-  },
+    }
+  }
 });

--- a/app/routes/project/tasks/task.js
+++ b/app/routes/project/tasks/task.js
@@ -32,6 +32,16 @@ export default Ember.Route.extend({
   },
 
   actions: {
+    save(task) {
+      return task.save().catch((error) => {
+        let payloadContainsValidationErrors = error.errors.some((error) => error.status === 422 );
+
+        if (!payloadContainsValidationErrors) {
+          this.controllerFor('project.tasks.task').set('error', error);
+        }
+      });
+    },
+
     saveComment(comment) {
       let route = this;
       comment.save().then(() => {
@@ -43,6 +53,6 @@ export default Ember.Route.extend({
           this.controllerFor('project.tasks.task').set('error', error);
         }
       });
-    },
-  },
+    }
+  }
 });

--- a/app/templates/components/task-header.hbs
+++ b/app/templates/components/task-header.hbs
@@ -1,2 +1,2 @@
 <div class="task-icon"></div>
-{{task-title task=task}}
+{{task-title task=task saveTask=saveTask}}

--- a/app/templates/components/task-title.hbs
+++ b/app/templates/components/task-title.hbs
@@ -1,7 +1,7 @@
 {{#if isEditing}}
   <div class="title-actions input-group">
     <button class="clear cancel" {{action 'cancel'}}>Cancel</button>
-    <button class="default save" {{action 'save'}}>Save</button>
+    <button class="default save" {{action 'applyEdit'}}>Save</button>
   </div>
   {{input type="text" value=newTitle name="title"}}
   {{#each task.errors.title as |error|}}

--- a/app/templates/project/tasks/task.hbs
+++ b/app/templates/project/tasks/task.hbs
@@ -1,4 +1,4 @@
-{{task-header task=task saveTitle="saveTaskTitle"}}
+{{task-header task=task saveTask=(route-action "save")}}
 {{task-status task=task}}
 <div class="task-timeline">
   {{task-details task=task}}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ember-moment": "7.0.0-beta.3",
     "ember-page-title": "3.0.9",
     "ember-resolver": "^2.0.3",
+    "ember-route-action-helper": "^2.0.0",
     "ember-simple-auth": "1.1.0",
     "ember-simple-auth-token": "^1.1.1",
     "ember-sinon": "0.5.1",

--- a/tests/integration/components/task-title-test.js
+++ b/tests/integration/components/task-title-test.js
@@ -4,28 +4,28 @@ import Ember from 'ember';
 
 let mockCurrentUser = Ember.Service.extend({
   user: {
-    id: 1
-  }
+          id: 1
+        }
 });
 
 let mockDifferentUser = Ember.Service.extend({
   user: {
-    id: 2
-  }
+          id: 2
+        }
 });
 
 let mockTask = Ember.Object.create({
   title: 'Original title',
-  body: 'A <strong>body</strong>',
-  number: 12,
-  taskType: 'issue',
-  user: {
-    id: 1,
-  },
-  save() {
-    this.set('title', this.get('title'));
-    return Ember.RSVP.resolve();
-  }
+    body: 'A <strong>body</strong>',
+    number: 12,
+    taskType: 'issue',
+    user: {
+      id: 1,
+    },
+    save() {
+      this.set('title', this.get('title'));
+      return Ember.RSVP.resolve();
+    }
 });
 
 moduleForComponent('task-title', 'Integration | Component | task title', {
@@ -75,7 +75,10 @@ test('it saves', function(assert) {
   this.register('service:current-user', mockCurrentUser);
 
   this.set('task', mockTask);
-  this.render(hbs`{{task-title task=task}}`);
+  this.on('applyEdit', () => {
+    return Ember.RSVP.resolve();
+  });
+  this.render(hbs`{{task-title task=task saveTask=(action "applyEdit")}}`);
 
   assert.equal(this.$('.task-title .title').text().trim(), 'Original title #12', 'The original title is right');
 


### PR DESCRIPTION
# What's in this PR?

Installed ember-route-action-helper addon and moved saving logic for 'post-title' from the component to the route. 

Progress on: #336 

I cannot get the integration test to pass. Any advice would be appreciated. The code works when I test it manually.
