### PR TITLE
Update Enumerable#contains to Enumerable#includes to fix Ember deprec…

### DIFF
--- a/tests/acceptance/organization-settings-profile-test.js
+++ b/tests/acceptance/organization-settings-profile-test.js
@@ -54,7 +54,7 @@ test('it allows editing of organization profile', function(assert) {
 
   andThen(() => {
     assert.equal(organizationPage.successAlerts().count, 1);
-    assert.equal(organizationPage.successAlerts(0).contains('Organization updated successfully'), true);
+    assert.equal(organizationPage.successAlerts(0).includes('Organization updated successfully'), true);
   });
 });
 
@@ -96,7 +96,7 @@ test("it allows editing of organization's image", function(assert) {
 
   andThen(() => {
     assert.equal(organizationPage.successAlerts().count, 1);
-    assert.equal(organizationPage.successAlerts(0).contains('Organization updated successfully'), true);
+    assert.equal(organizationPage.successAlerts(0).includes('Organization updated successfully'), true);
     let expectedStyle = `url(${droppedImageString})`;
     assert.equal(removeDoubleQuotes(find('.image-drop').css('background-image')), expectedStyle);
   });

--- a/tests/acceptance/task-creation-test.js
+++ b/tests/acceptance/task-creation-test.js
@@ -218,6 +218,6 @@ test('When task creation fails due to non-validation issues, the error is displa
 
   andThen(() => {
     assert.equal(projectTasksNewPage.errors().count, 1);
-    assert.equal(projectTasksNewPage.errors().contains('An unknown error: Something happened', 'The error is messaged'), true);
+    assert.equal(projectTasksNewPage.errors().includes('An unknown error: Something happened', 'The error is messaged'), true);
   });
 });

--- a/tests/unit/services/onboarding-test.js
+++ b/tests/unit/services/onboarding-test.js
@@ -148,6 +148,6 @@ test('it knows the onboarding routes', function(assert) {
   assert.expect(totalSteps);
 
   for (let i = 0; i < totalSteps; i++) {
-    assert.ok(routes.contains(steps[i].currentRoute));
+    assert.ok(routes.includes(steps[i].currentRoute));
   }
 });


### PR DESCRIPTION
# What's in this PR?

Fix `contains` deprecation. 

The Enumerable#contains and Array#contains methods were deprecated in favor of Enumerable#includes and Array#includes to stay in line with ES standards. See RFC for details.

## References
[Ember docs](http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains)