### PR TITLE
Fix deprecations with using Enumerable#contains instead of Enumerable#includes

### DIFF
--- a/tests/unit/services/onboarding-test.js
+++ b/tests/unit/services/onboarding-test.js
@@ -148,6 +148,6 @@ test('it knows the onboarding routes', function(assert) {
   assert.expect(totalSteps);
 
   for (let i = 0; i < totalSteps; i++) {
-    assert.ok(routes.contains(steps[i].currentRoute));
+    assert.ok(routes.includes(steps[i].currentRoute));
   }
 });


### PR DESCRIPTION
Pretty self-explanatory. We had a deprecation, causing a total of 4 warnings. There are other places where we use `.contains`, but those aren't for an `Ember.Enumerable`, so they are not a problem.