### PR TITLE
Move saving logic for task-details to route

### DIFF
--- a/app/components/task-details.js
+++ b/app/components/task-details.js
@@ -107,19 +107,12 @@ export default Component.extend({
 
       @method saveTaskBody
      */
-    saveTaskBody() {
-      let component = this;
+    applyEditTask() {
       let task = this.get('task');
 
-      task.save().then((task) => {
-        component.set('isEditingBody', false);
+      this.get('saveTask')(task).then((task) => {
+        this.set('isEditingBody', false);
         this._fetchMentions(task);
-      }).catch((error) => {
-        let payloadContainsValidationErrors = error.errors.some((error) => error.status === 422);
-
-        if (!payloadContainsValidationErrors) {
-          this.controllerFor('project.tasks.task').set('error', error);
-        }
       });
     }
   },

--- a/app/templates/components/task-details.hbs
+++ b/app/templates/components/task-details.hbs
@@ -11,7 +11,7 @@
         {{/each}}
       </div>
       <div class="input-group">
-        <button {{action 'saveTaskBody'}} class="default small right save">Save</button>
+        <button {{action 'applyEditTask'}} class="default small right save">Save</button>
         <button {{action 'cancelEditingTaskBody'}} class="clear small right cancel">Cancel</button>
       </div>
     {{else}}

--- a/app/templates/project/tasks/task.hbs
+++ b/app/templates/project/tasks/task.hbs
@@ -1,7 +1,7 @@
 {{task-header task=task saveTask=(route-action "save")}}
 {{task-status task=task}}
 <div class="task-timeline">
-  {{task-details task=task}}
+  {{task-details task=task saveTask=(route-action "save")}}
   {{task-comment-list comments=comments}}
   <div>
     {{#create-comment-form comment=newComment saveComment='saveComment'}}

--- a/tests/integration/components/task-details-test.js
+++ b/tests/integration/components/task-details-test.js
@@ -114,6 +114,34 @@ test('user can switch between view and edit mode for task body', function(assert
   assert.equal(this.$('.task-body .edit').length, 1, 'The edit button is rendered');
 });
 
+test('it saves', function(assert) {
+  assert.expect(2);
+
+  this.set('task', mockTask);
+  let mockMentionFetcher = Service.extend({
+    fetchBodyWithMentions(task) {
+      return RSVP.resolve(task.body);
+    },
+    prefetchBodyWithMentions() {
+      return 'A body';
+    }
+  });
+
+  this.register('service:mention-fetcher', mockMentionFetcher);
+
+  this.on('route-save', (task) => {
+    task.set('body', 'A new body');
+    return RSVP.resolve(task);
+  });
+
+  this.render(hbs`{{task-details task=task saveTask=(action 'route-save')}}`);
+  assert.equal(this.$('.task-details .comment-body').text().trim(), 'A body', 'The original body is correct');
+
+  this.$('.task-body .edit').click();
+  this.$('.task-body .editor-with-preview textarea').val('A new body').trigger('change');
+  this.$('.task-body .save').click();
+  assert.equal(this.$('.task-details .comment-body').text().trim(), 'A new body', 'The body is saved');
+});
 // NOTE: Commented out due to comment user mentions being disabled until reimplemented in phoenix
 /*
 test('mentions are rendered on task body in read-only mode', function(assert) {


### PR DESCRIPTION
# What's in this PR?

First stab at moving saving logic for {{task-details}} from the component to the route. 

I attempted to write a test for the saving logic, but I cannot get the test to pass. There is currently no test for the saving action, so maybe there's something tricky about it? Any help would be greatly appreciated.

The current error message for the test is `TypeError: 'undefined' is not a function (evaluating 'this.get('mentionFetcher').fetchBodyWithMentions(task, 'task')')`

## References

Progress on: #336 

