### PR TITLE
add test helper for stubbing service consistently

### DIFF
--- a/tests/helpers/stub-service.js
+++ b/tests/helpers/stub-service.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+const {
+  Logger: { error },
+  Service,
+  typeOf
+} = Ember;
+
+let stubService = (scope, name, hash = {}) => {
+  if (typeOf(name) !== 'string') {
+    error('The name of the service must be a string');
+  }
+
+  if (typeOf(scope) !== 'object') {
+    error('You must pass the test object to the stubService helper');
+  }
+
+  let stubbedService = Service.extend(hash);
+  scope.register(`service:${name}`, stubbedService);
+  scope.inject.service(name, { as: name });
+};
+
+export default stubService;

--- a/tests/integration/components/categories-list-test.js
+++ b/tests/integration/components/categories-list-test.js
@@ -1,11 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  K,
-  Service
-} = Ember;
+const { K } = Ember;
 
 moduleForComponent('categories-list', 'Integration | Component | categories list', {
   integration: true
@@ -14,10 +12,7 @@ moduleForComponent('categories-list', 'Integration | Component | categories list
 test('it renders the categories and sorts them by name', function(assert) {
   assert.expect(5);
 
-  let mockUserCategoriesService = Service.extend({
-    findUserCategory: K
-  });
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', { findUserCategory: K });
 
   let categories = [
     {

--- a/tests/integration/components/category-item-test.js
+++ b/tests/integration/components/category-item-test.js
@@ -2,13 +2,13 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   getOwner,
   Object,
   run,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
 moduleForComponent('category-item', 'Integration | Component | category item', {
@@ -20,7 +20,7 @@ moduleForComponent('category-item', 'Integration | Component | category item', {
 
 let defaultCategoryId = 2;
 
-let mockUserCategoriesService = Service.extend({
+let mockUserCategoriesService = {
   findUserCategory(category) {
     if (category.id === mockUserCategory.get('categoryId')) {
       return mockUserCategory;
@@ -44,9 +44,9 @@ let mockUserCategoriesService = Service.extend({
       });
     });
   }
-});
+};
 
-let mockUserCategoriesServiceForErrors = Service.extend({
+let mockUserCategoriesServiceForErrors = {
   findUserCategory(category) {
     if (category.id === mockUserCategory.get('categoryId')) {
       return mockUserCategory;
@@ -58,7 +58,7 @@ let mockUserCategoriesServiceForErrors = Service.extend({
   removeCategory() {
     return RSVP.reject();
   }
-});
+};
 
 let mockUserCategory = Object.create({
   id: 1,
@@ -84,7 +84,7 @@ test('it works for selecting unselected categories', function(assert) {
   let done = assert.async();
   assert.expect(6);
 
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', mockUserCategoriesService);
   this.set('category', unselectedCategory);
   this.render(hbs`{{category-item category=category}}`);
 
@@ -106,7 +106,7 @@ test('it works for removing selected categories', function(assert) {
   let done = assert.async();
   assert.expect(4);
 
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', mockUserCategoriesService);
   this.set('category', selectedCategory);
   this.render(hbs`{{category-item category=category}}`);
 
@@ -126,10 +126,10 @@ test('it creates a flash message on an error when adding', function(assert) {
   let done = assert.async();
   assert.expect(7);
 
-  this.register('service:user-categories', mockUserCategoriesServiceForErrors);
+  stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
   this.set('category', unselectedCategory);
 
-  let mockFlashMessages = Service.extend({
+  stubService(this, 'flash-messages', {
     clearMessages() {
       assert.ok(true);
     },
@@ -141,7 +141,6 @@ test('it creates a flash message on an error when adding', function(assert) {
       assert.equal(object.timeout, 5000);
     }
   });
-  this.register('service:flash-messages', mockFlashMessages);
 
   this.render(hbs`{{category-item category=category}}`);
 
@@ -156,10 +155,10 @@ test('it creates a flash message on an error when removing', function(assert) {
   let done = assert.async();
   assert.expect(7);
 
-  this.register('service:user-categories', mockUserCategoriesServiceForErrors);
+  stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
   this.set('category', selectedCategory);
 
-  let mockFlashMessages = Service.extend({
+  stubService(this, 'flash-messages', {
     clearMessages() {
       assert.ok(true);
     },
@@ -171,7 +170,6 @@ test('it creates a flash message on an error when removing', function(assert) {
       assert.equal(object.timeout, 5000);
     }
   });
-  this.register('service:flash-messages', mockFlashMessages);
 
   this.render(hbs`{{category-item category=category}}`);
 
@@ -186,7 +184,7 @@ test('it sets and unsets loading state when adding', function(assert) {
   let done = assert.async();
   assert.expect(3);
 
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', mockUserCategoriesService);
   this.set('category', unselectedCategory);
 
   this.render(hbs`{{category-item category=category}}`);
@@ -203,7 +201,7 @@ test('it sets and unsets loading state when adding', function(assert) {
 
 test('it sets and unsets loading state when removing', function(assert) {
   let done = assert.async();
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', mockUserCategoriesService);
   assert.expect(3);
 
   this.set('category', selectedCategory);

--- a/tests/integration/components/code-theme-selector-test.js
+++ b/tests/integration/components/code-theme-selector-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('code-theme-selector', 'Integration | Component | code theme selector', {
   integration: true
@@ -11,12 +9,11 @@ moduleForComponent('code-theme-selector', 'Integration | Component | code theme 
 test('it toggles code theme service when clicked', function(assert) {
   assert.expect(1);
 
-  let codeThemeServiceStub = Service.extend({
+  stubService(this, 'code-theme', {
     toggle() {
       assert.ok(true, 'Code theme service was called');
     }
   });
-  this.register('service:code-theme', codeThemeServiceStub);
   this.render(hbs`{{code-theme-selector}}`);
 
   this.$('.code-theme-selector').click();
@@ -25,10 +22,9 @@ test('it toggles code theme service when clicked', function(assert) {
 test('it has the class name from the service', function(assert) {
   assert.expect(1);
 
-  let codeThemeServiceStub = Service.extend({
+  stubService(this, 'code-theme', {
     className: 'light'
   });
-  this.register('service:code-theme', codeThemeServiceStub);
   this.render(hbs`{{code-theme-selector}}`);
 
   assert.ok(this.$('.code-theme-selector').hasClass('light'));

--- a/tests/integration/components/comment-item-test.js
+++ b/tests/integration/components/comment-item-test.js
@@ -1,30 +1,30 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   K,
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
-let mockMentionFetcher = Service.extend({
+let mockMentionFetcher = {
   fetchBodyWithMentions: RSVP.resolve,
   prefetchBodyWithMentions: K
-});
+};
 
-let mockStore = Service.extend({
+let mockStore = {
   query() {
     return RSVP.resolve([]);
   }
-});
+};
 
-let mockCurrentUser = Service.extend({
+let mockCurrentUser = {
   user: {
     id: 1
   }
-});
+};
 
 let mockComment = Object.create({
   body: 'A <strong>body</strong>',
@@ -49,14 +49,14 @@ let mockComment = Object.create({
 moduleForComponent('comment-item', 'Integration | Component | comment item', {
   integration: true,
   beforeEach() {
-    this.register('service:store', mockStore);
+    stubService(this, 'store', mockStore);
   }
 });
 
 test('it renders', function(assert) {
   assert.expect(1);
 
-  this.register('service:mention-fetcher', mockMentionFetcher);
+  stubService(this, 'mention-fetcher', mockMentionFetcher);
 
   this.set('comment', mockComment);
   this.render(hbs`{{comment-item comment=comment}}`);
@@ -82,8 +82,8 @@ test('it renders all required comment elements properly', function(assert) {
 test('it switches between editing and viewing mode', function(assert) {
   assert.expect(3);
 
-  this.register('service:mention-fetcher', mockMentionFetcher);
-  this.register('service:current-user', mockCurrentUser);
+  stubService(this, 'mention-fetcher', mockMentionFetcher);
+  stubService(this, 'current-user', mockCurrentUser);
 
   this.set('comment', mockComment);
   this.render(hbs`{{comment-item comment=comment}}`);

--- a/tests/integration/components/create-comment-form-test.js
+++ b/tests/integration/components/create-comment-form-test.js
@@ -2,16 +2,14 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import mockRouting from '../../helpers/mock-routing';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   $,
-  Object,
-  Service
+  Object
 } = Ember;
 
-let mockSession = Service.extend({
-  isAuthenticated: true
-});
+let mockSession = { isAuthenticated: true };
 
 let pressCtrlEnter = $.Event('keydown', {
   keyCode: 13,
@@ -36,7 +34,7 @@ test('it renders', function(assert) {
 test('it yelds to content', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', mockSession);
+  stubService(this, 'session', mockSession);
 
   this.render(hbs`{{#create-comment-form}}Random content{{/create-comment-form}}`);
   let componentTextContent = this.$('form.create-comment-form').text().trim();
@@ -46,7 +44,7 @@ test('it yelds to content', function(assert) {
 test('it renders the proper elements', function(assert) {
   assert.expect(2);
 
-  this.register('service:session', mockSession);
+  stubService(this, 'session', mockSession);
 
   this.set('comment', {});
 
@@ -58,7 +56,7 @@ test('it renders the proper elements', function(assert) {
 test('it calls action when user clicks submit', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', mockSession);
+  stubService(this, 'session', mockSession);
 
   this.set('comment', Object.create({ markdown: 'Test markdown' }));
   this.on('saveComment', (comment) => {
@@ -72,7 +70,7 @@ test('it calls action when user clicks submit', function(assert) {
 test('it calls action when user hits ctrl+enter', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', mockSession);
+  stubService(this, 'session', mockSession);
 
   this.set('comment', Object.create({ markdown: 'Test markdown' }));
   this.on('saveComment', (comment) => {

--- a/tests/integration/components/editor-with-preview-test.js
+++ b/tests/integration/components/editor-with-preview-test.js
@@ -1,12 +1,12 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   $,
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
 let mockPreview = Object.create({
@@ -17,23 +17,23 @@ let mockPreview = Object.create({
   }
 });
 
-let mockStore = Service.extend({
+let mockStore = {
   createRecord() {
     return mockPreview;
   }
-});
+};
 
-let mockMentionFetcher = Service.extend({
+let mockMentionFetcher = {
   fetchBodyWithMentions() {
     return RSVP.resolve('Lorem ipsum <strong>bla</strong>');
   }
-});
+};
 
 moduleForComponent('editor-with-preview', 'Integration | Component | editor with preview', {
   integration: true,
   beforeEach() {
-    this.register('service:store', mockStore);
-    this.register('service:mention-fetcher', mockMentionFetcher);
+    stubService(this, 'store', mockStore);
+    stubService(this, 'mention-fetcher', mockMentionFetcher);
   }
 });
 
@@ -182,22 +182,6 @@ test('it clears the editor style when previewing and done loading', function(ass
   this.set('isLoading', false);
   assert.equal(this.$('.editor-with-preview')[0].hasAttribute('style'), false);
 });
-
-// test('it autoresizes to a max height of 350px', function(assert) {
-//   assert.expect(3);
-//
-//   this.render(hbs`{{editor-with-preview input=input}}`);
-//
-//   assert.equal(this.$('.editor-with-preview textarea').css('height'), '100px');
-//
-//   var text = "";
-//   for(var i = 0; i < 100; i++) { text += "\n"; }
-//   this.set('input', text);
-//   assert.equal(this.$('.editor-with-preview textarea').css('height'), '350px');
-//
-//   this.set('input', '');
-//   assert.equal(this.$('.editor-with-preview textarea').css('height'), '100px');
-// });
 
 test('it sends the modifiedSubmit action with ctrl+enter', function(assert) {
   assert.expect(2);

--- a/tests/integration/components/member-list-item-test.js
+++ b/tests/integration/components/member-list-item-test.js
@@ -1,11 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
 let user = {
@@ -118,7 +118,7 @@ test('it sends the approve action when clicking approve', function(assert) {
   this.set('membership', membership);
   this.set('user', user);
 
-  let mockFlashMessages = Service.extend({
+  stubService(this, 'flash-messages', {
     clearMessages() {
       assert.ok(true);
     },
@@ -130,7 +130,6 @@ test('it sends the approve action when clicking approve', function(assert) {
       assert.equal(object.timeout, 5000);
     }
   });
-  this.register('service:flash-messages', mockFlashMessages);
 
   this.render(hbs`{{member-list-item membership=membership user=user}}`);
 
@@ -152,7 +151,7 @@ test('it sends the deny action when clicking deny', function(assert) {
     }
   });
 
-  let mockFlashMessages = Service.extend({
+  stubService(this, 'flash-messages', {
     clearMessages() {
       assert.ok(true);
     },
@@ -164,7 +163,6 @@ test('it sends the deny action when clicking deny', function(assert) {
       assert.equal(object.timeout, 5000);
     }
   });
-  this.register('service:flash-messages', mockFlashMessages);
 
   this.set('membership', membership);
   this.set('user', user);

--- a/tests/integration/components/navigation-menu-test.js
+++ b/tests/integration/components/navigation-menu-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('navigation-menu', 'Integration | Component | navigation menu', {
   integration: true
@@ -19,10 +17,7 @@ test('it renders elements for the default menu when logged out', function(assert
 });
 
 test('it renders elements for the default menu when logged in', function(assert) {
-  let mockSessionService = Service.extend({
-    isAuthenticated: true
-  });
-  this.register('service:session', mockSessionService);
+  stubService(this, 'session', { isAuthenticated: true });
 
   this.render(hbs`{{navigation-menu}}`);
 
@@ -34,16 +29,12 @@ test('it renders elements for the default menu when logged in', function(assert)
 });
 
 test('it renders elements for the onboarding menu', function(assert) {
-  let mockNavigationMenuService = Service.extend({
-    isOnboarding: true
-  });
-  this.register('service:navigation-menu', mockNavigationMenuService);
-  let mockOnboardingService = Service.extend({
+  stubService(this, 'navigation-menu', { isOnboarding: true });
+  stubService(this, 'onboarding', {
     currentStepNumber: 1,
     totalSteps: 3,
     progressPercentage: 100
   });
-  this.register('service:onboarding', mockOnboardingService);
 
   this.render(hbs`{{navigation-menu}}`);
 

--- a/tests/integration/components/organization-header-test.js
+++ b/tests/integration/components/organization-header-test.js
@@ -1,16 +1,20 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  Object,
-  Service
-} = Ember;
+const { Object } = Ember;
 
 moduleForComponent('organization-header', 'Integration | Component | organization header', {
   integration: true,
   beforeEach() {
-    this.register('service:credentials', mockCredentials);
+    stubService(this, 'credentials', {
+      currentUserMembership: Object.create({
+        member: user,
+        organization,
+        role: 'admin'
+      })
+    });
   }
 });
 
@@ -20,14 +24,6 @@ let organization = Object.create({
   description: 'A test organization',
   iconThumbUrl: 'icon_thumb.png',
   iconLargeUrl: 'icon_large.png'
-});
-
-let mockCredentials = Service.extend({
-  currentUserMembership: Object.create({
-    member: user,
-    organization,
-    role: 'admin'
-  })
 });
 
 test('it renders', function(assert) {

--- a/tests/integration/components/organization-menu-test.js
+++ b/tests/integration/components/organization-menu-test.js
@@ -1,9 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import { Ability } from 'ember-can';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('organization-menu', 'Integration | Component | organization menu', {
   integration: true
@@ -12,7 +10,7 @@ moduleForComponent('organization-menu', 'Integration | Component | organization 
 test('it renders', function(assert) {
   assert.expect(1);
 
-  this.register('service:credentials', Service);
+  stubService(this, 'credentials');
 
   this.render(hbs`{{organization-menu}}`);
 
@@ -22,11 +20,7 @@ test('it renders', function(assert) {
 test('when user cannot manage organization the proper menu items are rendered', function(assert) {
   assert.expect(2);
 
-  let mockCredentials = Service.extend({
-    userCanManageOrganization: false
-  });
-
-  this.register('service:credentials', mockCredentials);
+  stubService(this, 'credentials', { userCanManageOrganization: false });
   this.register('ability:organization', Ability.extend({ canManage: false }));
 
   this.render(hbs`{{organization-menu}}`);
@@ -38,11 +32,7 @@ test('when user cannot manage organization the proper menu items are rendered', 
 test('when user can manage organization, the proper menu items are rendered', function(assert) {
   assert.expect(2);
 
-  let mockCredentials = Service.extend({
-    userCanManageOrganization: true
-  });
-
-  this.register('service:credentials', mockCredentials);
+  stubService(this, 'credentials', { userCanManageOrganization: true });
   this.register('ability:organization', Ability.extend({ canManage: true }));
 
   this.render(hbs`{{organization-menu}}`);

--- a/tests/integration/components/organization-profile-test.js
+++ b/tests/integration/components/organization-profile-test.js
@@ -1,13 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('organization-profile', 'Integration | Component | organization profile', {
   integration: true,
   beforeEach() {
-    this.register('service:credentials', Service);
+    stubService(this, 'credentials');
   }
 });
 

--- a/tests/integration/components/organization-settings-form-test.js
+++ b/tests/integration/components/organization-settings-form-test.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  RSVP,
-  Service
-} = Ember;
+const { RSVP } = Ember;
 
 moduleForComponent('organization-settings-form', 'Integration | Component | organization settings form', {
   integration: true
@@ -47,13 +45,11 @@ test('it calls save on organization when save button is clicked', function(asser
 
   this.set('organization', organization);
 
-  let flashServiceStub = Service.extend({
+  stubService(this, 'flash-messages', {
     success() {
       assert.ok(true, 'Flash message service was called');
     }
   });
-
-  this.register('service:flash-messages', flashServiceStub);
 
   this.render(hbs`{{organization-settings-form organization=organization}}`);
 

--- a/tests/integration/components/organization-settings-menu-test.js
+++ b/tests/integration/components/organization-settings-menu-test.js
@@ -1,11 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  Object,
-  Service
-} = Ember;
+const { Object } = Ember;
 
 moduleForComponent('organization-settings-menu', 'Integration | Component | organization settings menu', {
   integration: true
@@ -20,13 +18,8 @@ test('when authenticated and can manage organization, it renders properly', func
     organization
   });
 
-  let mockSession = Service.extend({ isAuthenticated: true });
-  let mockCredentials = Service.extend({
-    currentUserMembership: membership
-  });
-
-  this.register('service:session', mockSession);
-  this.register('service:credentials', mockCredentials);
+  stubService(this, 'session', { isAuthenticated: true });
+  stubService(this, 'credentials', { currentUserMembership: membership });
 
   this.set('organization', organization);
 
@@ -42,11 +35,8 @@ test('when authenticated and cannot manage organization, it renders properly', f
   let organization = Object.create({ id: 1 });
   let membership = Object.create({ isAdmin: false, organization });
 
-  let mockSession = Service.extend({ isAuthenticated: true });
-  let mockCredentials = Service.extend({ currentUserMembership: membership });
-
-  this.register('service:session', mockSession);
-  this.register('service:credentials', mockCredentials);
+  stubService(this, 'session', { isAuthenticated: true });
+  stubService(this, 'credentials', { currentUserMembership: membership });
 
   this.set('organization', organization);
 
@@ -61,9 +51,7 @@ test('when not authenticated, it renders properly', function(assert) {
 
   let organization = Object.create({ id: 1 });
 
-  let mockSession = Service.extend({ isAuthenticated: false });
-
-  this.register('service:session', mockSession);
+  stubService(this, 'session', { isAuthenticated: false });
 
   this.set('organization', organization);
 

--- a/tests/integration/components/organization-settings-test.js
+++ b/tests/integration/components/organization-settings-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('organization-settings', 'Integration | Component | organization settings', {
   integration: true
@@ -11,9 +9,9 @@ moduleForComponent('organization-settings', 'Integration | Component | organizat
 test('it renders properly', function(assert) {
   assert.expect(3);
 
-  this.register('service:store', Service.extend({}));
-  this.register('service:session', Service.extend({}));
-  this.register('service:credentials', Service.extend({}));
+  stubService(this, 'store');
+  stubService(this, 'session');
+  stubService(this, 'credentials');
 
   this.render(hbs`{{organization-settings}}`);
 

--- a/tests/integration/components/project-card-skills.js
+++ b/tests/integration/components/project-card-skills.js
@@ -1,22 +1,20 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const { Service } = Ember;
-
-let userSkillsService = Service.extend({
+let userSkillsService = {
   hasSkill(skill) {
     return skill;
   },
   findUserSkill(skill) {
     return skill;
   }
-});
+};
 
 moduleForComponent('project-card-ksills', 'Integration | Component | project card skills', {
   integration: true,
   beforeEach() {
-    this.register('service:user-skills', userSkillsService);
+    stubService(this, 'user-skills', userSkillsService);
   }
 });
 

--- a/tests/integration/components/project-card-test.js
+++ b/tests/integration/components/project-card-test.js
@@ -2,11 +2,9 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import startMirage from '../../helpers/setup-mirage-for-integration';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  K,
-  Service
-} = Ember;
+const { K } = Ember;
 
 moduleForComponent('project-card', 'Integration | Component | project card', {
   integration: true,
@@ -37,10 +35,7 @@ test('it renders', function(assert) {
     projectCategories: [projectCategory]
   };
 
-  let mockUserCategoriesService = Service.extend({
-    findUserCategory: K
-  });
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', { findUserCategory: K });
 
   this.set('project', mockedProject);
   this.render(hbs`{{project-card project=project}}`);

--- a/tests/integration/components/project-categories-list-test.js
+++ b/tests/integration/components/project-categories-list-test.js
@@ -1,11 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  K,
-  Service
-} = Ember;
+const { K } = Ember;
 
 moduleForComponent('project-categories-list', 'Integration | Component | project categories list', {
   integration: true
@@ -29,10 +27,7 @@ let categories = [
 test('it renders the categories and sorts them by name', function(assert) {
   assert.expect(4);
 
-  let mockUserCategoriesService = Service.extend({
-    findUserCategory: K
-  });
-  this.register('service:user-categories', mockUserCategoriesService);
+  stubService(this, 'user-categories', { findUserCategory: K });
 
   this.set('categories', categories);
   this.render(hbs`{{project-categories-list categories=categories}}`);

--- a/tests/integration/components/project-category-item-test.js
+++ b/tests/integration/components/project-category-item-test.js
@@ -1,25 +1,23 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   Object,
-  run,
-  Service
+  run
 } = Ember;
 
 moduleForComponent('project-category-item', 'Integration | Component | project category item', {
   integration: true,
   beforeEach() {
-    this.register('service:user-categories', mockUserCategoriesService);
-  }
-});
-
-let mockUserCategoriesService = Service.extend({
-  findUserCategory(category) {
-    if (category.id === mockUserCategory.get('categoryId')) {
-      return mockUserCategory;
-    }
+    stubService(this, 'user-categories', {
+      findUserCategory(category) {
+        if (category.id === mockUserCategory.get('categoryId')) {
+          return mockUserCategory;
+        }
+      }
+    });
   }
 });
 

--- a/tests/integration/components/project-long-description-test.js
+++ b/tests/integration/components/project-long-description-test.js
@@ -1,25 +1,22 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
 moduleForComponent('project-long-description', 'Integration | Component | project long description', {
-  integration: true,
-  beforeEach() {
-    this.register('service:credentials', Service.extend({}));
-  }
+  integration: true
 });
 
-let credentialsWithAdminMembership = Service.extend({
+let credentialsWithAdminMembership = {
   currentUserMembership: Object.create({
     isAdmin: true
   })
-});
+};
 
 let projectWithDescription = Object.create({
   longDescriptionBody: 'A <strong>body</strong>',
@@ -33,6 +30,7 @@ let blankProject = Object.create({
 
 test('it renders properly when decription is blank and the user cannot add to it', function(assert) {
   assert.expect(3);
+  stubService(this, 'credentials');
 
   this.set('project', blankProject);
   this.render(hbs`{{project-long-description project=project}}`);
@@ -46,7 +44,7 @@ test('it renders properly when description is blank and the user can add to it',
   assert.expect(3);
 
   this.set('project', blankProject);
-  this.register('service:credentials', credentialsWithAdminMembership);
+  stubService(this, 'credentials', credentialsWithAdminMembership);
 
   this.render(hbs`{{project-long-description project=project}}`);
 
@@ -57,6 +55,7 @@ test('it renders properly when description is blank and the user can add to it',
 
 test('it renders properly when description is present and user cannot edit', function(assert) {
   assert.expect(6);
+  stubService(this, 'credentials');
 
   this.set('project', projectWithDescription);
 
@@ -74,7 +73,7 @@ test('it renders properly when description is present and user can edit', functi
   assert.expect(4);
 
   this.set('project', projectWithDescription);
-  this.register('service:credentials', credentialsWithAdminMembership);
+  stubService(this, 'credentials', credentialsWithAdminMembership);
 
   this.render(hbs`{{project-long-description project=project}}`);
 
@@ -95,7 +94,7 @@ test('it is possible to add a description', function(assert) {
   });
 
   this.set('project', savableProject);
-  this.register('service:credentials', credentialsWithAdminMembership);
+  stubService(this, 'credentials', credentialsWithAdminMembership);
 
   this.render(hbs`{{project-long-description project=project}}`);
 
@@ -113,7 +112,7 @@ test('it is possible to edit a description', function(assert) {
   });
 
   this.set('project', savableProject);
-  this.register('service:credentials', credentialsWithAdminMembership);
+  stubService(this, 'credentials', credentialsWithAdminMembership);
 
   this.render(hbs`{{project-long-description project=project}}`);
   assert.equal(this.$('.editor-with-preview').length, 0, 'The editor is not shown, since we are in read mode');

--- a/tests/integration/components/project-menu-test.js
+++ b/tests/integration/components/project-menu-test.js
@@ -1,21 +1,19 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import { Ability } from 'ember-can';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('project-menu', 'Integration | Component | project menu', {
   integration: true,
   beforeEach() {
-    this.register('service:credentials', Service.extend({}));
+    stubService(this, 'credentials');
   }
 });
 
 test('when not authenticated, it renders properly', function(assert) {
   assert.expect(5);
 
-  this.register('service:session', Service.extend({ isAuthenticated: false }));
+  stubService(this, 'session', { isAuthenticated: false });
 
   this.render(hbs`{{project-menu}}`);
 
@@ -30,7 +28,7 @@ test('when not authenticated, it renders properly', function(assert) {
 test('it renders the task count when it has tasks', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', Service.extend({ isAuthenticated: false }));
+  stubService(this, 'session', { isAuthenticated: false });
   this.set('project', {
     hasOpenTasks: true,
     openTasksCount: 7
@@ -44,7 +42,7 @@ test('it renders the task count when it has tasks', function(assert) {
 test('it does not render the task count when it has no tasks', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', Service.extend({ isAuthenticated: false }));
+  stubService(this, 'session', { isAuthenticated: false });
   this.set('project', {
     hasOpenTasks: false,
     openTasksCount: 0
@@ -58,7 +56,7 @@ test('it does not render the task count when it has no tasks', function(assert) 
 test('when authenticated, and user cannot manage organization, it renders properly', function(assert) {
   assert.expect(5);
 
-  this.register('service:session', Service.extend({ isAuthenticated: true }));
+  stubService(this, 'session', { isAuthenticated: true });
   this.register('ability:organization', Ability.extend({ canManage: false }));
 
   this.render(hbs`{{project-menu}}`);
@@ -73,7 +71,7 @@ test('when authenticated, and user cannot manage organization, it renders proper
 test('when authenticated, and user can manage organization, it renders properly', function(assert) {
   assert.expect(5);
 
-  this.register('service:session', Service.extend({ isAuthenticated: true }));
+  stubService(this, 'session', { isAuthenticated: true });
   this.register('ability:organization', Ability.extend({ canManage: true }));
 
   this.render(hbs`{{project-menu}}`);
@@ -88,7 +86,7 @@ test('when authenticated, and user can manage organization, it renders properly'
 test('when authenticated, and user can manage organization, and project has pending members', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', Service.extend({ isAuthenticated: true }));
+  stubService(this, 'session', { isAuthenticated: true });
   this.register('ability:organization', Ability.extend({ canManage: true }));
   let project = { hasPendingMembers: true, pendingMembersCount: 7 };
   this.set('project', project);
@@ -101,7 +99,7 @@ test('when authenticated, and user can manage organization, and project has pend
 test('when authenticated, and user can manage organization, and project has no pending members', function(assert) {
   assert.expect(1);
 
-  this.register('service:session', Service.extend({ isAuthenticated: true }));
+  stubService(this, 'session', { isAuthenticated: true });
   this.register('ability:organization', Ability.extend({ canManage: true }));
   let project = { hasPendingMembers: false, pendingMembersCount: 0 };
   this.set('project', project);

--- a/tests/integration/components/project-settings-form-test.js
+++ b/tests/integration/components/project-settings-form-test.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  RSVP,
-  Service
-} = Ember;
+const { RSVP } = Ember;
 
 moduleForComponent('project-settings-form', 'Integration | Component | project settings form', {
   integration: true
@@ -47,13 +45,11 @@ test('it calls save on project when save button is clicked', function(assert) {
 
   this.set('project', project);
 
-  let flashServiceStub = Service.extend({
+  stubService(this, 'flash-messages', {
     success() {
       assert.ok(true, 'Flash message service was called');
     }
   });
-
-  this.register('service:flash-messages', flashServiceStub);
 
   this.render(hbs`{{project-settings-form project=project}}`);
 

--- a/tests/integration/components/project-settings-menu-test.js
+++ b/tests/integration/components/project-settings-menu-test.js
@@ -1,11 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  Object,
-  Service
-} = Ember;
+const { Object } = Ember;
 
 moduleForComponent('project-settings-menu', 'Integration | Component | project settings menu', {
   integration: true
@@ -18,11 +16,8 @@ test('when authenticated and can manage organization, it renders properly', func
   assert.expect(4);
 
   let membership = Object.create({ isAdmin: true, organization });
-  let mockSession = Service.extend({ isAuthenticated: true });
-  let mockCredentials = Service.extend({ currentUserMembership: membership });
-
-  this.register('service:session', mockSession);
-  this.register('service:credentials', mockCredentials);
+  stubService(this, 'session', { isAuthenticated: true });
+  stubService(this, 'credentials', { currentUserMembership: membership });
 
   this.set('project', project);
 
@@ -38,11 +33,8 @@ test('when authenticated and cannot manage organization, it renders properly', f
   assert.expect(2);
 
   let membership = Object.create({ isAdmin: false, organization });
-  let mockSession = Service.extend({ isAuthenticated: true });
-  let mockCredentials = Service.extend({ currentUserMembership: membership });
-
-  this.register('service:session', mockSession);
-  this.register('service:credentials', mockCredentials);
+  stubService(this, 'session', { isAuthenticated: true });
+  stubService(this, 'credentials', { currentUserMembership: membership });
 
   this.set('project', project);
 
@@ -55,9 +47,7 @@ test('when authenticated and cannot manage organization, it renders properly', f
 test('when not authenticated, it renders properly', function(assert) {
   assert.expect(2);
 
-  let mockSession = Service.extend({ isAuthenticated: false });
-
-  this.register('service:session', mockSession);
+  stubService(this, 'session', { isAuthenticated: false });
 
   this.set('project', project);
 

--- a/tests/integration/components/role-item-test.js
+++ b/tests/integration/components/role-item-test.js
@@ -2,18 +2,18 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   getOwner,
   Object,
   RSVP,
-  run,
-  Service
+  run
 } = Ember;
 
 let defaultRoleId = 2;
 
-let mockUserRolesService = Service.extend({
+let mockUserRolesService = {
   findUserRole(role) {
     if (role.id === mockUserRole.get('roleId')) {
       return mockUserRole;
@@ -37,9 +37,9 @@ let mockUserRolesService = Service.extend({
       });
     });
   }
-});
+};
 
-let mockUserRolesServiceForErrors = Service.extend({
+let mockUserRolesServiceForErrors = {
   findUserRole(role) {
     if (role.id === mockUserRole.get('roleId')) {
       return mockUserRole;
@@ -51,7 +51,7 @@ let mockUserRolesServiceForErrors = Service.extend({
   removeRole() {
     return RSVP.reject();
   }
-});
+};
 
 let mockUserRole = Object.create({
   id: 1,
@@ -84,7 +84,7 @@ test('it works for selecting unselected roles', function(assert) {
   let done = assert.async();
   assert.expect(3);
 
-  this.register('service:user-roles', mockUserRolesService);
+  stubService(this, 'user-roles', mockUserRolesService);
   this.set('role', unselectedRole);
   this.render(hbs`{{role-item role=role}}`);
 
@@ -103,7 +103,7 @@ test('it works for removing selected roles', function(assert) {
   let done = assert.async();
   assert.expect(3);
 
-  this.register('service:user-roles', mockUserRolesService);
+  stubService(this, 'user-roles', mockUserRolesService);
   this.set('role', selectedRole);
   this.render(hbs`{{role-item role=role}}`);
 
@@ -122,10 +122,10 @@ test('it creates a flash message on an error when adding', function(assert) {
   let done = assert.async();
   assert.expect(7);
 
-  this.register('service:user-roles', mockUserRolesServiceForErrors);
+  stubService(this, 'user-roles', mockUserRolesServiceForErrors);
   this.set('role', unselectedRole);
 
-  let mockFlashMessages = Service.extend({
+  stubService(this, 'flash-messages', {
     clearMessages() {
       assert.ok(true);
     },
@@ -137,7 +137,6 @@ test('it creates a flash message on an error when adding', function(assert) {
       assert.equal(object.timeout, 5000);
     }
   });
-  this.register('service:flash-messages', mockFlashMessages);
 
   this.render(hbs`{{role-item role=role}}`);
 
@@ -152,10 +151,10 @@ test('it creates a flash message on an error when removing', function(assert) {
   let done = assert.async();
   assert.expect(7);
 
-  this.register('service:user-roles', mockUserRolesServiceForErrors);
+  stubService(this, 'user-roles', mockUserRolesServiceForErrors);
   this.set('role', selectedRole);
 
-  let mockFlashMessages = Service.extend({
+  stubService(this, 'flash-messages', {
     clearMessages() {
       assert.ok(true);
     },
@@ -167,7 +166,6 @@ test('it creates a flash message on an error when removing', function(assert) {
       assert.equal(object.timeout, 5000);
     }
   });
-  this.register('service:flash-messages', mockFlashMessages);
 
   this.render(hbs`{{role-item role=role}}`);
 
@@ -182,7 +180,7 @@ test('it sets and unsets loading state when adding', function(assert) {
   let done = assert.async();
   assert.expect(3);
 
-  this.register('service:user-roles', mockUserRolesService);
+  stubService(this, 'user-roles', mockUserRolesService);
   this.set('role', unselectedRole);
 
   this.render(hbs`{{role-item role=role}}`);
@@ -199,7 +197,7 @@ test('it sets and unsets loading state when adding', function(assert) {
 
 test('it sets and unsets loading state when removing', function(assert) {
   let done = assert.async();
-  this.register('service:user-roles', mockUserRolesService);
+  stubService(this, 'user-roles', mockUserRolesService);
   assert.expect(3);
 
   this.set('role', selectedRole);

--- a/tests/integration/components/skill-button-test.js
+++ b/tests/integration/components/skill-button-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('skill-button', 'Integration | Component | skill button', {
   integration: true
@@ -66,12 +64,11 @@ test('it responds to hovering', function(assert) {
 
 test('it removes the skill when clicking', function(assert) {
   let skill = { title: 'Ruby' };
-  let mockUserSkillsService = Service.extend({
+  stubService(this, 'user-skills', {
     removeSkill(removedSkill) {
       assert.deepEqual(skill, removedSkill);
     }
   });
-  this.register('service:user-skills', mockUserSkillsService);
   this.set('skill', skill);
   this.render(hbs`{{skill-button skill=skill}}`);
   this.$('button').click();

--- a/tests/integration/components/skill-list-item-test.js
+++ b/tests/integration/components/skill-list-item-test.js
@@ -1,22 +1,18 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
-
-let userSkillsService = Service.extend({
-  hasSkill(skill) {
-    return skill;
-  },
-  findUserSkill(skill) {
-    return skill;
-  }
-});
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('skill-list-item', 'Integration | Component | skill list item', {
   integration: true,
   beforeEach() {
-    this.register('service:user-skills', userSkillsService);
+    stubService(this, 'user-skills', {
+      hasSkill(skill) {
+        return skill;
+      },
+      findUserSkill(skill) {
+        return skill;
+      }
+    });
   }
 });
 

--- a/tests/integration/components/skill-list-items-test.js
+++ b/tests/integration/components/skill-list-items-test.js
@@ -1,22 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  Object,
-  Service
-} = Ember;
-
-let userSkillsService = Service.extend({
-  hasSkill(queriedSkill) {
-    return queriedSkill === skills[1];
-  },
-  findUserSkill(queriedSkill) {
-    if (queriedSkill === skills[1]) {
-      return queriedSkill;
-    }
-  }
-});
+const { Object } = Ember;
 
 let skills = [
   Object.create({
@@ -36,7 +23,16 @@ let skills = [
 moduleForComponent('skill-list-items', 'Integration | Component | skill list items', {
   integration: true,
   beforeEach() {
-    this.register('service:user-skills', userSkillsService);
+    stubService(this, 'user-skills', {
+      hasSkill(queriedSkill) {
+        return queriedSkill === skills[1];
+      },
+      findUserSkill(queriedSkill) {
+        if (queriedSkill === skills[1]) {
+          return queriedSkill;
+        }
+      }
+    });
   }
 });
 

--- a/tests/integration/components/slugged-route-model-details-test.js
+++ b/tests/integration/components/slugged-route-model-details-test.js
@@ -1,13 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { Service } = Ember;
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 moduleForComponent('slugged-route-model-details', 'Integration | Component | slugged route model details', {
   integration: true,
   beforeEach() {
-    this.register('service:credentials', Service);
+    stubService(this, 'credentials');
   }
 });
 

--- a/tests/integration/components/task-comment-list-test.js
+++ b/tests/integration/components/task-comment-list-test.js
@@ -1,23 +1,21 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
-
-let mockStore = Service.extend({
-  query() {
-    return RSVP.resolve([]);
-  }
-});
 
 moduleForComponent('task-comment-list', 'Integration | Component | task comment list', {
   integration: true,
   beforeEach() {
-    this.register('service:store', mockStore);
+    stubService(this, 'store', {
+      query() {
+        return RSVP.resolve([]);
+      }
+    });
   }
 });
 

--- a/tests/integration/components/task-details-test.js
+++ b/tests/integration/components/task-details-test.js
@@ -1,30 +1,30 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   K,
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
-let mockMentionFetcher = Service.extend({
+let mockMentionFetcher = {
   fetchBodyWithMentions: RSVP.resolve,
   prefetchBodyWithMentions: K
-});
+};
 
-let mockCurrentUser = Service.extend({
+let mockCurrentUser = {
   user: {
     id: 1
   }
-});
+};
 
-let mockStore = Service.extend({
+let mockStore = {
   query() {
     return RSVP.resolve([]);
   }
-});
+};
 
 let mockTask = Object.create({
   title: 'A task',
@@ -52,14 +52,14 @@ let mockTask = Object.create({
 moduleForComponent('task-details', 'Integration | Component | task details', {
   integration: true,
   beforeEach() {
-    this.register('service:current-user', mockCurrentUser);
-    this.register('service:store', mockStore);
+    stubService(this, 'current-user', mockCurrentUser);
+    stubService(this, 'store', mockStore);
   }
 });
 
 test('it renders', function(assert) {
 
-  this.register('service:mention-fetcher', mockMentionFetcher);
+  stubService(this, 'mention-fetcher', mockMentionFetcher);
 
   this.render(hbs`{{task-details}}`);
 
@@ -69,13 +69,11 @@ test('it renders', function(assert) {
 test('it renders all the ui elements properly bound', function(assert) {
   this.set('task', mockTask);
 
-  let mockMentionFetcher = Service.extend({
+  stubService(this, 'mention-fetcher', {
     prefetchBodyWithMentions() {
       return 'A body';
     }
   });
-
-  this.register('service:mention-fetcher', mockMentionFetcher);
 
   this.render(hbs`{{task-details task=task}}`);
 
@@ -84,13 +82,11 @@ test('it renders all the ui elements properly bound', function(assert) {
 });
 
 test('the task body is rendered as unescaped html', function(assert) {
-  let mockMentionFetcher = Service.extend({
+  stubService(this, 'mention-fetcher', {
     prefetchBodyWithMentions() {
       return 'A body with a <strong>strong element</strong>';
     }
   });
-
-  this.register('service:mention-fetcher', mockMentionFetcher);
 
   this.set('task', mockTask);
 
@@ -102,7 +98,7 @@ test('user can switch between view and edit mode for task body', function(assert
   assert.expect(3);
   this.set('task', mockTask);
 
-  this.register('service:mention-fetcher', mockMentionFetcher);
+  stubService(this, 'mention-fetcher', mockMentionFetcher);
 
   this.render(hbs`{{task-details task=task}}`);
   assert.equal(this.$('.task-body .edit').length, 1, 'The edit button is rendered');
@@ -118,7 +114,7 @@ test('it saves', function(assert) {
   assert.expect(2);
 
   this.set('task', mockTask);
-  let mockMentionFetcher = Service.extend({
+  stubService(this, 'mention-fetcher', {
     fetchBodyWithMentions(task) {
       return RSVP.resolve(task.body);
     },
@@ -126,8 +122,6 @@ test('it saves', function(assert) {
       return 'A body';
     }
   });
-
-  this.register('service:mention-fetcher', mockMentionFetcher);
 
   this.on('route-save', (task) => {
     task.set('body', 'A new body');

--- a/tests/integration/components/task-new-form-test.js
+++ b/tests/integration/components/task-new-form-test.js
@@ -1,22 +1,17 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  Object,
-  Service
-} = Ember;
+const { Object } = Ember;
 
 moduleForComponent('task-new-form', 'Integration | Component | task new form', {
-  integration: true,
-  beforeEach() {
-    this.register('service:credentials', Service.extend({ currentUserMembership: null }));
-  }
+  integration: true
 });
 
 test('it renders', function(assert) {
   assert.expect(1);
-
+  stubService(this, 'credentials', { currentUserMembership: null });
   this.render(hbs`{{task-new-form}}`);
 
   assert.equal(this.$('.task-new-form').length, 1, 'The component\'s element renders');
@@ -24,6 +19,7 @@ test('it renders', function(assert) {
 
 test('it renders proper ui elements, properly bound', function(assert) {
   assert.expect(8);
+  stubService(this, 'credentials', { currentUserMembership: null });
 
   let task = {
     title: 'A task',
@@ -49,6 +45,7 @@ test('it renders proper ui elements, properly bound', function(assert) {
 
 test('it triggers an action when the task is saved', function(assert) {
   assert.expect(2);
+  stubService(this, 'credentials', { currentUserMembership: null });
 
   let task = Object.create({ id: 1 });
 
@@ -66,9 +63,9 @@ test('it triggers an action when the task is saved', function(assert) {
 test('it renders only idea and issue task type options if user is not at least a contributor to the organization', function(assert) {
   assert.expect(3);
 
-  this.register('service:credentials', Service.extend({
+  stubService(this, 'credentials', {
     currentUserMembership: { isContributor: false, isAdmin: false, isOwner: false }
-  }));
+  });
 
   this.render(hbs`{{task-new-form task=task placeholder=placeholder}}`);
 
@@ -80,9 +77,9 @@ test('it renders only idea and issue task type options if user is not at least a
 test('it renders all task type options if user is at least contributor', function(assert) {
   assert.expect(3);
 
-  this.register('service:credentials', Service.extend({
+  stubService(this, 'credentials', {
     currentUserMembership: { isContributor: true }
-  }));
+  });
 
   this.render(hbs`{{task-new-form task=task placeholder=placeholder}}`);
 

--- a/tests/integration/components/task-title-test.js
+++ b/tests/integration/components/task-title-test.js
@@ -1,24 +1,24 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   Object,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
-let mockCurrentUser = Service.extend({
+let mockCurrentUser = {
   user: {
     id: 1
   }
-});
+};
 
-let mockDifferentUser = Service.extend({
+let mockDifferentUser = {
   user: {
     id: 2
   }
-});
+};
 
 let mockTask = Object.create({
   title: 'Original title',
@@ -35,9 +35,7 @@ let mockTask = Object.create({
 });
 
 moduleForComponent('task-title', 'Integration | Component | task title', {
-  integration: true,
-  beforeEach() {
-  }
+  integration: true
 });
 
 test('it renders', function(assert) {
@@ -47,7 +45,7 @@ test('it renders', function(assert) {
 });
 
 test('it is not editable if not the right user', function(assert) {
-  this.register('service:current-user', mockDifferentUser);
+  stubService(this, 'current-user', mockDifferentUser);
 
   assert.expect(1);
   this.render(hbs`{{task-title}}`);
@@ -57,7 +55,7 @@ test('it is not editable if not the right user', function(assert) {
 test('it switches between edit and view mode', function(assert) {
   assert.expect(8);
 
-  this.register('service:current-user', mockCurrentUser);
+  stubService(this, 'current-user', mockCurrentUser);
 
   this.set('task', mockTask);
   this.render(hbs`{{task-title task=task}}`);
@@ -77,7 +75,7 @@ test('it switches between edit and view mode', function(assert) {
 test('it saves', function(assert) {
   assert.expect(2);
 
-  this.register('service:current-user', mockCurrentUser);
+  stubService(this, 'current-user', mockCurrentUser);
 
   this.set('task', mockTask);
   this.on('applyEdit', () => {
@@ -93,14 +91,3 @@ test('it saves', function(assert) {
 
   assert.equal(this.$('.task-title .title').text().trim(), 'Edited title #12', 'The tile title is saved');
 });
-
-// test('it resets the input element when editing is cancelled and then restarted', function(assert) {
-//   assert.expect(1);
-//   this.set('task', mockTask);
-//   this.render(hbs`{{task-title task=task}}`);
-//   this.$('.task-title .edit').click();
-//   this.$('.task-title input[name=title]').val('Edited title').trigger('change');
-//   this.$('.task-title .cancel').click();
-//   this.$('.task-title .edit').click();
-//   assert.equal(this.$('.task-title input[name=title]').val(), 'Original title', 'Input is back to the original value');
-// });

--- a/tests/integration/components/user-settings-form-test.js
+++ b/tests/integration/components/user-settings-form-test.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  RSVP,
-  Service
-} = Ember;
+const { RSVP } = Ember;
 
 moduleForComponent('user-settings-form', 'Integration | Component | user settings form', {
   integration: true
@@ -53,13 +51,11 @@ test('it calls save on user when save button is clicked', function(assert) {
 
   this.set('user', user);
 
-  let flashServiceStub = Service.extend({
+  stubService(this, 'flash-messages', {
     success() {
       assert.ok(true, 'Flash message service was called');
     }
   });
-
-  this.register('service:flash-messages', flashServiceStub);
 
   this.render(hbs`{{user-settings-form user=user}}`);
 

--- a/tests/integration/components/user-skills-input-item-test.js
+++ b/tests/integration/components/user-skills-input-item-test.js
@@ -1,19 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const {
-  Object,
-  Service
-} = Ember;
-
-let userSkillsService = Service.extend({
-  findUserSkill(queriedSkill) {
-    if (queriedSkill === skill) {
-      return skill;
-    }
-  }
-});
+const { Object } = Ember;
 
 let skill = Object.create({
   selected: true,
@@ -23,7 +13,13 @@ let skill = Object.create({
 moduleForComponent('user-skills-input-item', 'Integration | Component | user skills input item', {
   integration: true,
   beforeEach() {
-    this.register('service:user-skills', userSkillsService);
+    stubService(this, 'user-skills', {
+      findUserSkill(queriedSkill) {
+        if (queriedSkill === skill) {
+          return skill;
+        }
+      }
+    });
   }
 });
 

--- a/tests/integration/components/user-skills-input-test.js
+++ b/tests/integration/components/user-skills-input-test.js
@@ -2,37 +2,37 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import jQuery from 'jquery';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 const {
   Object,
   K,
-  RSVP,
-  Service
+  RSVP
 } = Ember;
 
-let mockStore = Service.extend({
+let mockStore = {
   query() {
     return RSVP.resolve([
       Object.create({ title: 'Ruby' }),
       Object.create({ title: 'Ruby on Rails' })
     ]);
   }
-});
+};
 
-let mockUserSkillsService = Service.extend({
+let mockUserSkillsService = {
   findUserSkill() {
     return K;
   },
   removeSkill() {
     return K;
   }
-});
+};
 
 moduleForComponent('user-skills-input', 'Integration | Component | user skills input', {
   integration: true,
   beforeEach() {
-    this.register('service:store', mockStore);
-    this.register('service:user-skills', mockUserSkillsService);
+    stubService(this, 'store', mockStore);
+    stubService(this, 'user-skills', mockUserSkillsService);
   }
 });
 
@@ -194,13 +194,10 @@ test('it selects the skill when clicking it', function(assert) {
 test('it does nothing when there are no results', function(assert) {
   assert.expect(1);
 
-  let emptyStore = Service.extend({
-    query() {
-      return RSVP.resolve([]);
-    }
-  });
-
-  this.register('service:store', emptyStore);
+  let query = function() {
+    return RSVP.resolve([]);
+  };
+  this.set('store.query', query);
 
   this.render(hbs`{{user-skills-input query=query}}`);
 


### PR DESCRIPTION
# What's in this PR?

We have a lot of instances for stubbing services. It would be nice to do this consistently and add some error handling for when we do it incorrectly.  Plus I love test helpers 😄 .

## References
Fixes No issue for this yet. But I can open one if that helps.

