### PR TITLE
Remove our explicit false value for shouldBackgroundReloadRecord

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -11,11 +11,4 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   coalesceFindRequests: true,
 
   host: ENV.API_BASE_URL,
-
-  // eliminates a deprecation warning
-  // default behavior will return true in ember data 2.x
-  // so we should consider accounting for that
-  shouldBackgroundReloadRecord: function() {
-    return false;
-  },
 });


### PR DESCRIPTION
# What's in this PR?

Removing `shouldBackgroundReloadRecord` returning `false` because it's caching things we don't want and is not the default way for `ember-data` any longer.