### PR TITLE
Reorder mirage config

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -148,12 +148,12 @@ export default function() {
   // PATCH /organization-memberships/:id
   this.patch('/organization-memberships/:id');
 
+  // DELETE /organization-memberships/:id
+  this.delete('/organization-memberships/:id');
+
   /**
   * Organizations
   */
-
-  // DELETE /organization-memberships/:id
-  this.delete('/organization-memberships/:id');
 
   // GET /organizations
   this.get('/organizations', { coalesce: true });


### PR DESCRIPTION
Just a quick reorder of mirage config. An org membership endpoint was in the organization section.
