### PR TITLE
Add ember-keyboard and utilize for submittable-textarea

### DIFF
--- a/app/components/submittable-textarea.js
+++ b/app/components/submittable-textarea.js
@@ -1,24 +1,16 @@
 import Ember from 'ember';
+import { keyDown as keyDownEvent } from 'ember-keyboard';
 
-const { TextArea } = Ember;
+const { TextArea, on } = Ember;
 
 export default TextArea.extend({
-  keyDown(event) {
-    if (this._isValidCombination(event)) {
-      event.preventDefault();
-      this.sendAction('modifiedSubmit');
-    }
+  init() {
+    this._super(...arguments);
+    this.set('keyboardActivated', true);
   },
 
-  _hasCorrectModifier(event) {
-    return event.ctrlKey || event.metaKey;
-  },
-
-  _isCorrectKeyCode(keyCode) {
-    return keyCode === 13;
-  },
-
-  _isValidCombination(event) {
-    return this._hasCorrectModifier(event) && this._isCorrectKeyCode(event.keyCode);
-  }
+  customSubmit: on(keyDownEvent('cmd+Enter'), keyDownEvent('ctrl+Enter'), function(e) {
+    e.preventDefault();
+    this.sendAction('modifiedSubmit');
+  })
 });

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-exam": "0.5.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-keyboard": "^2.1.9",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.7.0",
     "ember-modal-dialog": "0.8.8",

--- a/tests/integration/components/submittable-textarea-test.js
+++ b/tests/integration/components/submittable-textarea-test.js
@@ -1,23 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
-
-const { $ } = Ember;
+import { triggerKeyDown, initialize } from 'ember-keyboard';
 
 moduleForComponent('submittable-textarea', 'Integration | Component | submittable textarea', {
-  integration: true
-});
+  integration: true,
 
-let pressCtrlEnter = $.Event('keydown', {
-  keyCode: 13,
-  which: 13,
-  ctrlKey: true
-});
-
-let pressCmdEnter = $.Event('keydown', {
-  keyCode: 13,
-  which: 13,
-  metaKey: true
+  beforeEach() {
+    initialize();
+  }
 });
 
 // This test is necessary because a new line after yield in the file will
@@ -36,7 +26,7 @@ test('it sends the modifiedSubmit action with ctrl+enter', function(assert) {
   });
   this.render(hbs`{{submittable-textarea modifiedSubmit="modifiedSubmit"}}`);
 
-  this.$('textarea').trigger(pressCtrlEnter);
+  triggerKeyDown('ctrl+Enter', this.$('textarea'));
   assert.equal(this.$('textarea').val().trim(), '');
 });
 
@@ -48,6 +38,6 @@ test('it sends the modifiedSubmit action with cmd+enter', function(assert) {
   });
   this.render(hbs`{{submittable-textarea modifiedSubmit="modifiedSubmit"}}`);
 
-  this.$('textarea').trigger(pressCmdEnter);
+  triggerKeyDown('cmd+Enter', this.$('textarea'));
   assert.equal(this.$('textarea').val().trim(), '');
 });


### PR DESCRIPTION
# What's in this PR?

Added ember-keyboard and refactored `submittable-textarea` component to use it. 
## References

Progress on: #608 
