### PR TITLE
add transform for cent value currency

### DIFF
--- a/app/transforms/dollar-cents.js
+++ b/app/transforms/dollar-cents.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+const { Transform } = DS;
+
+export default Transform.extend({
+  deserialize(serialized) {
+    return serialized  / 100;
+  },
+
+  serialize(deserialized) {
+    return Math.floor(deserialized * 100);
+  }
+});

--- a/tests/unit/transforms/dollar-cents-test.js
+++ b/tests/unit/transforms/dollar-cents-test.js
@@ -1,0 +1,16 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('transform:dollar-cents', 'Unit | Transform | dollar-cents', {});
+
+test('it turns integer into correct float value when deserializing', function(assert) {
+  assert.expect(1);
+  let value = this.subject().deserialize(1000);
+  assert.equal(value, 10.0);
+});
+
+test('it turns float into correct integer value when serializing', function(assert) {
+  assert.expect(1);
+
+  let value = this.subject().serialize(10.25);
+  assert.equal(value, 1025);
+});


### PR DESCRIPTION
# What's in this PR?

Spurred by the conversation here: https://github.com/code-corps/code-corps-ember/pull/634#issuecomment-257439956

If we want to deal with integer/cent values from our API but still have them reflect like decimals on the frontend, it may be easiest to create a custom transform to handle the currency conversation.  This would allow us to do:

`amount: attr('dollar-cents')`

And not have to do any cleaning of user input.

