### PR TITLE
[CLEANUP]: remove dropzone declaration from image-drop component

### DIFF
--- a/app/templates/components/image-drop.hbs
+++ b/app/templates/components/image-drop.hbs
@@ -6,4 +6,3 @@
   <p class="help-text">{{helpText}}</p>
 </div>
 <input type="file">
-{{drop-zone}}


### PR DESCRIPTION
remove dropzone declaration from image-drop component.  Don't see it declared anywhere else.

## References
Fixes #623 


