### PR TITLE
Fix tests with phantomjs 1.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ember-tooltips": "2.0.1",
     "ember-truth-helpers": "1.2.0",
     "ember-typed": "0.1.3",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "phantomjs": "^1.9.20"
   }
 }


### PR DESCRIPTION
this fix timeout in circleci tests because it install phantomjs version 1.9.x
(working) instead of 2.x that causes tests break on "just cloned" repo