### PR TITLE
use ember-concurrency to handle multiple signup requests

### DIFF
--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -1,6 +1,31 @@
 import Ember from 'ember';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-const { Route } = Ember;
+const {
+  Route,
+  inject: { service },
+  set
+} = Ember;
 
-export default Route.extend(UnauthenticatedRouteMixin, { });
+export default Route.extend(UnauthenticatedRouteMixin, {
+  model() {
+    return this.get('store').createRecord('user');
+  },
+
+  session: service(),
+
+  actions: {
+    signIn(credentials) {
+      this.get('session').authenticate('authenticator:jwt', credentials);
+    },
+
+    handleErrors(error) {
+      let { errors, status } = error;
+      let payloadContainsValidationErrors = errors.some(() => status === 422);
+
+      if (!payloadContainsValidationErrors) {
+        set(this, 'controller.signup.error', error);
+      }
+    }
+  }
+});

--- a/app/templates/signup.hbs
+++ b/app/templates/signup.hbs
@@ -1,3 +1,6 @@
 {{title "Sign up"}}
 
-{{signup-form}}
+{{signup-form 
+  handleErrors=(route-action "handleErrors")
+  user=model
+  signIn=(route-action "signIn")}}

--- a/tests/integration/components/signup-form-test.js
+++ b/tests/integration/components/signup-form-test.js
@@ -6,10 +6,6 @@ moduleForComponent('signup-form', 'Integration | Component | signup form', {
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
-
   this.render(hbs`{{signup-form}}`);
 
   assert.equal(this.$('.signup-form').length, 1);

--- a/tests/unit/routes/signup-test.js
+++ b/tests/unit/routes/signup-test.js
@@ -1,11 +1,39 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:signup', 'Unit | Route | signup', {
-  // Specify the other units that are required for this test.
-  needs: ['service:metrics']
+  needs: ['service:metrics', 'service:session']
 });
 
 test('it exists', function(assert) {
   let route = this.subject();
   assert.ok(route);
+});
+
+test('it renders errors through controller', function(assert) {
+  let route = this.subject({
+    controller: {
+      signup: {}
+    }
+  });
+
+  let error = {
+    errors: [{ status: 422 }]
+  };
+  route.send('handleErrors', error);
+
+  assert.deepEqual(route.get('controller.signup.error'), error);
+});
+
+test('it signs the user in through session service', function(assert) {
+  assert.expect(1);
+
+  let route = this.subject({
+    session: {
+      authenticate(_param, credentials) {
+        assert.equal(credentials, 'foo');
+      }
+    }
+  });
+
+  route.send('signIn', 'foo');
 });


### PR DESCRIPTION
# What's in this PR?

We use `ember-concurrency` in a couple of places in our app already. We should leverage tasks from `ember-concurrency` to solve the problem of trying to submit data multiple times.  This PR addresses the signup form and ensures the user can't spam the submit button.
## References

Progress on: #507 
Progress on: #336 
