### PR TITLE
Add ember-cli to GreenKeeper ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,10 @@
     "ember-typed": "0.1.3",
     "loader.js": "^4.0.1",
     "phantomjs": "^1.9.20"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "ember-cli"      
+    ]
   }
 }


### PR DESCRIPTION
# What's in this PR?

Add ember-cli to GreenKeeper ignore list
```
"greenkeeper": {
    "ignore": [
      "ember-cli"      
    ]
  }
```
## References
Fixes #481