### PR TITLE
Add donation goals

### DIFF
--- a/app/abilities/project.js
+++ b/app/abilities/project.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+const {
+  computed: { alias },
+  inject: { service }
+} = Ember;
+
+/**
+ * Ability object used to determine what the current user can do with a project
+ *
+ * @module  Ability
+ * @extends EmberCan.Ability
+ */
+export default Ability.extend({
+  _credentials: service('credentials'),
+
+  _isOwner: alias('_membership.isOwner'),
+  _membership: alias('_credentials.currentUserMembership'),
+
+  /**
+   * An `ember-can` ability.
+   *
+   * Indicates if the current user can manage donation goals in a project.
+   * Returns true if the user is the owner of the projects organization.
+   * @type {[type]}
+   */
+  canManageDonationGoals: alias('_isOwner')
+});

--- a/app/components/donation-goal-edit.js
+++ b/app/components/donation-goal-edit.js
@@ -1,0 +1,52 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+/**
+ * `donation-goal-edit` used to edit new and existing donation goals
+ *
+ * ## default usage
+ *
+ * ```handlebars
+ * {{donation-goal-edit
+ *   canCancel=externalCancellableFlag
+ *   cancel=(action externalCancelHandler donationGoal)
+ *   donationGoal = donationGoal
+ *   save=(action externalSaveHandler donationGoal)}}
+ *
+ * Used as above, the `externalSaveHandler` function will receive a call with the actual
+ * `donationGoal` model as the first argument, and the properties set via the
+ * component as the second argument.
+ *
+ * Similarly, the `externalCancelHandler` function will recieve a call with the
+ * `donationGoal` as the first and only argument.
+ *
+ * @class donation-goal-edit
+ * @module  Component
+ * @extends Ember.Component
+ */
+export default Component.extend({
+  classNames: ['donation-goal-edit'],
+
+  /**
+   * Indicates if "cancel" button should render.
+   *
+   * Cancel button should only render if one of two cases
+   * - the record is already persisted and we are simply editing it
+   * - the record is new, but there are other persisted records, so cancelling this one
+   *   does not mean there will be no persisted records at all
+   *
+   * @property canCancel
+   * @type {Boolean}
+   */
+  canCancel: false,
+
+  init() {
+    this._super(...arguments);
+    let donationGoal = this.get('donationGoal');
+    let { amount, description } = donationGoal.getProperties('amount', 'description');
+    this.setProperties({ amount, description });
+  }
+});

--- a/app/components/donation-goal.js
+++ b/app/components/donation-goal.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+/**
+ * `donation-goal` used to display information about a donation goal
+ *
+ * ## default usage
+ *
+ * ```handlebars
+ * {{donation-goal
+ *   canEdit=externalEditableFlag
+ *   donationGoal=donationGoal
+ *   edit=(action externalEditHandler donationGoal)}}
+ *
+ * Used as above, the `externalEditHandler` function will receive a call
+ * with the `donationGoal` as the first and only argument.
+ *
+ * @class donation-goal
+ * @module Component
+ * @extends Ember.Component
+ */
+export default Component.extend({
+  classNames: ['donation-goal'],
+
+  /**
+   * Flag indicating if component should render the edit link. Should be set from outside
+   *
+   * @property canEdit
+   * @type {Boolean}
+   */
+  canEdit: false
+});

--- a/app/components/donation-goals.js
+++ b/app/components/donation-goals.js
@@ -1,0 +1,86 @@
+import Ember from 'ember';
+
+const {
+  Component,
+  computed
+} = Ember;
+
+/**
+ * `donation-goals` used to display and manage a project's donation goals
+ *
+ * ## default usage
+ *
+ * {{donation-goals
+ *   add=(action 'addDonationGoal')
+ *   cancel=(action 'cancelDonationGoal')
+ *   edit=(action 'editDonationGoal')
+ *   project=project
+ *   save=(action 'saveDonationGoal')}}
+ *
+ *
+ * Used as above, the external container, probably a controller
+ * will receive the 'add', 'save', 'edit' and 'cancel' actions respectively,
+ * with the proper arguments.
+ *
+ * @class   donation-goals
+ * @module  Component
+ * @extends EmberComponent
+ */
+export default Component.extend({
+  classNames: ['donation-goals'],
+
+  /**
+   * Indicates if the user can add a new donation goal.
+   *
+   * This is possible if no other donation goal
+   * is currently being added or edited.
+   *
+   * @property canAdd
+   * @type {Boolean}
+   */
+  canAdd: computed.not('_currentlyEditingDonationGoals'),
+
+  /**
+   * Indicates if the user can activate donations for this project.
+   *
+   * This is possible if at least one donation goal has been added.
+   *
+   * @property canActivateDonations
+   * @type {Boolean}
+   */
+  canActivateDonations: computed.alias('hasExistingDonationGoals'),
+
+  /**
+   * Indicates if the user can cancel adding or editing a donation goal.
+   *
+   * This is possible if there is already a saved donation goal present.
+   *
+   * @property canCancel
+   * @type {Boolean}
+   */
+  canCancel: computed.alias('hasExistingDonationGoals'),
+
+  /**
+   * Indicates if the user can start editing a donation goal.
+   *
+   * This is possible if no other donation goal
+   * is currently being added or edited.
+   *
+   * @property canEdit
+   * @type {Boolean}
+   */
+  canEdit: computed.not('_currentlyEditingDonationGoals'),
+
+  /**
+   * Indicates if the user has existing donations goals for this project.
+   *
+   * @property hasExistingDonationGoals
+   * @type {Boolean}
+   */
+  hasExistingDonationGoals: computed.notEmpty('_existingDonationGoals'),
+
+  _currentlyEditingDonationGoals: computed.notEmpty('_editedDonationGoals'),
+  _editedDonationGoals: computed.filterBy('project.donationGoals', 'isEditing'),
+  _existingDonationGoals: computed.setDiff('project.donationGoals', '_newDonationGoals'),
+  _newDonationGoals: computed.filterBy('project.donationGoals', 'isNew')
+});

--- a/app/controllers/project/settings/donations.js
+++ b/app/controllers/project/settings/donations.js
@@ -1,0 +1,67 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+  actions: {
+    /**
+     * Action which calls to initialize a new donation goal record
+     * for the current project.
+     *
+     * Triggered when user clicks a button to add a new donation goal
+     *
+     * @method addDonationGoal
+     * @param  {DS.Model} project A project record to initialize a new donation goal for.
+     */
+    addDonationGoal(project) {
+      project.get('donationGoals').createRecord().set('isEditing', true);
+    },
+
+    /**
+     * Action which switches a donation goal from edit to view mode
+     * If the donation goal is a new, unsaved record, it will be destroyed.
+     *
+     * Triggered when user clicks the cancel button,
+     * when editing or adding a donation goal.
+     *
+     * @method cancelDonationGoal
+     * @param  {DS.Model} donationGoal A donation goal record
+     */
+    cancelDonationGoal(donationGoal) {
+      donationGoal.set('isEditing', false);
+
+      if (donationGoal.get('isNew')) {
+        donationGoal.destroyRecord();
+      }
+    },
+
+    /**
+     * Action which switches a donation goal from view to edit mode.
+     *
+     * Trigged when user clicks the edit link.
+     *
+     * @method editDonationGoal
+     * @param  {DS.Model} donationGoal A donation goal record
+     */
+    editDonationGoal(donationGoal) {
+      donationGoal.set('isEditing', true);
+    },
+
+    /**
+     * Action which commits changes to a donation goal.
+     *
+     * Triggers when user clicks the save button while edditing or
+     * adding a new donation goal.
+     *
+     * @method saveDonationGoal
+     * @param  {DS.Model} donationGoal An unmodified or new donation goal record
+     * @param  {Object}   properties   A hash consisting of donation goal properties to update and save
+     */
+    saveDonationGoal(donationGoal, properties) {
+      donationGoal.setProperties(properties);
+      donationGoal.save().then((donationGoal) => {
+        donationGoal.set('isEditing', false);
+      });
+    }
+  }
+});

--- a/app/helpers/format-currency.js
+++ b/app/helpers/format-currency.js
@@ -6,11 +6,29 @@ const {
 
 const COMMAS_EVERY_THREE_DIGITS = /(\d)(?=(\d{3})+(?!\d))/g;
 
+/**
+ * Used to display an amount (in dollars) as currency in the format of
+ * $20,000.50
+ *
+ * - prefixed with a dollar sign
+ * - commas every 3 digits
+ * - dot as decimal separator
+ * - fixed 2-decimal notation
+ *
+ * @param  {Array[String]} params An array of paramaters provided to the helper in the template
+ * @return {String}        Amount formated as $20,000.99
+ */
 export function formatCurrency(params) {
-  let [value] = params;
-  let floatValue = parseFloat(value);
+  let [dollarsAmountAsString] = params;
+  let dollarsAmount = parseFloat(dollarsAmountAsString);
 
-  return `$${floatValue.toFixed(2).replace(COMMAS_EVERY_THREE_DIGITS, '$1,')}`;
+  if (dollarsAmount) {
+    return `$${dollarsAmount.toFixed(2).replace(COMMAS_EVERY_THREE_DIGITS, '$1,')}`;
+  } else if (isNaN(dollarsAmount)) {
+    return '';
+  } else {
+    return dollarsAmount;
+  }
 }
 
 export default helper(formatCurrency);

--- a/app/models/donation-goal.js
+++ b/app/models/donation-goal.js
@@ -1,0 +1,17 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { belongsTo } from 'ember-data/relationships';
+
+export default Model.extend({
+  /**
+   * Donation amount, in cents
+   *
+   * @property amount
+   * @type { Number }
+   */
+  amount: attr('dollar-cents'),
+  current: attr('boolean'),
+  description: attr(),
+
+  project: belongsTo('project', { async: true })
+});

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -17,6 +17,7 @@ export default Model.extend({
   slug: attr(),
   title: attr(),
 
+  donationGoals: hasMany('donation-goals', { async: true }),
   organization: belongsTo('organization', { async: true }),
   tasks: hasMany('tasks', { async: true }),
   projectCategories: hasMany('project-category', { async: true }),

--- a/app/router.js
+++ b/app/router.js
@@ -45,19 +45,16 @@ AppRouter.map(function() {
     });
   });
 
-  this.route('project', {
-    path: '/:slugged_route_slug/:project_slug'
-  }, function() {
+  this.route('project', { path: '/:slugged_route_slug/:project_slug' }, function() {
     this.route('settings', function() {
       this.route('contributors');
       this.route('donations');
       this.route('profile');
     });
+
     this.route('tasks', function() {
       this.route('new');
-      this.route('task', {
-        path: '/:number'
-      });
+      this.route('task', { path: '/:number' });
     });
     this.route('donate');
   });

--- a/app/routes/project/settings/donations.js
+++ b/app/routes/project/settings/donations.js
@@ -1,25 +1,78 @@
 import Ember from 'ember';
+import { CanMixin } from 'ember-can';
 
 const {
   get,
-  inject: { service },
-  Route
+  Route,
+  RSVP
 } = Ember;
 
-export default Route.extend({
-  ajax: service(),
-
-  model() {
-    let project = this.modelFor('project');
-    return project;
+/**
+ * `project.settings.donations`
+ *
+ * Route used by organization owners to manage
+ * donation goals for an organization project
+ *
+ * Allows creating new and editing existing donation goals,
+ * as well as turning on donations for a project (work in progress)
+ *
+ * @module  Route
+ * @extends Ember.Route
+ */
+export default Route.extend(CanMixin, {
+  /**
+   * An Ember.Route hook
+   *
+   * Managing donation goals is for owners only, unlike managing
+   * organizations generally, which is also allowed for admins.
+   *
+   * The hook ensures the user is able to manage organization goals.
+   *
+   * @method beforeModel
+   */
+  beforeModel() {
+    if (this.cannot('manage donation goals in project')) {
+      return this.transitionTo('project');
+    } else {
+      return this._super(...arguments);
+    }
   },
 
-  afterModel(model) {
-    get(this, 'store').queryRecord('stripe-auth', {
-      projectId: model.id
-    }).then((result) => {
-      console.log(result);
-      this.controller.set('stripeAuth', result);
-    });
+  /**
+   * An Ember.Route hook
+   *
+   * Returns a promise hash, meaning hooks that follow the model hook will wait until
+   * all promises in the hash resolve
+   *
+   * @return {RSVP.hash} A promise hash consisting of a project and a stripeAuth record, once resolved
+   */
+  model() {
+    let project = this.modelFor('project');
+    let stripeAuth = get(this, 'store').queryRecord('stripe-auth', { projectId: project.id });
+
+    // the project is not actually a promise, but an actual record instead.
+    // However, RSVP.hash knows how to deal with that.
+    return RSVP.hash({ project, stripeAuth });
+  },
+
+  /**
+   * An Ember.Route hook
+   *
+   * Assingns the project and stripeAuth models as
+   * controller properties.
+   *
+   * If the project has no donation goals, initializes a new record.
+   *
+   * @method setupController
+   * @param  {Ember.Controller} controller
+   * @param  {DS.Model} modelHash.project    The currently loaded project
+   * @param  {DS.Model} modelHash.stripeAuth The stripeAuth record, for the current project
+   */
+  setupController(controller, { project, stripeAuth }) {
+    if (project.get('donationGoals.length') == 0) {
+      controller.send('addDonationGoal', project);
+    }
+
+    controller.setProperties({ project, stripeAuth });
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -36,6 +36,8 @@
 @import "components/create-comment-form";
 @import "components/donation-payment";
 @import "components/drag-zone";
+@import "components/donation-goal";
+@import "components/donation-goal-edit";
 @import "components/editor-with-preview";
 @import "components/error-wrapper";
 @import "components/image-drop";

--- a/app/styles/components/donation-goal-edit.scss
+++ b/app/styles/components/donation-goal-edit.scss
@@ -1,0 +1,25 @@
+.donation-goal-edit{
+  .amount-group {
+    background: $background-gray;
+    border: 1px solid;
+    border-color: $gray;
+    border-radius: 4px;
+    float: left;
+    margin: 0 0 10px 0;
+
+    .amount, .currency, .period {
+      display: inline-block;
+    }
+
+    .currency, .period {
+      padding: 0 10px;
+    }
+
+    .amount {
+      background: #FFF;
+      border-color: $gray;
+      border-width: 0 1px;
+      border-radius: 0;
+    }
+  }
+}

--- a/app/styles/components/donation-goal.scss
+++ b/app/styles/components/donation-goal.scss
@@ -1,0 +1,25 @@
+.donation-goal {
+  border-left: 5px solid $border-default;
+  margin: 10px 0;
+  padding: 5px 20px;
+
+  .amount, .edit {
+    display: inline-block;
+  }
+
+  .amount {
+    font-size: $header-font-size-small;
+    font-weight: 700;
+    margin: 5px 10px 5px 0;
+  }
+
+  .description {
+    color: $light-text;
+    font-size: $body-font-size-small;
+    margin: 5px 0;
+  }
+
+  .edit {
+    font-size: $body-font-size-small;
+  }
+}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -162,3 +162,15 @@ p.subtext {
   position: absolute;
   width: 1px;
 }
+
+.header-section {
+  margin: 20px 0;
+
+  h3 {
+    font-weight: 300;
+  }
+
+  p {
+    color: $light-text;
+  }
+}

--- a/app/templates/components/donation-goal-edit.hbs
+++ b/app/templates/components/donation-goal-edit.hbs
@@ -1,0 +1,20 @@
+<div class="amount-group">
+  <span class="currency">$</span>
+  {{input class="amount" name="amount" type="number" placeholder="Custom amount" value=amount}}
+  <span class="period">per month</span>
+</div>
+<div class="input-group">
+  {{textarea
+    class="description"
+    name="description"
+    placeholder="Tell your donors what this goal will allow you to do. Be specific, but make it interesting!"
+    value=description}}
+</div>
+<div class="input-group">
+  <button class="default save" {{action save (hash amount=amount description=description)}}>
+    {{#if donationGoal.isNew}}Create Goal{{else}}Save changes{{/if}}
+  </button>
+  {{#if canCancel}}
+    <button class="clear cancel" {{action cancel}}>Cancel</button>
+  {{/if}}
+</div>

--- a/app/templates/components/donation-goal.hbs
+++ b/app/templates/components/donation-goal.hbs
@@ -1,0 +1,5 @@
+<h3 class="amount">{{format-currency donationGoal.amount}}</h3>
+{{#if canEdit}}
+  <a class="edit" {{action edit}}>Edit</a>
+{{/if}}
+<p class="description">{{donationGoal.description}}</p>

--- a/app/templates/components/donation-goals.hbs
+++ b/app/templates/components/donation-goals.hbs
@@ -1,0 +1,39 @@
+{{#if canActivateDonations}}
+  <div class="header-section">
+    <h3>Ready to accept donations?</h3>
+    <p>You've added fundraising goals. Just say the word and start accepting donations now.</p>
+    <button class="default activate-donations">Turn on donations</button>
+  </div>
+{{/if}}
+
+{{#if hasExistingDonationGoals}}
+  <div class="header-section">
+    <h3>Your fundraising goals</h3>
+    <p>Add or edit your fundraising goals.</p>
+  </div>
+{{else}}
+  <div class="header-section">
+    <h3>Add your fundraising goals</h3>
+    <p>Before you can start taking donations, you'll need to add at least one fundraising goal.</p>
+  </div>
+{{/if}}
+
+{{#each project.donationGoals as |donationGoal|}}
+  {{#if donationGoal.isEditing}}
+    {{donation-goal-edit
+      canCancel=canCancel
+      cancel=(action cancel donationGoal)
+      donationGoal=donationGoal
+      save=(action save donationGoal)
+    }}
+  {{else}}
+    {{donation-goal
+      canEdit=canEdit
+      donationGoal=donationGoal
+      edit=(action edit donationGoal)
+    }}
+  {{/if}}
+{{/each}}
+{{#if canAdd}}
+  <button class="clear add" {{action add project}}>Add Goal</button>
+{{/if}}

--- a/app/templates/project/settings/donations.hbs
+++ b/app/templates/project/settings/donations.hbs
@@ -1,1 +1,7 @@
 {{stripe-connect-button url=stripeAuth.url}}
+{{donation-goals
+  add=(action 'addDonationGoal')
+  cancel=(action 'cancelDonationGoal')
+  edit=(action 'editDonationGoal')
+  project=project
+  save=(action 'saveDonationGoal')}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -63,7 +63,7 @@ function generatePreviewMentions(schema, preview) {
 
 // The set of routes we have defined; needs updated when adding new routes
 const routes = [
-  'categories', 'comment-user-mentions', 'comments', 'organizations',
+  'categories', 'comment-user-mentions', 'comments', 'donation-goals', 'organizations',
   'task-user-mentions', 'tasks', 'previews', 'projects', 'project-categories',
   'slugged-routes', 'user-categories', 'users'
 ];
@@ -134,6 +134,15 @@ export default function() {
 
     return comment;
   });
+
+  /**
+   * Donation goals
+   */
+
+  this.get('/donation-goals', { coalesce: true });
+  this.get('/donation-goals/:id');
+  this.patch('/donation-goals/:id');
+  this.post('/donation-goals');
 
   /**
   * Organization memberships

--- a/mirage/factories/donation-goal.js
+++ b/mirage/factories/donation-goal.js
@@ -1,0 +1,6 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  amount: faker.list.random(10000, 20000, 15020),
+  description: faker.lorem.paragraph
+});

--- a/mirage/models/donation-goal.js
+++ b/mirage/models/donation-goal.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  project: belongsTo()
+});

--- a/mirage/models/project.js
+++ b/mirage/models/project.js
@@ -1,6 +1,7 @@
 import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
+  donationGoals: hasMany(),
   organization: belongsTo(),
   tasks: hasMany(),
   projectCategories: hasMany(),

--- a/tests/acceptance/project-donation-goals-test.js
+++ b/tests/acceptance/project-donation-goals-test.js
@@ -1,0 +1,181 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
+import { authenticateAsMemberOfRole } from 'code-corps-ember/tests/helpers/authentication';
+import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
+import projectDonationGoalsPage from '../pages/project/settings/donations';
+
+moduleForAcceptance('Acceptance | Project Donation Goals');
+
+test('it requires authentication', function(assert) {
+  assert.expect(1);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'login', 'User was redirected to project route');
+  });
+});
+
+test('it redirects to project list page if user is not allowed to manage donation goals', function(assert) {
+  assert.expect(1);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'admin');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'project.index', 'User was redirected to project list route');
+  });
+});
+
+test('it renders existing donation goals', function(assert) {
+  assert.expect(1);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+  server.createList('donation-goal', 3, { project });
+  server.createList('donation-goal', 2);
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.donationGoals().count, 3, 'All project donation goals are rendered');
+  });
+});
+
+test('it sets up a new unsaved donation goal if there are no donation goals, which can be added', function(assert) {
+  assert.expect(4);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.editedDonationGoals().count, 1, 'A single edited donation goal form is rendered');
+    let form = projectDonationGoalsPage.editedDonationGoals(0);
+
+    form.amount(200);
+    form.description('Lorem ipsum');
+    form.clickSave();
+  });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
+    assert.equal(server.schema.donationGoals.all().models.length, 1, 'Donation goal has been saved.');
+    // mirage doesn't support custom transforms, so we search by cents amount
+    assert.ok(server.schema.donationGoals.findBy({ amount: 20000, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
+  });
+});
+
+test('it is possible to add a donation goal when donation goals already exists', function(assert) {
+  assert.expect(3);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+  server.createList('donation-goal', 1, { project });
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    projectDonationGoalsPage.clickAddNew();
+    let form = projectDonationGoalsPage.editedDonationGoals(0);
+
+    form.amount(200);
+    form.description('Lorem ipsum');
+    form.clickSave();
+  });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.donationGoals().count, 2, 'Both donation goals are rendered.');
+    assert.equal(server.schema.donationGoals.all().models.length, 2, 'Donation goal has been saved.');
+    // mirage doesn't support custom transforms, so we search by cents amount
+    assert.ok(server.schema.donationGoals.findBy({ amount: 20000, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
+  });
+});
+
+test('it allows editing of existing donation goals', function(assert) {
+  assert.expect(3);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+  server.createList('donation-goal', 1, { project });
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    projectDonationGoalsPage.donationGoals(0).clickEdit();
+
+    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    form.amount(200.50);
+    form.description('Lorem ipsum');
+    form.clickSave();
+  });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
+    assert.equal(server.schema.donationGoals.all().models.length, 1, 'Donation goal has been saved as update.');
+    // mirage doesn't support custom transforms, so we search by cents amount
+    assert.ok(server.schema.donationGoals.findBy({ amount: 20050, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
+  });
+});
+
+test('cancelling edit of an unsaved new goal removes that goal from the list', function(assert) {
+  assert.expect(1);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+  server.createList('donation-goal', 1, { project });
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    projectDonationGoalsPage.clickAddNew();
+
+    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    form.clickCancel();
+  });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'New goal is not rendered anymore.');
+  });
+});
+
+test('cancelling edit of an unsaved existing goal keeps that goal in the list', function(assert) {
+  assert.expect(1);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+  server.createList('donation-goal', 1, { project });
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    projectDonationGoalsPage.donationGoals(0).clickEdit();
+
+    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    form.clickCancel();
+  });
+
+  andThen(() => {
+    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'Existing goal is still rendered.');
+  });
+});

--- a/tests/acceptance/stripe-connect-test.js
+++ b/tests/acceptance/stripe-connect-test.js
@@ -1,6 +1,6 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
-import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
+import { authenticateAsMemberOfRole } from 'code-corps-ember/tests/helpers/authentication';
 import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
 import projectSettingsDonationsPage from 'code-corps-ember/tests/pages/project/settings/donations';
 
@@ -9,17 +9,10 @@ moduleForAcceptance('Acceptance | Stripe Connect');
 test('it navigates through Stripes OAuth flow', function(assert) {
   assert.expect(1);
 
-  let user = server.create('user');
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
 
-  server.create('organizationMembership', {
-    member: user,
-    organization,
-    role: 'admin'
-  });
-
-  authenticateSession(this.application, { user_id: user.id });
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
   projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 

--- a/tests/helpers/attributes.js
+++ b/tests/helpers/attributes.js
@@ -1,0 +1,17 @@
+import { test } from 'ember-qunit';
+import Ember from 'ember';
+import 'code-corps-ember/tests/helpers/has-attributes';
+
+const { get } = Ember;
+
+// modified from gist source for relationships
+// source: https://gist.github.com/he9qi/b6354a81a0672dc63294
+export function testForAttributes(name, expectedAttributes) {
+  test(`should have attributes [${expectedAttributes.join(', ')}]`, function(assert) {
+    assert.expect(1);
+    let Model = this.store().modelFor(name);
+    let actualAttributes = get(Model, 'attributes');
+
+    assert.hasAttributes(actualAttributes, expectedAttributes);
+  });
+}

--- a/tests/helpers/authentication.js
+++ b/tests/helpers/authentication.js
@@ -1,0 +1,7 @@
+import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
+
+export function authenticateAsMemberOfRole(application, server, organization, role) {
+  let member = server.schema.create('user');
+  server.schema.create('organization-membership', { member, organization, role });
+  authenticateSession(application, { user_id: member.id });
+}

--- a/tests/integration/components/donation-goal-edit-test.js
+++ b/tests/integration/components/donation-goal-edit-test.js
@@ -1,0 +1,80 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import Ember from 'ember';
+
+const {
+  Object,
+  K
+} = Ember;
+
+let mockGoal = Object.create({ amount: 20, description: 'Some description' });
+
+function setHandlers(context, { saveHandler = K, cancelHandler = K } = {}) {
+  context.set('saveHandler', saveHandler);
+  context.set('cancelHandler', cancelHandler);
+}
+
+moduleForComponent('edit-donation-goal', 'Integration | Component | donation goal edit', {
+  integration: true,
+  beforeEach() {
+    this.set('donationGoal', mockGoal);
+    setHandlers(this);
+  }
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal cancel=cancelHandler save=saveHandler}}`);
+
+  assert.equal(this.$('.donation-goal-edit').length, 1);
+});
+
+test('it renders cancel button, when canCancel is true', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=true cancel=cancelHandler save=saveHandler}}`);
+
+  assert.equal(this.$('.cancel').length, 1, 'The "cancel" button is rendered');
+});
+
+test('it does not render cancel button, when canCancel is false', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=false save=saveHandler}}`);
+
+  assert.equal(this.$('.cancel').length, 0, 'The "cancel" button is not rendered');
+});
+
+test('it sends save action, with user input properties as argument, when save button is clicked', function(assert) {
+  assert.expect(2);
+
+  let mockProperties = { amount: '10', description: 'Updated description' };
+  let saveHandler = function(sumbittedGoal, submitedProperties) {
+    assert.deepEqual(submitedProperties, mockProperties, 'submitted values are passed to external action');
+    assert.deepEqual(sumbittedGoal, mockGoal, 'donation goal is curried unchanged');
+  };
+
+  setHandlers(this, { saveHandler });
+
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal save=(action saveHandler donationGoal)}}`);
+
+  this.$('.amount').val(mockProperties.amount).change();
+  this.$('.description').val(mockProperties.description).change();
+  this.$('.save').click();
+});
+
+test('it sends cancel action, when cancel button is clicked', function(assert) {
+  assert.expect(1);
+
+  let cancelHandler = function(actualGoal) {
+    assert.deepEqual(mockGoal, actualGoal, 'donation goal is curried unchanged');
+  };
+
+  setHandlers(this, { cancelHandler });
+
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=true cancel=(action cancelHandler donationGoal) save=saveHandler}}`);
+
+  this.$('.cancel').click();
+});

--- a/tests/integration/components/donation-goal-test.js
+++ b/tests/integration/components/donation-goal-test.js
@@ -1,0 +1,71 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const {
+  Object,
+  K
+} = Ember;
+
+let mockGoal = Object.create({
+  amount: 500, // dollars
+  description: 'A test goal'
+});
+
+function setHandler(context, editHandler = K) {
+  context.set('editHandler', editHandler);
+}
+
+moduleForComponent('donation-goal', 'Integration | Component | donation goal', {
+  integration: true,
+  beforeEach() {
+    this.set('donationGoal', mockGoal);
+    setHandler(this);
+  }
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goal}}`);
+
+  assert.equal(this.$('.donation-goal').length, 1, 'Component element is rendered');
+});
+
+test('it displays the donation goal info', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`{{donation-goal donationGoal=donationGoal}}`);
+
+  assert.equal(this.$('.amount').text().trim(), '$500.00', 'Correct amount is rendered');
+  assert.equal(this.$('.description').text().trim(), 'A test goal', 'Correct description is rendered');
+});
+
+test('it renders the edit link, if canEdit flag is set to true', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goal canEdit=true edit=editHandler donationGoal=donationGoal}}`);
+
+  assert.equal(this.$('.edit').length, 1, 'Edit button is rendered');
+});
+
+test('it does not render the edit link, if canEdit flag is set to false', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goal canEdit=false donationGoal=donationGoal}}`);
+
+  assert.equal(this.$('.edit').length, 0, 'Edit button is not rendered');
+});
+
+test('it sends the edit action when the edit link is clicked', function(assert) {
+  assert.expect(1);
+
+  let editHandler = function(donationGoal) {
+    assert.deepEqual(mockGoal, donationGoal, 'Handler got called, with donation goal curried');
+  };
+  setHandler(this, editHandler);
+
+  this.render(hbs`{{donation-goal canEdit=true donationGoal=donationGoal edit=(action editHandler donationGoal)}}`);
+
+  this.$('.edit').click();
+});

--- a/tests/integration/components/donation-goals-test.js
+++ b/tests/integration/components/donation-goals-test.js
@@ -1,0 +1,269 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const {
+  Object,
+  K
+} = Ember;
+
+function setHandlers(context, { addHandler = K, cancelHandler = K, editHandler = K, saveHandler = K } = {}) {
+  context.set('addHandler', addHandler);
+  context.set('cancelHandler', cancelHandler);
+  context.set('editHandler', editHandler);
+  context.set('saveHandler', saveHandler);
+}
+
+moduleForComponent('donation-goals', 'Integration | Component | donation goals', {
+  integration: true,
+  beforeEach() {
+    setHandlers(this);
+  }
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{donation-goals add=addHandler}}`);
+
+  assert.equal(this.$('.donation-goals').length, 1, 'Renders the component element');
+});
+
+test('it renders the correct number of subcomponents', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({}),
+    Object.create({}),
+    Object.create({})
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+
+  assert.equal(this.$('.donation-goal').length, 3, 'Renders correct number of donation-goal components');
+});
+
+test('it renders the correct number of subcomponents in view or edit mode', function(assert) {
+  assert.expect(2);
+
+  let mockGoals = [
+    Object.create({ isEditing: false }),
+    Object.create({ isEditing: true }),
+    Object.create({ isEditing: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+
+  assert.equal(this.$('.donation-goal').length, 2, 'Renders correct number of donation-goal components');
+  assert.equal(this.$('.donation-goal-edit').length, 1, 'Renders correct number of donation-goal-edit components');
+});
+
+test('it sends "cancel" action with donation goal as parameter when cancel button is clicked', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  let cancelHandler =  function(donationGoal) {
+    assert.deepEqual(mockGoals[0], donationGoal, 'Handler got called, with donation goal');
+  };
+  setHandlers(this, { cancelHandler });
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
+
+  this.$('.cancel').click();
+});
+
+test('it sends "edit" action with donation goal as parameter when edit button is clicked', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: false, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  let editHandler = function(donationGoal) {
+    assert.deepEqual(mockGoals[0], donationGoal, 'Handler got called, with donation goal');
+  };
+  setHandlers(this, { editHandler });
+
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+
+  this.$('.edit').click();
+});
+
+test('it sends "save" action with donation goal curried first, and values second when save button is clicked', function(assert) {
+  assert.expect(2);
+
+  let mockGoals = [
+    Object.create({ amount: 500, description: 'Lorem ipsum', isEditing: true, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  let saveHandler = function(donationGoal, values) {
+    assert.deepEqual(mockGoals[0], donationGoal, 'First parameter for handler is donation goal');
+    assert.deepEqual(values, { amount: 500, description: 'Lorem ipsum' }, 'Second parameter for handler are provided values');
+  };
+  setHandlers(this, { saveHandler });
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
+
+  this.$('.save').click();
+});
+
+test('it does not allow cancelling an edited record if that record is the only one, and new', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: true })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
+
+  assert.equal(this.$('.cancel').length, 0, 'No cancel button is rendered');
+});
+
+test('it allows cancelling an edited record if that record is the only one and not new', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler edit=editHandler project=project}}`);
+
+  assert.equal(this.$('.cancel').length, 1, 'Cancel button is rendered');
+});
+
+test('it allows cancelling an edited record if that record new, but there are other persisted goals', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: true }),
+    Object.create({ isEditing: false, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+
+  assert.equal(this.$('.cancel').length, 1, 'Cancel button is rendered');
+});
+
+test('it only allows editing a single record at a time', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: false }),
+    Object.create({ isEditing: false, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+
+  assert.equal(this.$('.edit').length, 0, 'A record is being edited, so no other record can be edited');
+});
+
+test('it does not allow adding a record if a record is being edited', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+
+  assert.equal(this.$('.add').length, 0, 'A record is being edited, so no other record can be added');
+});
+
+test('it does not allow adding a record if a record is being added', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: true, isNew: true })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+
+  assert.equal(this.$('.add').length, 0, 'A record is being added, so no other record can be added');
+});
+
+test('it allows adding a record if no record is being added or edited', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: false, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+
+  assert.equal(this.$('.add').length, 1, 'No record is being added or edited, so a new record can be added');
+});
+
+test('it calls provided "add" action with project as parameter when add button is clicked', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: false, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  let addHandler = function(actualProject) {
+    let expectedProject = this.get('project');
+    assert.deepEqual(actualProject, expectedProject);
+  };
+  setHandlers(this, { addHandler });
+
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+
+  this.$('.add').click();
+});
+
+test('it allows activating donations if there are persisted records', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: false, isNew: false })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+
+  assert.equal(this.$('.activate-donations').length, 1, 'The "activate donations" button is rendered');
+});
+
+test('it prevents activating donations if there are no persisted records', function(assert) {
+  assert.expect(1);
+
+  let mockGoals = [
+    Object.create({ isEditing: false, isNew: true })
+  ];
+
+  this.set('project', Object.create({ donationGoals: mockGoals }));
+
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+
+  assert.equal(this.$('.activate-donations').length, 0, 'The "activate donations" button is not rendered');
+});

--- a/tests/integration/components/donation/donation-container-test.js
+++ b/tests/integration/components/donation/donation-container-test.js
@@ -26,7 +26,7 @@ test('it renders donation amount and frequency', function(assert) {
 
 test('it renders donation amount and frequency', function(assert) {
   assert.expect(1);
-  this.set('amount', 100);
+  this.set('amount', 100); // in cents
 
   this.render(hbs`{{donation/donation-container donationAmount=amount}}`);
 

--- a/tests/pages/project/settings/donations.js
+++ b/tests/pages/project/settings/donations.js
@@ -1,17 +1,38 @@
 import {
   attribute,
   clickable,
+  collection,
   create,
+  fillable,
   visitable
 } from 'ember-cli-page-object';
 
 export default create({
   visit: visitable(':organization/:project/settings/donations'),
 
-  clickStripeConnectButton: clickable('.stripe-connect'),
+  donationGoals: collection({
+    itemScope: '.donation-goals .donation-goal',
+    item: {
+      clickEdit: clickable('.edit')
+    }
+  }),
+
+  editedDonationGoals: collection({
+    itemScope: '.donation-goals .donation-goal-edit',
+    item: {
+      amount: fillable('input[name=amount]'),
+      description: fillable('textarea[name=description]'),
+      clickSave: clickable('.save'),
+      clickCancel: clickable('.cancel')
+    }
+  }),
 
   stripeConnectButton: {
     scope: '.stripe-connect',
     href: attribute('href')
-  }
+  },
+
+  clickAddNew: clickable('.add'),
+
+  clickStripeConnectButton: clickable('.stripe-connect')
 });

--- a/tests/unit/abilities/project-test.js
+++ b/tests/unit/abilities/project-test.js
@@ -1,0 +1,26 @@
+import { moduleFor, test } from 'ember-qunit';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
+
+moduleFor('ability:project', 'Unit | Ability | project', {
+  needs: ['service:credentials']
+});
+
+test('it allows managing donation goals if user is owner of project organization', function(assert) {
+  assert.expect(1);
+
+  let ability = this.subject();
+
+  stubService(this, 'credentials', { currentUserMembership: { isOwner: true } });
+
+  assert.ok(ability.get('canManageDonationGoals'));
+});
+
+test('it allows managing donation goals if user is not owner of project organization', function(assert) {
+  assert.expect(1);
+
+  let ability = this.subject();
+
+  stubService(this, 'credentials', { currentUserMembership: { isOwner: false } });
+
+  assert.notOk(ability.get('canManageDonationGoals'));
+});

--- a/tests/unit/controllers/project/settings/donations-test.js
+++ b/tests/unit/controllers/project/settings/donations-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:project/settings/donations', 'Unit | Controller | project/settings/donations', {
+  needs: ['service:metrics']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/helpers/format-currency-test.js
+++ b/tests/unit/helpers/format-currency-test.js
@@ -6,7 +6,7 @@ module('Unit | Helper | format-currency');
 test('formats hundreds correctly', function(assert) {
   assert.expect(1);
 
-  let result = formatCurrency([123]);
+  let result = formatCurrency([123.00]);
   assert.equal(result, '$123.00');
 });
 
@@ -22,4 +22,11 @@ test('formats millions correctly', function(assert) {
 
   let result = formatCurrency([234567890.55]);
   assert.equal(result, '$234,567,890.55');
+});
+
+test('formats empty values correctly', function(assert) {
+  assert.expect(1);
+
+  let result = formatCurrency([null]);
+  assert.equal(result, '');
 });

--- a/tests/unit/models/donation-goal-test.js
+++ b/tests/unit/models/donation-goal-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+import { testForAttributes } from 'code-corps-ember/tests/helpers/attributes';
+import { testForBelongsTo } from 'code-corps-ember/tests/helpers/relationship';
+
+moduleForModel('donation-goal', 'Unit | Model | donation-goal', {
+  needs: ['model:project']
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  assert.ok(!!model);
+});
+
+testForAttributes('donation-goal', ['amount', 'current', 'description']);
+testForBelongsTo('donation-goal', 'project');

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -11,6 +11,7 @@ const {
 moduleForModel('project', 'Unit | Model | project', {
   // Specify the other units that are required for this test.
   needs: [
+    'model:donation-goal',
     'model:organization',
     'model:organization-membership',
     'model:project-category',

--- a/tests/unit/routes/project/settings/donations-test.js
+++ b/tests/unit/routes/project/settings/donations-test.js
@@ -1,0 +1,10 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:project/settings/donations', 'Unit | Route | project/settings/donations', {
+  needs: ['service:metrics']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
# What's in this PR?
## `donation-goal``

A component for viewing a donation goal. Can send an `edit` action to the parent, indicating that the "Edit" link rendered by the component was clicked.

``` handlebars
{{donation-goal 
  donationGoal=donationGoal 
  edit=(action externalEditHandler donationGoal)}}
```
## `donation-goal-edit`

A component for editing a donation goal

The component is not added anywhere into the app, but it's well tested with integration tests. I tried to finally use the "proper" data-down-actions-up approach here (or I hope I did, someone with more ember knowledge can correct me on it.

The component has two actions, `save` and `cancel`. In order to use it correctly, we do the following:

``` handlebars
{{donation-goal-edit
  cancel=(action externalCancelHandler)
  donationGoal=donationGoal
  save=(action externalSaveHandler donationGoal)}}
```
## `donation-goals`

A component for displaying a list of donation goals. Each can be edited/cancelled/saved individually

``` handlebars
{{donation-goals
  add=(action 'addDonationGoal')
  cancel=(action 'cancelDonationGoal')
  edit=(action 'editDonationGoal')
  project=project
  save=(action 'saveDonationGoal')}}
```

The action handlers will both receive the donation goal which is being saved/cancelled.
## Route behavior

Initially, all of the project's donation goals are listed. If there are none, a new record is initialized and added to the list. 
- Saving a new or existing records commits those changes to the API.
- Cancelling a new record removes that record from the list.
- Cancelling an existing record simply puts it back to display mode.
## TODO
- [x] `donation-goal-edit` component
- [x] `donation-goal` component
- [x] `donation-goals` component
- [x] `donation-goal` route
- [x] UI details (texts, etc.)
- [x] Hide the `edit` link and `add new buttons` for unauthorized users
- [x] add missing route and model unit tests (basic, but did not create them yet).
- [x] rewrite `donation-goal-edit` to bind to the donationGoal, not individual properties. Should then set initial values of individual properties on init. More explicit that way, but easier to use.
* [x] Merge #654 
* [x] Add it to the `donation-goal-edit` component here.
* [x] Update tests
* [x] Add project ability tests

## References

Progress on  #470
Progress on: #469 
