### PR TITLE
Refactor Slugged Route acceptance tests to use page objects

### DIFF
--- a/tests/acceptance/slugged-route-test.js
+++ b/tests/acceptance/slugged-route-test.js
@@ -1,6 +1,7 @@
 import Ember from "ember";
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
+import sluggedRoutePage from '../pages/slugged-route';
 
 let application;
 
@@ -20,9 +21,10 @@ test("It renders user details when the sluggedRoute model is a user", function(a
   sluggedRoute.createUser({ username: 'test_user' });
   sluggedRoute.save();
 
-  visit('/test_user');
+  sluggedRoutePage.visit({ slug: 'test_user' });
+
   andThen(function() {
-    assert.equal(find('.user-details').length, 1, 'user-details component is rendered');
+    assert.equal(sluggedRoutePage.userDetails.isVisible, true, 'user-details component is rendered');
   });
 });
 
@@ -33,9 +35,10 @@ test("It renders organization profile when the sluggedRoute model is an organiza
   sluggedRoute.createOrganization({ slug: 'test_organization' });
   sluggedRoute.save();
 
-  visit('/test_organization');
+  sluggedRoutePage.visit({ slug: 'test_organization' });
+
   andThen(function() {
-    assert.equal(find('.organization-profile').length, 1, 'organization-profile component is rendered');
+    assert.equal(sluggedRoutePage.organizationProfile.isVisible, true, 'organization-profile component is rendered');
   });
 });
 
@@ -53,16 +56,17 @@ test("It renders a 404 error when no slugged route exists", function(assert) {
     },
     404);
 
-  visit('/no_slug');
+  sluggedRoutePage.visit({ slug: 'no_slug' });
+
   andThen(function() {
-    assert.equal(find('.error-wrapper').length, 1, 'error-wrapper component is rendered');
-    assert.equal(find('.error-wrapper h1').text(), '404 Error', 'The 404 title is rendered');
-    assert.ok($('html').hasClass('warning'), 'The class of the html element is correct');
-    click('.error-wrapper a');
+    assert.equal(sluggedRoutePage.errorWrapper.isVisible, true, 'error-wrapper component is rendered');
+    assert.equal(sluggedRoutePage.errorWrapper.title.text, '404 Error', 'The 404 title is rendered');
+    assert.equal($('html').hasClass('warning'), true, 'The class of the html element is correct');
+    sluggedRoutePage.errorWrapper.clickLink();
   });
 
   andThen(function() {
-    assert.equal(find('.error-wrapper').length, 0, 'error-wrapper component is not rendered');
-    assert.notOk($('html').hasClass('warning'), 'The class of the html element is unset');
+    assert.equal(sluggedRoutePage.errorWrapper.isVisible, false, 'error-wrapper component is not rendered');
+    assert.equal($('html').hasClass('warning'), false, 'The class of the html element is unset');
   });
 });

--- a/tests/pages/components/error-wrapper.js
+++ b/tests/pages/components/error-wrapper.js
@@ -1,0 +1,15 @@
+import {
+  clickable,
+  text,
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.error-wrapper',
+
+  clickLink: clickable('a'),
+
+  title: {
+    scope: 'h1',
+    text: text(),
+  },
+};

--- a/tests/pages/components/organization-profile.js
+++ b/tests/pages/components/organization-profile.js
@@ -1,0 +1,3 @@
+export default {
+  scope: '.organization-profile',
+};

--- a/tests/pages/slugged-route.js
+++ b/tests/pages/slugged-route.js
@@ -1,0 +1,15 @@
+import {
+  create,
+  visitable
+} from 'ember-cli-page-object';
+import errorWrapper from './components/error-wrapper';
+import organizationProfile from './components/organization-profile';
+import userDetails from './components/user-details';
+
+export default create({
+  visit: visitable(':slug'),
+
+  errorWrapper,
+  organizationProfile,
+  userDetails
+});


### PR DESCRIPTION
# What's in this PR?

- Adds slugged route page object
- Adds error wrapper component page object
- Adds organization profile component page object

## References
Fixes #520

Progress on: #141 