### PR TITLE
update YUIDoc to new output path, add generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist
 /tmp
+/docs/yuidoc
 
 # dependencies
 /node_modules

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -6,7 +6,7 @@
     "exclude": "vendor",
     "linkNatives": true,
     "lint": false,
-    "outdir": "docs",
+    "outdir": "docs/yuidoc",
     "parseOnly": false,
     "paths": [
       "app"


### PR DESCRIPTION
# What's in this PR?

This changes YUIDoc's configuration to output to a subfolder of `docs/` so that it doesn't delete our usage documentation.

## References
Fixes #558 

