### PR TITLE
Fix first few ESLint offenses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,8 +42,7 @@ module.exports = {
     'ember-suave/no-direct-property-access': 'off',
     'ember-suave/prefer-destructuring': 'off',
     'ember-suave/require-access-in-comments': 'off',
-    'ember-suave/require-const-for-ember-properties': 'off',
-    'no-unused-vars': 'off'
+    'ember-suave/require-const-for-ember-properties': 'off'
   },
   globals: {
     'server': true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
     'keyword-spacing': 'off',
     'no-var': 'off',
     'space-in-parens': 'off',
-    'generator-star-spacing': 'off',
     'indent': 'off',
     'space-infix-ops': 'off',
     'operator-linebreak': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
     'comma-spacing': 'off',
     'no-multiple-empty-lines': 'off',
     'camelcase': 'off',
-    'no-trailing-spaces': 'off',
     'key-spacing': 'off',
     'new-cap': 'off',
     'space-before-blocks': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,6 @@ module.exports = {
     'no-trailing-spaces': 'off',
     'key-spacing': 'off',
     'new-cap': 'off',
-    'one-var': 'off',
     'space-before-blocks': 'off',
     'ember-suave/no-const-outside-module-scope': 'off',
     'ember-suave/no-direct-property-access': 'off',

--- a/app/components/demo-categories.js
+++ b/app/components/demo-categories.js
@@ -52,7 +52,7 @@ export default Component.extend({
     }
   }),
 
-  _animateItem: task(function * (category) {
+  _animateItem: task(function* (category) {
     category.set('selected', true);
     category.set('isLoading', true);
     later(() => {

--- a/app/components/demo-skills.js
+++ b/app/components/demo-skills.js
@@ -65,7 +65,7 @@ export default Component.extend({
     }
   }),
 
-  _animateItem: task(function * (skill) {
+  _animateItem: task(function* (skill) {
     skill.set('selected', true);
     skill.set('isLoading', true);
     later(() => {

--- a/app/components/image-drop.js
+++ b/app/components/image-drop.js
@@ -53,8 +53,9 @@ export default Component.extend({
     var img = new Image();
     img.crossOrigin = 'Anonymous';
     img.onload = function(){
-        var canvas = document.createElement('CANVAS'),
-        ctx = canvas.getContext('2d'), dataURL;
+        var canvas = document.createElement('CANVAS');
+        var ctx = canvas.getContext('2d');
+        var dataURL;
         canvas.height = this.height;
         canvas.width = this.width;
         ctx.drawImage(this, 0, 0);

--- a/app/mixins/can-animate.js
+++ b/app/mixins/can-animate.js
@@ -6,11 +6,10 @@ export default Ember.Mixin.create({
   windowHeight: 0,
   windowWidth: 0,
 
-  canAnimate: Ember.computed('boundingClientRect', 'windowHeight', 'windowWidth', function() {
-    var rect, windowHeight, windowWidth;
+  canAnimate: Ember.computed('boundingClientRect', 'windowHeight', function() {
+    var rect, windowHeight;
     rect = this.get('boundingClientRect');
     windowHeight = this.get('windowHeight');
-    windowWidth = this.get('windowWidth');
     return (
       rect.top <= windowHeight - 150
     );

--- a/tests/acceptance/slugged-route-test.js
+++ b/tests/acceptance/slugged-route-test.js
@@ -20,7 +20,7 @@ test("It renders user details when the sluggedRoute model is a user", function(a
   assert.expect(1);
 
   let user = createUserWithSluggedRoute();
-  
+
   sluggedRoutePage.visit({ slug: user.username });
 
   andThen(function() {

--- a/tests/helpers/has-attributes.js
+++ b/tests/helpers/has-attributes.js
@@ -11,7 +11,7 @@ function compareArrays(actualAttributes, expectedAttributes) {
   expectedAttributes.sort();
 
   return actualAttributes.sort().every(function(element, index) {
-    return element === expectedAttributes[index]; 
+    return element === expectedAttributes[index];
   });
 }
 

--- a/tests/pages/signup.js
+++ b/tests/pages/signup.js
@@ -10,7 +10,6 @@ export default create({
 
   form: {
     scope: '.signup-form',
-    
     email: fillable('[name=email]'),
     password: fillable('[name=password]'),
     save: clickable('[name=signup]'),

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -51,8 +51,8 @@ test('it should have open tasks', function(assert) {
 test('it should have computed properties for its organization\'s members', function(assert) {
   assert.expect(2);
 
-  let _this = this,
-      project;
+  let _this = this;
+  let project;
 
   Ember.run(function(){
     let organization = _this.store().createRecord('organization');

--- a/tests/unit/models/skill-test.js
+++ b/tests/unit/models/skill-test.js
@@ -19,6 +19,6 @@ test('it should have all of its attributes', function(assert) {
      "matched",
      "title",
    ];
- 
+
    assert.hasAttributes(actualAttributes, expectedAttributes);
 });


### PR DESCRIPTION
# What's in this PR?

Fixes the following: 

✔️ `no-undef`
http://eslint.org/docs/rules/no-undef
Disallow Undeclared Variables (no-undef)
This rule can help you locate potential ReferenceErrors resulting from misspellings of variable and parameter names, or accidental implicit globals (for example, from forgetting the var keyword in a for loop initialiser).

✔️ `one-var`
http://eslint.org/docs/rules/one-var-declaration-per-line
require or disallow newlines around variable declarations (one-var-declaration-per-line)

✔️ `generator-star-spacing`
http://eslint.org/docs/rules/generator-star-spacing
Enforce spacing around the * in generator functions (generator-star-spacing)

✔️ `no-trailing-spaces`
http://eslint.org/docs/rules/no-trailing-spaces
disallow trailing whitespace at the end of lines (no-trailing-spaces)
Sometimes in the course of editing files, you can end up with extra
whitespace at the end of lines. These whitespace differences can be
picked up by source control systems and flagged as diffs, causing
frustration for developers. While this extra whitespace causes no
functional issues, many code conventions require that trailing spaces
be removed before check-in.

## References

Progress on: #594 