### PR TITLE
Refactor Profile acceptance tests to use page objects

### DIFF
--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
+import userProfile from '../pages/user';
 
 let application;
 
@@ -27,20 +28,16 @@ test('it displays the user-details component with user details', (assert) => {
 
   sluggedRoute.save();
 
-  for(let i = 1; i <= 3; i++) {
-    server.create('organization-membership', {
-      member: user,
-      organization: server.create('organization')
-    });
-  }
+  server.createList('organization-membership', 3, { member: user, organization: server.create('organization')});
 
-  visit(user.username);
+  userProfile.visit({ username: user.username });
+
   andThen(() => {
-    assert.equal(find('.user-details').length, 1);
-    assert.equal(find('.user-details .twitter').text().trim(), '@test_twitter', "The user's twitter renders");
-    assert.equal(find('.user-details .twitter a').attr('href'), 'https://twitter.com/test_twitter', "The user's twitter URL renders");
-    assert.equal(find('.website').text().trim(), 'test.com', "The user's website renders");
-    assert.equal(find('.user-organization-item').length, 3, "The user's organizations are rendered");
+    assert.equal(userProfile.userDetails.isVisible, true, 'The user details component renders');
+    assert.equal(userProfile.userDetails.twitter.text, `@${user.twitter}`, "The user's twitter renders");
+    assert.equal(userProfile.userDetails.twitter.link.href, 'https://twitter.com/test_twitter', "The user's twitter URL renders");
+    assert.equal(userProfile.userDetails.website.text, 'test.com', "The user's website renders");
+    assert.equal(userProfile.organizations().count, 3, "The user's organizations are rendered");
   });
 });
 
@@ -57,13 +54,13 @@ test('the user can navigate to an organization from the organizations list', (as
 
   server.create('organization-membership', { member: user, organization: organization });
 
-  visit(user.username);
+  userProfile.visit({ username: user.username });
 
   let href = `/${organization.slug}`;
 
   andThen(() => {
-    assert.equal(find('.user-organization-item:eq(0) a').attr('href'), href, 'The link is rendered');
-    click('.user-organization-item:eq(0) a');
+    assert.equal(userProfile.organizations(0).href, href, 'The link is rendered');
+    userProfile.organizations(0).click();
   });
 
   andThen(() => {

--- a/tests/pages/components/user-details.js
+++ b/tests/pages/components/user-details.js
@@ -1,0 +1,27 @@
+import {
+  attribute,
+  text,
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.user-details',
+
+  twitter: {
+    scope: '.twitter',
+
+    link: {
+      scope: 'a',
+      href: attribute('href'),
+      text: text(),
+    }
+  },
+  website: {
+    scope: '.website',
+
+    link: {
+      scope: 'a',
+      href: attribute('href'),
+      text: text(),
+    }
+  },
+};

--- a/tests/pages/organization.js
+++ b/tests/pages/organization.js
@@ -24,9 +24,9 @@ export default create({
   }),
 
   clickSettingsMenuItem: clickable('.organization-menu li a:contains("Settings")'),
-  
+
   projectsMenuItemIsActive: hasClass('active', '.organization-menu li a:contains("Projects")'),
-  
+
   settingsMenuItemIsActive: hasClass('active', '.organization-menu li a:contains("Settings")'),
 
   orgHeader: {

--- a/tests/pages/user.js
+++ b/tests/pages/user.js
@@ -1,0 +1,23 @@
+import {
+  attribute,
+  clickable,
+  collection,
+  create,
+  visitable,
+} from 'ember-cli-page-object';
+import userDetails from './components/user-details';
+
+export default create({
+  visit: visitable(':username'),
+
+  organizations: collection({
+    scope: '.user-organizations-list li',
+    itemScope: 'h3 a',
+    item: {
+      click: clickable(),
+      href: attribute('href'),
+    },
+  }),
+
+  userDetails,
+});


### PR DESCRIPTION
# What's in this PR?

- Adds `/pages/user.js`
- Adds `/pages/components/user-details.js`
- Refactors tests to use these objects

## References
Fixes #519

Progress on: #141 