### PR TITLE
Move 'containsCode' function out of task and comment models into mixin

### DIFF
--- a/app/mixins/contains-code.js
+++ b/app/mixins/contains-code.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+const {
+  computed,
+  Mixin
+} = Ember;
+
+/**
+ * `contains-code` provides a computed property to the extended class
+ * that returns whether or not the `body` property contains `code`
+ * tags.
+ *
+ * ## default usage
+ *
+ * ```
+ * import ContainsCodeMixin from 'code-corps/mixins/contains-code';
+ *
+ * export default Model.extend(ContainsCodeMixin, { ... });
+ * ```
+ *
+ * @mixin contains-code
+ * @module mixin
+ */
+export default Mixin.create({
+
+  /**
+   * returns whether or not the `body` property contains `code` tags
+   *
+   * @property containsCode
+   * @type Boolean
+   */
+  containsCode: computed('body', function() {
+    let body = this.get('body');
+    if (body) {
+      return body.indexOf('<code>') !== -1;
+    }
+    return false;
+  })
+});

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -1,25 +1,14 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
-import Ember from 'ember';
+import ContainsCodeMixin from '../mixins/contains-code';
 
-const { computed } = Ember;
-
-export default Model.extend({
+export default Model.extend(ContainsCodeMixin, {
   body: attr('string'),
   insertedAt: attr('date'),
   markdown: attr('string'),
 
   commentUserMentions: hasMany('comment-user-mention', { async: true }),
   task: belongsTo('task', { async: true }),
-  user: belongsTo('user', { async: true }),
-
-  containsCode: computed('body', function() {
-    let body = this.get('body');
-    if (body) {
-      return body.indexOf('<code>') !== -1;
-    } else {
-      return false;
-    }
-  })
+  user: belongsTo('user', { async: true })
 });

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -1,11 +1,9 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
-import Ember from 'ember';
+import ContainsCodeMixin from '../mixins/contains-code';
 
-const { computed } = Ember;
-
-export default Model.extend({
+export default Model.extend(ContainsCodeMixin, {
   body: attr(),
   insertedAt: attr('date'),
   likesCount: attr('number'),
@@ -19,14 +17,5 @@ export default Model.extend({
   commentUserMentions: hasMany('comment-user-mention', { asnyc: true }),
   taskUserMentions: hasMany('task-user-mention', { asnyc: true }),
   project: belongsTo('project', { async: true }),
-  user: belongsTo('user', { async: true }),
-
-  containsCode: computed('body', function() {
-    let body = this.get('body');
-    if (body) {
-      return body.indexOf('<code>') !== -1;
-    } else {
-      return false;
-    }
-  })
+  user: belongsTo('user', { async: true })
 });

--- a/tests/unit/mixins/contains-code-test.js
+++ b/tests/unit/mixins/contains-code-test.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import ContainsCodeMixin from 'code-corps-ember/mixins/contains-code';
+import { moduleFor, test } from 'ember-qunit';
+
+const {
+  getOwner,
+  run
+} = Ember;
+
+moduleFor('mixin:contains-code', 'Unit | Mixin | contains code mixin', {
+  subject(record) {
+    let ContainsCodeMixinObject = Model.extend(ContainsCodeMixin, {
+      body: attr('string')
+    });
+    this.register('model:contains-code-mixin-object', ContainsCodeMixinObject);
+    return run(() => {
+      let store = getOwner(this).lookup('service:store');
+      return store.createRecord('contains-code-mixin-object', record || {});
+    });
+  }
+});
+
+test('it works', function(assert) {
+  let subject = this.subject();
+  assert.ok(subject);
+});
+
+test('it returns true "code" tag is present', function(assert) {
+  assert.expect(1);
+
+  let model = this.subject({ body: '<code>Hello, world!<code>' });
+
+  assert.equal(model.get('containsCode'), true);
+});
+
+test('it returns false if "code" tag is absent', function(assert) {
+  assert.expect(1);
+
+  let model = this.subject({ body: 'Hello, world!' });
+
+  assert.equal(model.get('containsCode'), false);
+});


### PR DESCRIPTION
# What's in this PR?

DRYs up comment and task models. Creates "containsCode" mixin.

## References
Fixes #131