### PR TITLE
configure ember-try to use ember exam for testing in CI

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,44 @@
+module.exports = {
+  command: "ember exam --split=3 --weighted --parallel",
+  scenarios: [
+    {
+      name: 'default',
+      bower: {
+        dependencies: { }
+      }
+    },
+    {
+      name: 'ember-release',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      }
+    },
+    {
+      name: 'ember-beta',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#beta'
+        },
+        resolutions: {
+          'ember': 'beta'
+        }
+      }
+    },
+    {
+      name: 'ember-canary',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#canary'
+        },
+        resolutions: {
+          'ember': 'canary'
+        }
+      }
+    }
+  ]
+};

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -37,6 +37,14 @@ We use [ember-exam](https://github.com/trentmwillis/ember-exam) for running test
 * `ember exam --random` will run the tests in a random order
 * `ember exam --filter='acceptance'` will only run acceptance tests. The same syntax can be used for other types of tests, such as `ember exam --filter='unit'` and `ember exam --filter='integration'`
 
+We also take advantage of [ember-try](https://github.com/ember-cli/ember-try), which allows us to test against different versions of packages. We have a few set up in the [configuration file](../config/ember-try.js), which can be used as follows:
+* `ember try:one default` will run the tests with everything currently listed in `package.json` and `bower.json`
+* `ember try:one ember-release` will run the tests using the current release version of ember
+* `ember try:one ember-beta` will run the tests using the current beta release of ember
+* `ember try:one ember-canary` will run the tests using the current canary release of ember
+* `ember try:each` will run all configurations in `config/ember-try.js`
+You'll notice that all of these will run using `ember exam`. 
+
 ## Generating Documentation
 
 The Code Corps Ember application uses [YUIDoc](http://yui.github.io/yuidoc/) for documentation. 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember exam"
+    "test": "ember try:one default"
   },
   "repository": "",
   "engines": {


### PR DESCRIPTION
# What's in this PR?

This uses ember-try to allow the use of ember exam in Circle CI. Instead of running the usual `ember test`, circle now runs `ember exam --split=3 --weighted --parallel` to run the tests in parallelization. This saves some time (Our average non-deploy builds have been around 5:50, this runs about 4:10).

Note that ember-try is now included by default within ember-cli, so there isn't a dependency to add to enable this.

I also included several configration options (actually, these are the same ones used in ember-stripe-service) that we can use locally to test against beta, canary, or any other configurations. This is pretty easy to use (you can also set up your own to test adding a certain package, for example) and I'll update the documentation with instructions for this. In short, to run our package.json, use `ember try:one default`, but if you want to test against the current beta build of ember, you'd run `ember try:one beta`.

## References
Solves #505 
