### PR TITLE
Clarify wording in error helper: model => error

### DIFF
--- a/app/components/error-wrapper.js
+++ b/app/components/error-wrapper.js
@@ -14,7 +14,7 @@ const {
   ## default usage
 
   ```Handlebars
-  {{error-wrapper model=model}}
+  {{error-wrapper error=model}}
   ```
 
   @class error-wrapper
@@ -49,10 +49,10 @@ export default Component.extend({
   */
   // Map the HTTP status codes into an array or
   // an empty array if there are no such status codes
-  httpStatusCodes: computed('model', function() {
-    let model = this.get('model');
-    if (model && model.hasOwnProperty('errors')) {
-      let { errors } = model;
+  httpStatusCodes: computed('error', function() {
+    let error = this.get('error');
+    if (error && error.hasOwnProperty('errors')) {
+      let { errors } = error;
       return errors.map(function(err) {
         return err.status;
       });

--- a/app/templates/application-error.hbs
+++ b/app/templates/application-error.hbs
@@ -1,1 +1,1 @@
-{{error-wrapper model=model}}
+{{error-wrapper error=model}}

--- a/tests/integration/components/error-wrapper-test.js
+++ b/tests/integration/components/error-wrapper-test.js
@@ -13,14 +13,14 @@ test('it renders', function(assert) {
 test('it renders all required elements for the 404 case', function(assert) {
   assert.expect(6);
 
-  let model = {
+  let error = {
     errors: [{
       status: 404
     }]
   };
 
-  this.set('model', model);
-  this.render(hbs`{{error-wrapper model=model}}`);
+  this.set('model', error);
+  this.render(hbs`{{error-wrapper error=model}}`);
 
   assert.equal(this.$('.not-found-img').length, 1, 'The 404 image renders');
   assert.equal(this.$('h1').text().trim(), '404 Error', 'The title renders');
@@ -33,14 +33,14 @@ test('it renders all required elements for the 404 case', function(assert) {
 test('it renders all required elements for the general error case', function(assert) {
   assert.expect(6);
 
-  let model = {
+  let error = {
     errors: [{
       status: 500
     }]
   };
 
-  this.set('model', model);
-  this.render(hbs`{{error-wrapper model=model}}`);
+  this.set('model', error);
+  this.render(hbs`{{error-wrapper error=model}}`);
 
   assert.equal(this.$('.server-error-img').length, 1, 'The general error image renders');
   assert.equal(this.$('h1').text().trim(), 'Server Error', 'The title renders');


### PR DESCRIPTION
# What's in this PR?

Changes the `model` to a more descriptive `error` for the `error-wrapper`.

## References
None.