### PR TITLE
Remove useless link from skill list item

### DIFF
--- a/app/templates/components/skill-list-item.hbs
+++ b/app/templates/components/skill-list-item.hbs
@@ -1,3 +1,1 @@
-<a>
-  {{skill.title}}
-</a>
+{{skill.title}}

--- a/tests/integration/components/skill-list-item-test.js
+++ b/tests/integration/components/skill-list-item-test.js
@@ -37,7 +37,7 @@ test('it renders and sends an action when its hidden', function(assert) {
     </div>
   `);
 
-  assert.equal(this.$('li a').text().trim(), 'Ruby');
+  assert.equal(this.$('li').text().trim(), 'Ruby');
 });
 
 test('it renders and sends no action when not hidden', function(assert) {
@@ -55,5 +55,5 @@ test('it renders and sends no action when not hidden', function(assert) {
 
   this.render(hbs`{{skill-list-item skill=skill action='skillItemHidden'}}`);
 
-  assert.equal(this.$('li a').text().trim(), 'Ruby');
+  assert.equal(this.$('li').text().trim(), 'Ruby');
 });


### PR DESCRIPTION
# What's in this PR?

Removes the `a` tag wrapping skills, because it goes nowhere and is therefore useless.