### PR TITLE
Update model tests to use the new hasAttributes helper

### DIFF
--- a/tests/unit/models/category-test.js
+++ b/tests/unit/models/category-test.js
@@ -1,5 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForHasMany } from '../../helpers/relationship';
+import '../../helpers/has-attributes';
 
 moduleForModel('category', 'Unit | Model | category', {
   // Specify the other units that are required for this test.
@@ -13,14 +14,15 @@ test('it exists', function(assert) {
 });
 
 test('it should have all its attributes', function(assert) {
-  assert.expect(3);
+  let category = this.subject();
+  let actualAttributes = Object.keys(category.toJSON());
+  let expectedAttributes = [
+    "description",
+    "name",
+    "slug",
+  ];
 
-  const category = this.subject();
-  const attributes = Object.keys(category.toJSON());
-
-  assert.ok(attributes.includes('description'), 'should have description attribute');
-  assert.ok(attributes.includes('name'), 'should have name attribute');
-  assert.ok(attributes.includes('slug'), 'should have slug attribute');
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 testForHasMany('category', 'projectCategories');

--- a/tests/unit/models/comment-test.js
+++ b/tests/unit/models/comment-test.js
@@ -1,5 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo, testForHasMany } from '../../helpers/relationship';
+import '../../helpers/has-attributes';
 
 moduleForModel('comment', 'Unit | Model | comment', {
   // Specify the other units that are required for this test.
@@ -17,14 +18,17 @@ test('it exists', function(assert) {
 });
 
 test('it has all of its attributes', function(assert) {
-  assert.expect(3);
+  let comment = this.subject();
+  let actualAttributes = Object.keys(comment.toJSON());
+  let expectedAttributes = [
+    "body",
+    "insertedAt",
+    "markdown",
+    "task",
+    "user",
+  ];
 
-  const comment = this.subject();
-  const attributes = Object.keys(comment.toJSON());
-
-  assert.ok(attributes.includes('body'), 'should have body attribute');
-  assert.ok(attributes.includes('insertedAt'), 'should have insertedAt attribute');
-  assert.ok(attributes.includes('markdown'), 'should have markdown attribute');
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 testForBelongsTo('comment', 'task');

--- a/tests/unit/models/organization-membership-test.js
+++ b/tests/unit/models/organization-membership-test.js
@@ -1,6 +1,7 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo } from '../../helpers/relationship';
 import Ember from 'ember';
+import '../../helpers/has-attributes';
 
 const {
   get,
@@ -20,12 +21,15 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-  assert.expect(1);
-
   let organizationMembership = this.subject();
-  let attributes = Object.keys(organizationMembership.toJSON());
+  let actualAttributes = Object.keys(organizationMembership.toJSON());
+  let expectedAttributes = [
+    "member",
+    "organization",
+    "role",
+  ];
 
-  assert.ok(attributes.includes('role'), 'should have the role attribute');
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 testForBelongsTo('organization-membership', 'member');

--- a/tests/unit/models/slugged-route-test.js
+++ b/tests/unit/models/slugged-route-test.js
@@ -1,5 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo } from '../../helpers/relationship';
+import '../../helpers/has-attributes';
 
 moduleForModel('slugged-route', 'Unit | Model | slugged-route', {
   // Specify the other units that are required for this test.
@@ -13,12 +14,15 @@ test('it exists', function(assert) {
 });
 
 test('should have all of its attributes', function(assert) {
-  assert.expect(1);
-
   let sluggedRoute = this.subject();
-  let attributes = Object.keys(sluggedRoute.toJSON());
+  let actualAttributes = Object.keys(sluggedRoute.toJSON());
+  let expectedAttributes = [
+    "organization",
+    "slug",
+    "user",
+  ];
 
-  assert.ok(attributes.includes('slug'), 'should have the slug attribute');
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 // slugged-route may belong to either a user or organization, but not both

--- a/tests/unit/models/task-test.js
+++ b/tests/unit/models/task-test.js
@@ -1,5 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo, testForHasMany } from '../../helpers/relationship';
+import '../../helpers/has-attributes';
 
 moduleForModel('task', 'Unit | Model | task', {
   // Specify the other units that are required for this test.
@@ -19,19 +20,23 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-  assert.expect(8);
-
   let task = this.subject();
-  let attributes = Object.keys(task.toJSON());
+  let actualAttributes = Object.keys(task.toJSON());
+  let expectedAttributes = [
+    "body",
+    "commentUserMentions",
+    "insertedAt",
+    "likesCount",
+    "markdown",
+    "number",
+    "project",
+    "status",
+    "taskType",
+    "title",
+    "user",
+  ];
 
-  assert.ok(attributes.includes('body'), 'task should have the body attribute');
-  assert.ok(attributes.includes('insertedAt'), 'task should have the insertedAt attribute');
-  assert.ok(attributes.includes('likesCount'), 'task should have the likesCount attribute');
-  assert.ok(attributes.includes('markdown'), 'task should have the markdown attribute');
-  assert.ok(attributes.includes('number'), 'task should have the number attribute');
-  assert.ok(attributes.includes('status'), 'task should have the status attribute');
-  assert.ok(attributes.includes('taskType'), 'task should have the taskType attribute');
-  assert.ok(attributes.includes('title'), 'task should have the title attribute');
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 testForBelongsTo('task', 'project');

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,5 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForHasMany } from '../../helpers/relationship';
+import '../../helpers/has-attributes';
 
 moduleForModel('user', 'Unit | Model | user', {
   // Specify the other units that are required for this test.
@@ -19,26 +20,27 @@ test('it exists', function(assert) {
 });
 
 test('it has all of its attributes', function(assert) {
-  assert.expect(15);
+  let user = this.subject();
+  let actualAttributes = Object.keys(user.toJSON());
+  let expectedAttributes = [
+    "base64PhotoData",
+    "biography",
+    "email",
+    "firstName",
+    "insertedAt",
+    "lastName",
+    "name",
+    "password",
+    "photoLargeUrl",
+    "photoThumbUrl",
+    "state",
+    "stateTransition",
+    "twitter",
+    "username",
+    "website",
+  ];
 
-  const user = this.subject();
-  const attributes = Object.keys(user.toJSON());
-
-  assert.ok(attributes.includes('base64PhotoData'), 'should have base64PhotoData attribute');
-  assert.ok(attributes.includes('biography'), 'should have biography attribute');
-  assert.ok(attributes.includes('email'), 'should have email attribute');
-  assert.ok(attributes.includes('firstName'), 'should have firstName attribute');
-  assert.ok(attributes.includes('insertedAt'), 'should have insertedAt attribute');
-  assert.ok(attributes.includes('lastName'), 'should have lastName attribute');
-  assert.ok(attributes.includes('name'), 'should have name attribute');
-  assert.ok(attributes.includes('password'), 'should have password attribute');
-  assert.ok(attributes.includes('photoLargeUrl'), 'should have photoLargeUrl attribute');
-  assert.ok(attributes.includes('photoThumbUrl'), 'should have photoThumbUrl attribute');
-  assert.ok(attributes.includes('state'), 'should have state attribute');
-  assert.ok(attributes.includes('stateTransition'), 'should have stateTransition attribute');
-  assert.ok(attributes.includes('twitter'), 'should have twitter attribute');
-  assert.ok(attributes.includes('username'), 'should have username attribute');
-  assert.ok(attributes.includes('website'), 'should have website attribute');
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 testForHasMany('user', 'organizationMemberships');


### PR DESCRIPTION
# What's in this PR?

Update model tests to use the new hasAttributes helper. 
`assert.hasAttributes(actualAttributes, expectedAttributes);`

## References
Fixes #552 

Progress on: #98 

