### PR TITLE
[WIP] [507] add async input helper to prevent multiple submits

### DIFF
--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+const {
+  Component,
+  get
+} = Ember;
+
+export default Component.extend({
+  attributeBindings: ['disabled', 'name', 'type', 'value'],
+  classNames: ['button', 'default'],
+  classNameBindings: ['hasError'],
+  disabled: false,
+  name: null,
+  type: 'submit',
+  tagName: 'input',
+  value: null,
+
+  click() {
+    get(this, 'submitAction')();
+  }
+});

--- a/app/components/signup-form.js
+++ b/app/components/signup-form.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const {
   Component,
   computed,
-  computed: { alias, and, gte },
+  computed: { alias, and, gte, or },
   inject: { service },
   run: { later }
 } = Ember;
@@ -18,6 +18,7 @@ export default Component.extend({
   store: service(),
 
   canSubmit: and('emailValid', 'passwordValid', 'usernameValid'),
+  hasSaved: or('user.isLoading', 'user.isReloading', 'user.isSaving'),
   passwordLength: alias('password.length'),
   passwordValid: gte('passwordLength', 6),
 

--- a/app/templates/components/signup-form.hbs
+++ b/app/templates/components/signup-form.hbs
@@ -5,7 +5,13 @@
   {{signup-email-input user=user emailValidated="emailValidated"}}
   {{signup-password-input user=user}}
   <div class="input-group">
-    <input class="button default {{if hasError "has-error"}}" name="signup" type="submit" value='Sign up' {{action 'signUp'}} />
+    {{async-button
+      hasError=hasError
+      disabled=hasSaved
+      name="signup"
+      type="submit"
+      value="Sign up"
+      submitAction=(action "signUp")}}
   </div>
   {{#if error}}
     {{error-formatter error=error}}

--- a/tests/integration/components/async-button-test.js
+++ b/tests/integration/components/async-button-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const { run } = Ember;
+
+moduleForComponent('async-button', 'Integration | Component | async button', {
+  integration: true
+});
+
+test('button calls submit action', function(assert) {
+  assert.expect(1);
+  this.disabled = false;
+  this.on('saveAction', () => {
+    this.set('disabled', true);
+    assert.ok(true, 'this action is only called once');
+  });
+
+  this.render(hbs`{{async-button submitAction=(action "saveAction") disabled=disabled}}`);
+  this.$('input').click();
+
+  run(() => {
+    this.$('input').click();
+  });
+});


### PR DESCRIPTION
# What's in this PR?

As described in the issue, users are able to spam a submit button to make multiple POST requests, which inevitably fail, telling the user their username is taken and doesn't begin the onboarding process.  This PR adds a component to disable the submit button through a passed in boolean.

## References
Fixes https://github.com/code-corps/code-corps-ember/issues/507

Progress on: https://github.com/code-corps/code-corps-ember/issues/507

