### PR TITLE
update sprite sheet height

### DIFF
--- a/app/styles/_icons.scss
+++ b/app/styles/_icons.scss
@@ -15,7 +15,7 @@ $spritePath: '/assets/images/icons/sprite';
 $spriteURL: $spritePath + '.png';
 $spritex2URL: $spritePath + '@2x.png';
 $sprite-bgiSizeW: 230px;
-$sprite-bgiSizeH: 248px;
+$sprite-bgiSizeH: 288px;
 $logo: 230px 50px $spriteURL 0px 0px $spritex2URL;
 $logo-small: 161px 35px $spriteURL 0px -50px $spritex2URL;
 $location: 16px 16px $spriteURL 0px -85px $spritex2URL;


### PR DESCRIPTION
# What's in this PR?

Update the icon style sheets to use the new height for the updated sprite-sheet.

Whoops!

Before:
<img width="545" alt="screen shot 2016-10-28 at 1 06 11 pm" src="https://cloud.githubusercontent.com/assets/881981/19815111/5ca0b1ee-9d0f-11e6-8db9-c86b25e9648a.png">

After:
<img width="474" alt="screen shot 2016-10-28 at 1 06 24 pm" src="https://cloud.githubusercontent.com/assets/881981/19815115/5fa46322-9d0f-11e6-8b3d-eaff7a8eb463.png">

