### PR TITLE
Add page objects to project tasks

### DIFF
--- a/app/templates/components/project-card-members.hbs
+++ b/app/templates/components/project-card-members.hbs
@@ -1,6 +1,8 @@
 {{#each visibleMembers as |user|}}
-  <li>
+  <li class="member">
     <img class="icon tiny circle" src={{user.photoThumbUrl}} />
   </li>
 {{/each}}
-{{#if hiddenMembersExist}}<li class="count">+{{hiddenMembersCount}} more</li>{{/if}}
+{{#if hiddenMembersExist}}
+  <li class="count">+{{hiddenMembersCount}} more</li>
+{{/if}}

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
 import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
+import projectTasksIndexPage from '../pages/project/tasks/index';
 
 let application;
 
@@ -19,15 +20,14 @@ test('It renders navigation properly', (assert) => {
   assert.expect(2);
 
   let project = createProjectWithSluggedRoute();
-  let aboutURL = `/${project.organization.slug}/${project.slug}`;
-  let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
-  visit(tasksURL);
+  let organization = project.organization;
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
+  let aboutURL = `/${organization.slug}/${project.slug}`;
+  let tasksURL = `${aboutURL}/tasks`;
 
   andThen(function() {
-    let hrefToAbout = find('.project-menu li:first a').attr('href');
-    assert.equal(hrefToAbout, aboutURL, 'Link to about is properly rendered');
-    let hrefToTasks = find('.project-menu li:eq(1) a').attr('href');
-    assert.equal(hrefToTasks, tasksURL, 'Link to tasks is properly rendered');
+    assert.equal(projectTasksIndexPage.projectMenu.aboutLink.href, aboutURL, 'Link to about is properly rendered');
+    assert.equal(projectTasksIndexPage.projectMenu.tasksLink.href, tasksURL, 'Link to tasks is properly rendered');
   });
 });
 
@@ -35,22 +35,22 @@ test('Navigation works', (assert) => {
   assert.expect(6);
 
   let project = createProjectWithSluggedRoute();
-  let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
-  visit(tasksURL);
+  let organization = project.organization;
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(function() {
     assert.equal(currentRouteName(), 'project.tasks.index');
-    assert.ok(find('.project-menu li:eq(1) a.active').length === 1, 'Tasks link is active');
-    click('.project-menu li:eq(0) a');
+    assert.ok(projectTasksIndexPage.projectMenu.tasksLink.isActive, 'Tasks link is active');
+    projectTasksIndexPage.projectMenu.aboutLink.click();
   });
   andThen(() => {
     assert.equal(currentRouteName(), 'project.index');
-    assert.ok(find('.project-menu li:eq(0) a.active').length === 1, 'About link is active');
-    click('.project-menu li:eq(1) a');
+    assert.ok(projectTasksIndexPage.projectMenu.aboutLink.isActive, 'About link is active');
+    projectTasksIndexPage.projectMenu.tasksLink.click();
   });
   andThen(() => {
     assert.equal(currentRouteName(), 'project.tasks.index');
-    assert.ok(find('.project-menu li:eq(1) a.active').length === 1, 'Tasks link is active');
+    assert.ok(projectTasksIndexPage.projectMenu.tasksLink.isActive, 'Tasks link is active');
   });
 });
 
@@ -58,19 +58,19 @@ test('It renders all the required ui elements for task list', (assert) => {
   assert.expect(4);
 
   let project = createProjectWithSluggedRoute();
-  server.createList('task', 5, { projectId: project.id });
-  let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
-  visit(tasksURL);
+  server.createList('task', 5, { project });
+  let organization = project.organization;
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
+  let tasksURL = `/${organization.slug}/${project.slug}/tasks`;
 
   andThen(function() {
     assert.equal(find('.project-details').length, 1, 'project-details component is rendered');
-    assert.equal(find('.project-task-list').length, 1, 'project-task-list component is rendered');
-    assert.equal(find('.project-task-list .task-item').length, 5, 'correct number of tasks is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.isVisible, true, 'project-task-list component is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 5, 'correct number of tasks is rendered');
 
-    let hrefToFirstTask = find('.project-task-list .task-item:first a').attr('href');
     let expectedHrefToFirstTask = `${tasksURL}/0`;
 
-    assert.equal(hrefToFirstTask, expectedHrefToFirstTask, 'Link to specific task is properly rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems(0).href, expectedHrefToFirstTask, 'Link to specific task is properly rendered');
   });
 });
 
@@ -78,35 +78,34 @@ test('Task filtering by type works', (assert) => {
   assert.expect(4);
 
   let project = createProjectWithSluggedRoute();
+  let organization = project.organization;
 
   // we use server.createList so factories are used in creation
-  server.createList('task', 1, { taskType: 'idea', projectId: project.id });
-  server.createList('task', 6, { taskType: 'task', projectId: project.id });
-  server.createList('task', 3, { taskType: 'issue', projectId: project.id });
+  server.createList('task', 1, { taskType: 'idea', project });
+  server.createList('task', 6, { taskType: 'task', project });
+  server.createList('task', 3, { taskType: 'issue', project });
 
-  let tasksURL = `${project.organization.slug}/${project.slug}/tasks`;
-
-  visit(tasksURL);
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    assert.equal(find('.project-task-list .task-item').length, 10, 'correct number of tasks is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 10, 'correct number of tasks is rendered');
     click('.filter.ideas');
   });
 
   andThen(() => {
-    assert.equal(find('.project-task-list .task-item').length, 1, 'only ideas are rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 1, 'only ideas are rendered');
     click('.tasks-filters .all a');
     click('.filter.tasks');
   });
 
   andThen(() => {
-    assert.equal(find('.project-task-list .task-item').length, 6, 'only task tasks are rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 6, 'only task tasks are rendered');
     click('.tasks-filters .all a');
     click('.filter.issues');
   });
 
   andThen(() => {
-    assert.equal(find('.project-task-list .task-item').length, 3, 'only issues are rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 3, 'only issues are rendered');
   });
 });
 
@@ -118,8 +117,8 @@ test('Task filtering by status works', (assert) => {
   project.openTasksCount = 4;
   project.save();
 
-  server.createList('task', 2, { taskType: 'issue', status: 'closed', projectId: project.id });
-  server.createList('task', 4, { taskType: 'issue', status: 'open', projectId: project.id });
+  server.createList('task', 2, { taskType: 'issue', status: 'closed', project });
+  server.createList('task', 4, { taskType: 'issue', status: 'open', project });
 
   let tasksURL = `${project.organization.slug}/${project.slug}/tasks`;
 
@@ -130,19 +129,19 @@ test('Task filtering by status works', (assert) => {
     assert.equal(find('.statuses .closed').text().trim(), '2 Closed', 'closed count is rendered');
 
     assert.equal(find('.statuses .open').hasClass('active'), true, 'open count has the active class');
-    assert.equal(find('.project-task-list .task-item').length, 4, 'open tasks are rendered by default');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 4, 'open tasks are rendered by default');
     click('.statuses .closed');
   });
 
   andThen(() => {
     assert.equal(find('.statuses .closed').hasClass('active'), true, 'closed count has the active class');
-    assert.equal(find('.project-task-list .task-item').length, 2, 'only closed tasks are rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 2, 'only closed tasks are rendered');
     click('.statuses .open');
   });
 
   andThen(() => {
     assert.equal(find('.statuses .open').hasClass('active'), true, 'open count has the active class');
-    assert.equal(find('.project-task-list .task-item').length, 4, 'open tasks are rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 4, 'open tasks are rendered');
   });
 });
 
@@ -152,32 +151,32 @@ test('Task paging links are correct', (assert) =>  {
   let project = createProjectWithSluggedRoute();
 
   // we use server.createList so factories are used in creation
-  server.createList('task', 20, { taskType: 'idea', projectId: project.id });
-  server.createList('task', 20, { taskType: 'task', projectId: project.id });
+  server.createList('task', 20, { taskType: 'idea', project });
+  server.createList('task', 20, { taskType: 'task', project });
 
   let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
 
   visit(`${tasksURL}?page=2`);
 
   andThen(() => {
-    assert.equal(find('.previous-page').attr('href'), `${tasksURL}`, 'Previous page link links to page 1');
-    assert.equal(find('.next-page').attr('href'), `${tasksURL}?page=3`, 'Link to next page links to page 3');
-    assert.equal(find('.page.1').attr('href'), `${tasksURL}`, 'Link to page 1 is correct');
-    assert.equal(find('.page.2').attr('href'), `${tasksURL}?page=2`, 'Link to page 2 is correct');
-    assert.equal(find('.page.3').attr('href'), `${tasksURL}?page=3`, 'Link to page 3 is correct');
-    assert.equal(find('.page.4').attr('href'), `${tasksURL}?page=4`, 'Link to page 4 is correct');
+    assert.equal(projectTasksIndexPage.pagerControl.previousPage.href, `${tasksURL}`, 'Previous page link links to page 1');
+    assert.equal(projectTasksIndexPage.pagerControl.nextPage.href, `${tasksURL}?page=3`, 'Link to next page links to page 3');
+    assert.equal(projectTasksIndexPage.pagerControl.pages(0).href, `${tasksURL}`, 'Link to page 1 is correct');
+    assert.equal(projectTasksIndexPage.pagerControl.pages(1).href, `${tasksURL}?page=2`, 'Link to page 2 is correct');
+    assert.equal(projectTasksIndexPage.pagerControl.pages(2).href, `${tasksURL}?page=3`, 'Link to page 3 is correct');
+    assert.equal(projectTasksIndexPage.pagerControl.pages(3).href, `${tasksURL}?page=4`, 'Link to page 4 is correct');
     click('.filter.ideas');
   });
 
   andThen(() => {
-    assert.equal(find('.next-page').attr('href'), `${tasksURL}?page=2&taskType=idea`, 'Next page link maintains type filter');
-    assert.equal(find('.page.1').attr('href'), `${tasksURL}?taskType=idea`, 'Link to page 1 maintains type filter');
-    assert.equal(find('.page.2').attr('href'), `${tasksURL}?page=2&taskType=idea`, 'Link to page 2 maintains type filter');
-    click('.page.2');
+    assert.equal(projectTasksIndexPage.pagerControl.nextPage.href, `${tasksURL}?page=2&taskType=idea`, 'Next page link maintains type filter');
+    assert.equal(projectTasksIndexPage.pagerControl.pages(0).href, `${tasksURL}?taskType=idea`, 'Link to page 1 maintains type filter');
+    assert.equal(projectTasksIndexPage.pagerControl.pages(1).href, `${tasksURL}?page=2&taskType=idea`, 'Link to page 2 maintains type filter');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
-    assert.equal(find('.previous-page').attr('href'), `${tasksURL}?taskType=idea`, 'Previous page link maintains type filter');
+    assert.equal(projectTasksIndexPage.pagerControl.previousPage.href, `${tasksURL}?taskType=idea`, 'Previous page link maintains type filter');
   });
 });
 
@@ -186,19 +185,19 @@ test('Paging of tasks works', (assert) => {
 
   let project = createProjectWithSluggedRoute();
 
-  server.createList('task', 12, { projectId: project.id });
+  server.createList('task', 12, { project });
 
   let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
   visit(tasksURL);
 
   andThen(() => {
     assert.equal(find('.pager-control').length, 1, 'pager is rendered');
-    assert.equal(find('.task-item').length, 10, 'first page of 10 records is rendered');
-    click('.pager-control .page.2');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 10, 'first page of 10 records is rendered');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
-    assert.equal(find('.task-item').length, 2, 'second page of 2 records is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 2, 'second page of 2 records is rendered');
   });
 });
 
@@ -207,47 +206,47 @@ test('Paging and filtering of tasks combined works', (assert) => {
 
   let project = createProjectWithSluggedRoute();
 
-  server.createList('task', 12, { taskType: 'task', projectId: project.id });
-  server.createList('task', 12, { taskType: 'issue', projectId: project.id });
+  server.createList('task', 12, { taskType: 'task', project });
+  server.createList('task', 12, { taskType: 'issue', project });
 
   let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
   visit(tasksURL);
 
   andThen(() => {
-    assert.equal(find('.task-item').length, 10, 'first page of 10 tasks is rendered');
-    click('.pager-control .page.2');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 10, 'first page of 10 tasks is rendered');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
-    assert.equal(find('.task-item').length, 10, 'second page of 10 tasks is rendered');
-    click('.pager-control .page.3');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 10, 'second page of 10 tasks is rendered');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
-    assert.equal(find('.task-item').length, 4, 'third page of 4 tasks is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 4, 'third page of 4 tasks is rendered');
     click('.filter.tasks');
   });
 
   andThen(() => {
-    assert.equal(find('.task-item.task').length, 10, 'first page of 10 tasks is rendered');
-    click('.pager-control .page.2');
+    assert.equal(projectTasksIndexPage.projectTaskList.tasks().count, 10, 'first page of 10 tasks is rendered');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
-    assert.equal(find('.task-item.task').length, 2, 'second page of 2 tasks is rendered');
-    assert.equal(find('.task-item').length, 2, 'there are no other tasks rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.tasks().count, 2, 'second page of 2 tasks is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 2, 'there are no other tasks rendered');
     click('.tasks-filters .all a');
     click('.filter.issues');
   });
 
   andThen(() => {
-    assert.equal(find('.task-item.issue').length, 10, 'first page of 10 issues is rendered');
-    click('.pager-control .page.2');
+    assert.equal(projectTasksIndexPage.projectTaskList.issues().count, 10, 'first page of 10 issues is rendered');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
-    assert.equal(find('.task-item.issue').length, 2, 'second page of 2 issues is rendered');
-    assert.equal(find('.task-item').length, 2, 'there are no other tasks rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.issues().count, 2, 'second page of 2 issues is rendered');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 2, 'there are no other tasks rendered');
   });
 });
 
@@ -256,8 +255,8 @@ test('Paging and filtering uses query parameters', (assert) => {
 
   let project = createProjectWithSluggedRoute();
 
-  server.createList('task', 22, { taskType: 'task', projectId: project.id });
-  server.createList('task', 12, { taskType: 'issue', projectId: project.id });
+  server.createList('task', 22, { taskType: 'task', project });
+  server.createList('task', 12, { taskType: 'issue', project });
 
   let tasksURL = `/${project.organization.slug}/${project.slug}/tasks`;
 
@@ -265,7 +264,7 @@ test('Paging and filtering uses query parameters', (assert) => {
 
   andThen(() => {
     assert.equal(currentURL(), `${tasksURL}`);
-    click('.pager-control .page.2');
+    projectTasksIndexPage.pagerControl.nextPage.click();
   });
 
   andThen(() => {
@@ -275,7 +274,7 @@ test('Paging and filtering uses query parameters', (assert) => {
 
   andThen(() => {
     assert.equal(currentURL(), `${tasksURL}?taskType=task`, 'We switched type, so page param should reset as well');
-    click('.pager-control .page.3');
+    projectTasksIndexPage.pagerControl.pages(2).click();
   });
 
   andThen(() => {
@@ -290,7 +289,7 @@ test('Paging and filtering uses query parameters', (assert) => {
   visit(`${tasksURL}?page=3&taskType=task`);
 
   andThen(() => {
-    assert.equal(find('.project-task-list .task-item').length, 2, 'Visiting URL via params directly, should fetch the correct tasks');
+    assert.equal(projectTasksIndexPage.projectTaskList.taskItems().count, 2, 'Visiting URL via params directly, should fetch the correct tasks');
   });
 });
 
@@ -304,7 +303,7 @@ test('A user can join the organization of the project', (assert) => {
   visit(projectURL);
 
   andThen(() => {
-    assert.equal(find('.join-project a').text().trim(), 'Sign up', 'The link to sign up is present when logged out');
+    assert.equal(projectTasksIndexPage.projectDetails.signUpLink.text, 'Sign up', 'The link to sign up is present when logged out');
 
     authenticateSession(application, { user_id: user.id });
     visit(projectURL);
@@ -312,8 +311,9 @@ test('A user can join the organization of the project', (assert) => {
 
 
   andThen(() => {
-    assert.equal(find('.join-project button').text().trim(), 'Join project', 'The button to join is present when logged in');
-    click('.join-project button');
+    let joinButton = projectTasksIndexPage.projectDetails.joinProjectButton;
+    assert.equal(joinButton.text, 'Join project', 'The button to join is present when logged in');
+    joinButton.click();
   });
 
   let done = assert.async();

--- a/tests/acceptance/projects-test.js
+++ b/tests/acceptance/projects-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
 import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
+import projectsPage from '../pages/projects';
 
 moduleForAcceptance('Acceptance | Projects');
 
@@ -16,7 +17,7 @@ test('visiting /projects', function(assert) {
   project.skills = [skill];
   project.save();
 
-  visit('/projects');
+  projectsPage.visit();
 
   andThen(function() {
     assert.equal(currentURL(), '/projects');
@@ -31,9 +32,9 @@ test('members are displayed correctly', (assert) => {
     organization
   });
 
-  visit('/projects');
+  projectsPage.visit();
   andThen(() => {
-    assert.equal(find('.icon.tiny.circle').length, 8, '8 members are rendered');
-    assert.equal(find('.project-card-members .count').text().trim(), '+2 more', 'The "+2 more" text is rendered');
+    assert.equal(projectsPage.projectCard.members().count, 8, '8 members are rendered');
+    assert.equal(projectsPage.projectCard.memberCount.text, '+2 more', 'The "+2 more" text is rendered');
   });
 });

--- a/tests/acceptance/task-creation-test.js
+++ b/tests/acceptance/task-creation-test.js
@@ -5,7 +5,8 @@ import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple
 import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
 import Mirage from 'ember-cli-mirage';
 import loginPage from '../pages/login';
-import projectTasksPage from '../pages/project-tasks';
+import projectTasksIndexPage from '../pages/project/tasks/index';
+import projectTasksNewPage from '../pages/project/tasks/new';
 
 let application;
 
@@ -24,10 +25,10 @@ test('Creating a task requires logging in', (assert) => {
   let project = createProjectWithSluggedRoute();
   let organization = project.organization;
 
-  projectTasksPage.visitIndex({ organization: organization.slug, project: project.slug });
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectTasksPage.clickNewTask();
+    projectTasksIndexPage.clickNewTask();
   });
 
   andThen(() => {
@@ -49,16 +50,16 @@ test('A task can be successfully created', (assert) => {
   let project = createProjectWithSluggedRoute();
   let organization = project.organization;
   authenticateSession(application, { user_id: user.id });
-  projectTasksPage.visitIndex({ organization: organization.slug, project: project.slug });
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectTasksPage.clickNewTask();
+    projectTasksIndexPage.clickNewTask();
   });
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.tasks.new', 'Button takes us to the proper route');
     assert.equal(find('[name=task-type]').val(), 'issue', 'Has the right default task type');
-    projectTasksPage.taskTitle('A task title').taskMarkdown('A task body').taskType('idea').clickSubmit();
+    projectTasksNewPage.taskTitle('A task title').taskMarkdown('A task body').taskType('idea').clickSubmit();
   });
 
   andThen(() => {
@@ -87,15 +88,15 @@ test('Task preview works during creation', (assert) => {
   let organization = project.organization;
   authenticateSession(application, { user_id: user.id });
 
-  projectTasksPage.visitNew({ organization: organization.slug, project: project.slug });
+  projectTasksNewPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectTasksPage.taskMarkdown('Some type of markdown');
-    projectTasksPage.clickPreviewTask();
+    projectTasksNewPage.taskMarkdown('Some type of markdown');
+    projectTasksNewPage.clickPreviewTask();
   });
 
   andThen(() => {
-    assert.equal(projectTasksPage.previewBody.text, 'Some type of markdown', 'The preview is rendered');
+    assert.equal(projectTasksNewPage.previewBody.text, 'Some type of markdown', 'The preview is rendered');
   });
 });
 
@@ -109,14 +110,14 @@ test('Task preview works during creation', (assert) => {
   let user2 = server.create('user');
   let markdown = `Mentioning @${user1.username} and @${user2.username}`;
   const expectedBody = `Mentioning @${user1.username} and @${user2.username}`;
-  projectTasksPage.visitNew({ organization: organization.slug, project: project.slug });
+  projectTasksNewPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectTasksPage.taskMarkdown(markdown);
-    projectTasksPage.clickPreviewTask();
+    projectTasksIndexPage.taskMarkdown(markdown);
+    projectTasksIndexPage.clickPreviewTask();
 
     andThen(() => {
-      assert.equal(projectTasksPage.previewBody.text, expectedBody, 'The mentions render');
+      assert.equal(projectTasksIndexPage.previewBody.text, expectedBody, 'The mentions render');
     });
   });
 });*/
@@ -129,12 +130,12 @@ test('When task creation succeeeds, the user is redirected to the task page for 
   let organization = project.organization;
   authenticateSession(application, { user_id: user.id });
 
-  projectTasksPage.visitIndex({ organization: organization.slug, project: project.slug });
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
-  andThen(() => projectTasksPage.clickNewTask());
+  andThen(() => projectTasksIndexPage.clickNewTask());
 
   andThen(() => {
-    projectTasksPage.taskTitle('A task title').taskMarkdown('A task body').taskType('Task').clickSubmit();
+    projectTasksNewPage.taskTitle('A task title').taskMarkdown('A task body').taskType('Task').clickSubmit();
   });
 
   andThen(() => {
@@ -150,9 +151,9 @@ test('When task creation fails due to validation, validation errors are displaye
   let organization = project.organization;
   authenticateSession(application, { user_id: user.id });
 
-  projectTasksPage.visitIndex({ organization: organization.slug, project: project.slug });
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
-  andThen(() => projectTasksPage.clickNewTask());
+  andThen(() => projectTasksIndexPage.clickNewTask());
 
   andThen(() => {
     let taskCreationDone = assert.async();
@@ -186,10 +187,10 @@ test('When task creation fails due to validation, validation errors are displaye
           }
       ]});
     });
-    projectTasksPage.clickSubmit();
+    projectTasksNewPage.clickSubmit();
   });
 
-  andThen(() => assert.equal(projectTasksPage.errors().count, 4));
+  andThen(() => assert.equal(projectTasksNewPage.errors().count, 4));
 });
 
 test('When task creation fails due to non-validation issues, the error is displayed', (assert) => {
@@ -201,10 +202,10 @@ test('When task creation fails due to non-validation issues, the error is displa
   let organization = project.organization;
   authenticateSession(application, { user_id: user.id });
 
-  projectTasksPage.visitIndex({ organization: organization.slug, project: project.slug });
+  projectTasksIndexPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectTasksPage.clickNewTask();
+    projectTasksIndexPage.clickNewTask();
   });
 
   andThen(() => {
@@ -222,11 +223,11 @@ test('When task creation fails due to non-validation issues, the error is displa
         ]
       });
     });
-    projectTasksPage.clickSubmit();
+    projectTasksNewPage.clickSubmit();
   });
 
   andThen(() => {
-    assert.equal(projectTasksPage.errors().count, 1);
-    assert.equal(projectTasksPage.errors().contains('An unknown error: Something happened', 'The error is messaged'), true);
+    assert.equal(projectTasksNewPage.errors().count, 1);
+    assert.equal(projectTasksNewPage.errors().contains('An unknown error: Something happened', 'The error is messaged'), true);
   });
 });

--- a/tests/pages/components/pager-control.js
+++ b/tests/pages/components/pager-control.js
@@ -1,0 +1,25 @@
+import {
+  attribute,
+  collection,
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.pager-control',
+
+  nextPage: {
+    scope: '.next-page',
+    href: attribute('href')
+  },
+
+  pages: collection({
+    itemScope: '.page',
+    item: {
+      href: attribute('href'),
+    }
+  }),
+
+  previousPage: {
+    scope: '.previous-page',
+    href: attribute('href')
+  },
+};

--- a/tests/pages/components/project-card.js
+++ b/tests/pages/components/project-card.js
@@ -1,0 +1,16 @@
+import {
+  collection
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.project-card',
+
+  memberCount: {
+    scope: '.project-card-members .count'
+  },
+
+  members: collection({
+    scope: '.project-card-members',
+    itemScope: 'li.member',
+  }),
+};

--- a/tests/pages/components/project-details.js
+++ b/tests/pages/components/project-details.js
@@ -1,0 +1,17 @@
+import {
+  attribute
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.project-details',
+
+  joinProjectButton: {
+    scope: '.join-project button',
+    href: attribute('href'),
+  },
+
+  signUpLink: {
+    scope: '.join-project a',
+    href: attribute('href'),
+  }
+};

--- a/tests/pages/components/project-menu.js
+++ b/tests/pages/components/project-menu.js
@@ -1,0 +1,19 @@
+import {
+  attribute,
+  hasClass
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.project-menu',
+
+  aboutLink: {
+    scope: 'li:eq(0) a',
+    href: attribute('href'),
+    isActive: hasClass('active')
+  },
+  tasksLink: {
+    scope: 'li:eq(1) a',
+    href: attribute('href'),
+    isActive: hasClass('active')
+  }
+};

--- a/tests/pages/components/project-task-list.js
+++ b/tests/pages/components/project-task-list.js
@@ -1,0 +1,24 @@
+import {
+  attribute,
+  collection,
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.project-task-list',
+
+  issues: collection({
+    scope: '.task-item.issue'
+  }),
+
+  taskItems: collection({
+    scope: '.task-item',
+    itemScope: 'a',
+    item: {
+      href: attribute('href'),
+    },
+  }),
+
+  tasks: collection({
+    scope: '.task-item.task'
+  })
+};

--- a/tests/pages/project/tasks/index.js
+++ b/tests/pages/project/tasks/index.js
@@ -1,0 +1,21 @@
+import {
+  clickable,
+  create,
+  visitable
+} from 'ember-cli-page-object';
+import pagerControl from '../../components/pager-control';
+import projectDetails from '../../components/project-details';
+import projectMenu from '../../components/project-menu';
+import projectTaskList from '../../components/project-task-list';
+
+export default create({
+  visit: visitable(':organization/:project/tasks'),
+
+  clickNewTask: clickable('.new-task'),
+  clickPreviewTask: clickable('.preview'),
+
+  pagerControl,
+  projectDetails,
+  projectMenu,
+  projectTaskList
+});

--- a/tests/pages/project/tasks/new.js
+++ b/tests/pages/project/tasks/new.js
@@ -7,10 +7,8 @@ import {
 } from 'ember-cli-page-object';
 
 export default create({
-  visitIndex: visitable(':organization/:project/tasks'),
-  visitNew: visitable(':organization/:project/tasks/new'),
+  visit: visitable(':organization/:project/tasks/new'),
 
-  clickNewTask: clickable('.new-task'),
   clickPreviewTask: clickable('.preview'),
 
   taskTitle: fillable('[name=title]'),
@@ -18,7 +16,7 @@ export default create({
   taskType: fillable('[name=task-type]'),
 
   clickSubmit: clickable('[name=submit]'),
-  
+
   previewBody: {
     scope: '.body-preview'
   },

--- a/tests/pages/projects.js
+++ b/tests/pages/projects.js
@@ -1,0 +1,11 @@
+import {
+  create,
+  visitable
+} from 'ember-cli-page-object';
+import projectCard from './components/project-card';
+
+export default create({
+  visit: visitable('/projects'),
+
+  projectCard,
+});


### PR DESCRIPTION
# What's in this PR?

- Add a bunch of page object components
- Add page objects to project tasks

I also intentionally did not turn the task filtering or open/closed pieces into page objects since we're removing that completely.

## References
Fixes #515
Fixes #516 

Progress on: #141 