### PR TITLE
Update hasAttributes helper

### DIFF
--- a/tests/helpers/has-attributes.js
+++ b/tests/helpers/has-attributes.js
@@ -1,10 +1,11 @@
 import QUnit from 'qunit';
 /*
   This assertion will compare 2 arrays of attributes.
-  It first sorts both arrays and then compares each element.
+  It first convert the attributes Map to an Array,
+  then sorts both arrays and then compares each element.
 
   @method hasAttributes
-  @param {Array} actualAttributes
+  @param {Map} actualAttributes
   @param {Array} expectedAttributes
 */
 function compareArrays(actualAttributes, expectedAttributes) {
@@ -18,6 +19,11 @@ function compareArrays(actualAttributes, expectedAttributes) {
 QUnit.assert.hasAttributes = function(actualAttributes, expectedAttributes) {
   this.expect(2);
 
-  this.ok(actualAttributes.length === expectedAttributes.length, `should have ${expectedAttributes.length} attributes`);
-  this.ok(compareArrays(actualAttributes, expectedAttributes), 'should have the expected attributes');
+  let actualAttributesArray = [];
+  actualAttributes.forEach(function(meta, name) {
+    actualAttributesArray.push(name);
+  });
+
+  this.ok(actualAttributesArray.length === expectedAttributes.length, `should have ${expectedAttributes.length} attributes`);
+  this.ok(compareArrays(actualAttributesArray, expectedAttributes), 'should have the expected attributes');
 };

--- a/tests/unit/models/category-test.js
+++ b/tests/unit/models/category-test.js
@@ -1,10 +1,14 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForHasMany } from '../../helpers/relationship';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('category', 'Unit | Model | category', {
   // Specify the other units that are required for this test.
-  needs: ['model:user-category', 'model:project-category']
+  needs: [
+    'model:project-category',
+    'model:user-category'
+  ]
 });
 
 test('it exists', function(assert) {
@@ -14,12 +18,13 @@ test('it exists', function(assert) {
 });
 
 test('it should have all its attributes', function(assert) {
-  let category = this.subject();
-  let actualAttributes = Object.keys(category.toJSON());
+  let model = this.store().modelFor('category');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
     "description",
     "name",
-    "slug",
+    "slug"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);

--- a/tests/unit/models/comment-test.js
+++ b/tests/unit/models/comment-test.js
@@ -1,13 +1,14 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo, testForHasMany } from '../../helpers/relationship';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('comment', 'Unit | Model | comment', {
   // Specify the other units that are required for this test.
   needs: [
+    'model:comment-user-mention',
     'model:task',
-    'model:user',
-    'model:comment-user-mention'
+    'model:user'
   ]
 });
 
@@ -18,14 +19,13 @@ test('it exists', function(assert) {
 });
 
 test('it has all of its attributes', function(assert) {
-  let comment = this.subject();
-  let actualAttributes = Object.keys(comment.toJSON());
+  let model = this.store().modelFor('comment');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
     "body",
     "insertedAt",
-    "markdown",
-    "task",
-    "user",
+    "markdown"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);

--- a/tests/unit/models/comment-user-mention-test.js
+++ b/tests/unit/models/comment-user-mention-test.js
@@ -1,12 +1,29 @@
 import { moduleForModel, test } from 'ember-qunit';
+import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('comment-user-mention', 'Unit | Model | comment user mention', {
   // Specify the other units that are required for this test.
-  needs: ['model:comment', 'model:user']
+  needs: [
+    'model:comment',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);
+});
+
+test('it should have all of its attributes', function(assert) {
+  let model = this.store().modelFor('comment-user-mention');
+  let actualAttributes = Ember.get(model, 'attributes');
+
+  let expectedAttributes = [
+    "indices",
+    "username"
+  ];
+
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });

--- a/tests/unit/models/organization-membership-test.js
+++ b/tests/unit/models/organization-membership-test.js
@@ -1,7 +1,7 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo } from '../../helpers/relationship';
-import Ember from 'ember';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 const {
   get,
@@ -11,7 +11,10 @@ const {
 
 moduleForModel('organization-membership', 'Unit | Model | organization membership', {
   // Specify the other units that are required for this test.
-  needs: ['model:user', 'model:organization']
+  needs: [
+    'model:organization',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
@@ -21,12 +24,11 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-  let organizationMembership = this.subject();
-  let actualAttributes = Object.keys(organizationMembership.toJSON());
+  let model = this.store().modelFor('organization-membership');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
-    "member",
-    "organization",
-    "role",
+    "role"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -1,12 +1,52 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { testForHasMany } from '../../helpers/relationship';
+import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('organization', 'Unit | Model | organization', {
   // Specify the other units that are required for this test.
-  needs: ['model:project', 'model:user', 'model:organization-membership']
+  needs: [
+    'model:organization-membership',
+    'model:project',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);
+});
+
+test('it should have all of its attributes', function(assert) {
+  let model = this.store().modelFor('organization');
+  let actualAttributes = Ember.get(model, 'attributes');
+
+  let expectedAttributes = [
+    "base64IconData",
+    "description",
+    "iconLargeUrl",
+    "iconThumbUrl",
+    "name",
+    "slug"
+  ];
+
+  assert.hasAttributes(actualAttributes, expectedAttributes);
+});
+
+testForHasMany('organization', 'organizationMemberships');
+testForHasMany('organization', 'projects');
+
+test('it should have computed properties for its organization\'s members', function(assert) {
+  assert.expect(2);
+
+  let store = this.store();
+  let model = this.subject();
+
+  Ember.run(function(){
+    store.createRecord('organization-membership', { organization: model, role: 'pending'});
+  });
+
+  assert.equal(model.get('pendingMembersCount'), 1, 'pendingMembersCount should return 1');
+  assert.equal(model.get('hasPendingMembers'), true, 'hasPendingMembers should return true');
 });

--- a/tests/unit/models/preview-test.js
+++ b/tests/unit/models/preview-test.js
@@ -1,6 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
-import Ember from 'ember';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 const {
   get,
@@ -8,7 +8,10 @@ const {
 
 moduleForModel('preview', 'Unit | Model | preview', {
   // Specify the other units that are required for this test.
-  needs: ['model:user', 'model:preview-user-mention']
+  needs: [
+    'model:preview-user-mention',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
@@ -18,15 +21,15 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-   let preview = this.subject();
-   let actualAttributes = Object.keys(preview.toJSON());
-   let expectedAttributes = [
-     "body",
-     "markdown",
-     "user"
-   ];
+  let model = this.store().modelFor('preview');
+  let actualAttributes = Ember.get(model, 'attributes');
 
-   assert.hasAttributes(actualAttributes, expectedAttributes);
+  let expectedAttributes = [
+    "body",
+    "markdown"
+  ];
+
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });
 
 test('should belong to a user', function(assert) {

--- a/tests/unit/models/preview-user-mention-test.js
+++ b/tests/unit/models/preview-user-mention-test.js
@@ -1,12 +1,29 @@
 import { moduleForModel, test } from 'ember-qunit';
+import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('preview-user-mention', 'Unit | Model | preview user mention', {
   // Specify the other units that are required for this test.
-  needs: ['model:preview', 'model:user']
+  needs: [
+    'model:preview',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);
+});
+
+test('it should have all of its attributes', function(assert) {
+  let model = this.store().modelFor('preview-user-mention');
+  let actualAttributes = Ember.get(model, 'attributes');
+
+  let expectedAttributes = [
+    "indices",
+    "username"
+  ];
+
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -5,9 +5,14 @@ import Ember from 'ember';
 
 moduleForModel('project', 'Unit | Model | project', {
   // Specify the other units that are required for this test.
-  needs: ['model:project-category', 'model:organization',
-          'model:organization-membership', 'model:user',
-          'model:task', 'model:project-skill']
+  needs: [
+    'model:organization',
+    'model:organization-membership',
+    'model:project-category',
+    'model:project-skill',
+    'model:task',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
@@ -16,8 +21,9 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-  let model = this.subject();
-  let actualAttributes = Object.keys(model.toJSON());
+  let model = this.store().modelFor('project');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
     "base64IconData",
     "closedTasksCount",
@@ -27,9 +33,8 @@ test('it should have all of its attributes', function(assert) {
     "longDescriptionBody",
     "longDescriptionMarkdown",
     "openTasksCount",
-    "organization",
     "slug",
-    "title",
+    "title"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);

--- a/tests/unit/models/skill-test.js
+++ b/tests/unit/models/skill-test.js
@@ -1,4 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
+import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('skill', 'Unit | Model | skill', {
   // Specify the other units that are required for this test.
@@ -12,13 +14,14 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-   let model = this.subject();
-   let actualAttributes = Object.keys(model.toJSON());
-   let expectedAttributes = [
-     "description",
-     "matched",
-     "title",
-   ];
+  let model = this.store().modelFor('skill');
+  let actualAttributes = Ember.get(model, 'attributes');
 
-   assert.hasAttributes(actualAttributes, expectedAttributes);
+  let expectedAttributes = [
+    "description",
+    "matched",
+    "title"
+  ];
+
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });

--- a/tests/unit/models/slugged-route-test.js
+++ b/tests/unit/models/slugged-route-test.js
@@ -1,10 +1,14 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo } from '../../helpers/relationship';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('slugged-route', 'Unit | Model | slugged-route', {
   // Specify the other units that are required for this test.
-  needs: ['model:organization', 'model:user']
+  needs: [
+    'model:organization',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
@@ -14,12 +18,11 @@ test('it exists', function(assert) {
 });
 
 test('should have all of its attributes', function(assert) {
-  let sluggedRoute = this.subject();
-  let actualAttributes = Object.keys(sluggedRoute.toJSON());
+  let model = this.store().modelFor('slugged-route');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
-    "organization",
-    "slug",
-    "user",
+    "slug"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);

--- a/tests/unit/models/task-test.js
+++ b/tests/unit/models/task-test.js
@@ -1,15 +1,16 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForBelongsTo, testForHasMany } from '../../helpers/relationship';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('task', 'Unit | Model | task', {
   // Specify the other units that are required for this test.
   needs: [
-    'model:project',
-    'model:user',
     'model:comment',
     'model:comment-user-mention',
-    'model:task-user-mention'
+    'model:project',
+    'model:task-user-mention',
+    'model:user'
   ]
 });
 
@@ -20,20 +21,18 @@ test('it exists', function(assert) {
 });
 
 test('it should have all of its attributes', function(assert) {
-  let task = this.subject();
-  let actualAttributes = Object.keys(task.toJSON());
+  let model = this.store().modelFor('task');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
     "body",
-    "commentUserMentions",
     "insertedAt",
     "likesCount",
     "markdown",
     "number",
-    "project",
     "status",
     "taskType",
-    "title",
-    "user",
+    "title"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);

--- a/tests/unit/models/task-user-mention-test.js
+++ b/tests/unit/models/task-user-mention-test.js
@@ -1,12 +1,29 @@
 import { moduleForModel, test } from 'ember-qunit';
+import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('task-user-mention', 'Unit | Model | task user mention', {
   // Specify the other units that are required for this test.
-  needs: ['model:task', 'model:user']
+  needs: [
+    'model:task',
+    'model:user'
+  ]
 });
 
 test('it exists', function(assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);
+});
+
+test('it should have all of its attributes', function(assert) {
+  let model = this.store().modelFor('task-user-mention');
+  let actualAttributes = Ember.get(model, 'attributes');
+
+  let expectedAttributes = [
+    "indices",
+    "username"
+  ];
+
+  assert.hasAttributes(actualAttributes, expectedAttributes);
 });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,6 +1,7 @@
 import { moduleForModel, test } from 'ember-qunit';
 import { testForHasMany } from '../../helpers/relationship';
 import '../../helpers/has-attributes';
+import Ember from 'ember';
 
 moduleForModel('user', 'Unit | Model | user', {
   // Specify the other units that are required for this test.
@@ -20,8 +21,9 @@ test('it exists', function(assert) {
 });
 
 test('it has all of its attributes', function(assert) {
-  let user = this.subject();
-  let actualAttributes = Object.keys(user.toJSON());
+  let model = this.store().modelFor('user');
+  let actualAttributes = Ember.get(model, 'attributes');
+
   let expectedAttributes = [
     "base64PhotoData",
     "biography",
@@ -37,7 +39,7 @@ test('it has all of its attributes', function(assert) {
     "stateTransition",
     "twitter",
     "username",
-    "website",
+    "website"
   ];
 
   assert.hasAttributes(actualAttributes, expectedAttributes);


### PR DESCRIPTION
# What's in this PR?

Update the hasAttributes helper test to work with the map object of attributes

Using this code 
```
  let model = this.store().modelFor('task');
  let actualAttributes = Ember.get(model, 'attributes');
```
we can return only the real attributes that were created using the DS.attr().
http://emberjs.com/api/data/classes/DS.Model.html#property_attributes

## References

Fixes: #526 

Progress on: #98 

