### PR TITLE
Fix injected container warnings

### DIFF
--- a/tests/integration/components/category-item-test.js
+++ b/tests/integration/components/category-item-test.js
@@ -3,6 +3,8 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
+const { getOwner } = Ember;
+
 moduleForComponent('category-item', 'Integration | Component | category item', {
   integration: true,
   beforeEach() {
@@ -22,7 +24,7 @@ let mockUserCategoriesService = Ember.Service.extend({
     return new Ember.RSVP.Promise((fulfill) => {
       Ember.run.next(() => {
         mockUserCategory.set('categoryId', category.get('id'));
-        this.container.lookup('service:user-categories').set('userCategories', [mockUserCategory]);
+        getOwner(this).lookup('service:user-categories').set('userCategories', [mockUserCategory]);
         fulfill();
       });
     });
@@ -31,7 +33,7 @@ let mockUserCategoriesService = Ember.Service.extend({
     return new Ember.RSVP.Promise((fulfill, reject) => {
       Ember.run.next(() => {
         mockUserCategory.set('categoryId', null);
-        this.container.lookup('service:user-categories').set('userCategories', []);
+        getOwner(this).lookup('service:user-categories').set('userCategories', []);
         reject();
       });
     });

--- a/tests/integration/components/role-item-test.js
+++ b/tests/integration/components/role-item-test.js
@@ -3,6 +3,8 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
+const { getOwner } = Ember;
+
 moduleForComponent('role-item', 'Integration | Component | role item', {
   integration: true,
   beforeEach() {
@@ -22,7 +24,7 @@ let mockUserRolesService = Ember.Service.extend({
     return new Ember.RSVP.Promise((fulfill) => {
       Ember.run.next(() => {
         mockUserRole.set('roleId', role.get('id'));
-        this.container.lookup('service:user-roles').set('userRoles', [mockUserRole]);
+        getOwner(this).lookup('service:user-roles').set('userRoles', [mockUserRole]);
         fulfill();
       });
     });
@@ -31,7 +33,7 @@ let mockUserRolesService = Ember.Service.extend({
     return new Ember.RSVP.Promise((fulfill, reject) => {
       Ember.run.next(() => {
         mockUserRole.set('roleId', null);
-        this.container.lookup('service:user-roles').set('userRoles', []);
+        getOwner(this).lookup('service:user-roles').set('userRoles', []);
         reject();
       });
     });


### PR DESCRIPTION
# What's in this PR?

Uses `getOwner(this).lookup()` instead of `this.container.lookup()` per http://emberjs.com/deprecations/v2.x/#toc_injected-container-access

## References
Fixes #492 