### PR TITLE
Add Project About tests with page objects

### DIFF
--- a/tests/acceptance/project-about-test.js
+++ b/tests/acceptance/project-about-test.js
@@ -2,6 +2,7 @@ import Ember from "ember";
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
+import projectAboutPage from '../pages/project/about';
 
 let application;
 
@@ -21,19 +22,20 @@ test('When unauthenticated, and project has no long description, it shows proper
   let organization = sluggedRoute.createOrganization({ slug: 'test' });
   sluggedRoute.save();
 
-  let projectWithoutDescription = server.create('project', {
+  let project = server.create('project', {
     longDescriptionBody: null,
     longDescriptionMarkdown: null,
     organization: organization
   });
 
-  let urlForProjectWithoutDescription = `${sluggedRoute.slug}/${projectWithoutDescription.slug}`;
-
-  visit(urlForProjectWithoutDescription);
+  projectAboutPage.visit({
+    organization: organization.slug,
+    project: project.slug
+  });
 
   andThen(() => {
-    assert.equal(find('.long-description.empty').length, 1, 'The empty container is shown');
-    assert.equal(find('.editor-with-preview').length, 0, 'User is not logged in, so they cannot edit the description');
+    assert.equal(projectAboutPage.projectLongDescription.longDescription.isEmpty, true, 'The empty container is shown');
+    assert.ok(projectAboutPage.editorWithPreview.isHidden, 'User is not logged in, so they cannot edit the description');
   });
 });
 
@@ -44,21 +46,20 @@ test('When unauthenticated, and project has long description, it shows the proje
   let organization = sluggedRoute.createOrganization({ slug: 'test' });
   sluggedRoute.save();
 
-  let projectWithDescription = server.create('project', {
+  let project = server.create('project', {
     longDescriptionBody: 'A body',
     longDescriptionMarkdown: 'A body',
     organization: organization
   });
 
-  let urlForProjectWithDescription = `${sluggedRoute.slug}/${projectWithDescription.slug}`;
-
-  andThen(() => {
-    visit(urlForProjectWithDescription);
+  projectAboutPage.visit({
+    organization: organization.slug,
+    project: project.slug
   });
 
   andThen(() => {
-    assert.ok(find('.long-description').text().trim().indexOf(projectWithDescription.longDescriptionBody) !== -1, 'The body is rendered');
-    assert.equal(find('button[name=edit]').length, 0, 'User is not logged in, so they cannot edit the description');
+    assert.ok(projectAboutPage.projectLongDescription.text.indexOf(project.longDescriptionBody) !== -1, 'The body is rendered');
+    assert.ok(projectAboutPage.projectLongDescription.editButton.isHidden, 'User is not logged in, so they cannot edit the description');
   });
 });
 
@@ -73,29 +74,29 @@ test('When authenticated as admin, and project has no long description, it allow
 
   server.create('organization-membership', { organization: organization, member: user, role: 'admin' });
 
-  let projectWithoutDescription = server.create('project', {
+  let project = server.create('project', {
     longDescriptionBody: null,
     longDescriptionMarkdown: null,
     organization: organization
   });
 
-  let urlForProjectWithoutDescription = `${sluggedRoute.slug}/${projectWithoutDescription.slug}`;
-
   authenticateSession(application, { user_id: user.id });
 
-  visit(urlForProjectWithoutDescription);
-
-  andThen(() => {
-    fillIn('textarea', 'A new body');
-    click('button[name=save]');
+  projectAboutPage.visit({
+    organization: organization.slug,
+    project: project.slug
   });
 
   andThen(() => {
-    projectWithoutDescription.reload();
-    assert.equal(projectWithoutDescription.longDescriptionMarkdown, 'A new body');
-    assert.equal(projectWithoutDescription.longDescriptionBody, '<p>A new body</p>');
-    assert.ok(find('.long-description').html().trim().indexOf(projectWithoutDescription.longDescriptionBody) !== -1, 'The body is rendered');
-    assert.equal(find('button[name=edit]').length, 1, 'We can edit the description further');
+    projectAboutPage.projectLongDescription.textarea('A new body').clickSave();
+  });
+
+  andThen(() => {
+    project.reload();
+    assert.equal(project.longDescriptionMarkdown, 'A new body');
+    assert.equal(project.longDescriptionBody, '<p>A new body</p>');
+    assert.equal(projectAboutPage.projectLongDescription.longDescription.paragraph.text, project.longDescriptionMarkdown, 'The body is rendered');
+    assert.ok(projectAboutPage.projectLongDescription.editButton.isVisible, 'We can edit the description again');
   });
 });
 
@@ -110,31 +111,28 @@ test('When authenticated as admin, and project has long description, it allows e
 
   server.create('organization-membership', { organization: organization, member: user, role: 'admin' });
 
-  let projectWithDescription = server.create('project', {
+  let project = server.create('project', {
     longDescriptionBody: 'A body',
     longDescriptionMarkdown: 'A body',
     organization: organization
   });
 
-  let urlForProjectWithDescription = `${sluggedRoute.slug}/${projectWithDescription.slug}`;
-
   authenticateSession(application, { user_id: user.id });
 
-  andThen(() => {
-    visit(urlForProjectWithDescription);
+  projectAboutPage.visit({
+    organization: organization.slug,
+    project: project.slug
   });
 
   andThen(() => {
-    click('button[name=edit]');
-    fillIn('textarea', 'An edited body');
-    click('button[name=save]');
+    projectAboutPage.projectLongDescription.clickEdit().textarea('An edited body').clickSave();
   });
 
   andThen(() => {
-    projectWithDescription.reload();
-    assert.equal(projectWithDescription.longDescriptionMarkdown, 'An edited body');
-    assert.equal(projectWithDescription.longDescriptionBody, '<p>An edited body</p>');
-    assert.ok(find('.long-description').html().trim().indexOf(projectWithDescription.longDescriptionBody) !== -1, 'The body is rendered');
-    assert.equal(find('button[name=edit]').length, 1, 'We can edit the description further');
+    project.reload();
+    assert.equal(project.longDescriptionMarkdown, 'An edited body');
+    assert.equal(project.longDescriptionBody, '<p>An edited body</p>');
+    assert.equal(projectAboutPage.projectLongDescription.longDescription.paragraph.text, project.longDescriptionMarkdown, 'The body is rendered');
+    assert.ok(projectAboutPage.projectLongDescription.editButton.isVisible, 'We can edit the description again');
   });
 });

--- a/tests/pages/components/editor-with-preview.js
+++ b/tests/pages/components/editor-with-preview.js
@@ -1,0 +1,6 @@
+import {
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.editor-with-preview',
+};

--- a/tests/pages/components/project-long-description.js
+++ b/tests/pages/components/project-long-description.js
@@ -1,0 +1,31 @@
+import {
+  clickable,
+  fillable,
+  hasClass,
+  text,
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.project-long-description',
+
+  clickEdit: clickable('button[name=edit]'),
+  clickSave: clickable('button[name=save]'),
+
+  textarea: fillable('textarea'),
+
+  editButton: {
+    scope: 'button[name=edit]',
+  },
+
+  longDescription: {
+    scope: '.long-description',
+
+    text: text(),
+    isEmpty: hasClass('empty'),
+
+    paragraph: {
+      scope: 'p',
+      text: text(),
+    }
+  },
+};

--- a/tests/pages/project/about.js
+++ b/tests/pages/project/about.js
@@ -1,0 +1,13 @@
+import {
+  create,
+  visitable
+} from 'ember-cli-page-object';
+import editorWithPreview from '../components/editor-with-preview';
+import projectLongDescription from '../components/project-long-description';
+
+export default create({
+  visit: visitable(':organization/:project'),
+
+  editorWithPreview,
+  projectLongDescription
+});


### PR DESCRIPTION
# What's in this PR?

- Adds project about page object
- Adds project long description component page object
- Adds editor with preview component page object
- Updates about test to use these page objects

## References
Fixes #513 

Progress on: #141 

