### PR TITLE
Add donation status to sidebar

### DIFF
--- a/app/components/donations/become-a-donor.js
+++ b/app/components/donations/become-a-donor.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+/**
+ * `become-a-donor` used to initiate the subscribing process
+ *
+ * ## default usage
+ *
+ * ```handlebars
+ * {{become-a-donor becomeADonor=(action externalHandler)}}
+ *
+ * Used as above, the `externalHandler` function will receive a
+ * call when the button rendered by the component is clicked.
+ *
+ * @class become-a-donor
+ * @module  Component
+ * @extends Ember.Component
+ */
+export default Component.extend({
+  classNames: ['become-a-donor']
+});

--- a/app/components/donations/create-donation.js
+++ b/app/components/donations/create-donation.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  classNames: ['create-donation'],
+  presetAmounts: [10, 15, 25, 50],
+  amount: 15
+});

--- a/app/components/donations/donation-amount-button.js
+++ b/app/components/donations/donation-amount-button.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+const { Component, computed } = Ember;
+
+export default Component.extend({
+  classNames: ['preset-amount'],
+  classNameBindings: ['presetAmount', 'selected:default:clear'],
+  tagName: 'button',
+
+  selected: computed('presetAmount', 'selectedAmount', function() {
+    let { presetAmount, selectedAmount } = this.getProperties('presetAmount', 'selectedAmount');
+    return parseInt(presetAmount) === parseInt(selectedAmount);
+  }),
+
+  click() {
+    let presetAmount = this.get('presetAmount');
+    this.sendAction('action', presetAmount);
+  }
+});

--- a/app/components/donations/donation-status.js
+++ b/app/components/donations/donation-status.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+export default Component.extend({
+  classNames: ['donation-status'],
+  processStarted: false
+});

--- a/app/components/donations/show-donation.js
+++ b/app/components/donations/show-donation.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+export default Component.extend({
+  classNames: ['show-donation']
+});

--- a/app/controllers/project/index.js
+++ b/app/controllers/project/index.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+const {
+  Controller,
+  computed,
+  inject: { service }
+} = Ember;
+
+export default Controller.extend({
+  store: service(),
+  currentUser: service(),
+
+  user: computed.alias('currentUser.user'),
+
+  actions: {
+    saveSubscription(amount) {
+      let project = this.get('project');
+      let queryParams = { amount };
+      this.transitionToRoute('project.donate', project, { queryParams });
+    }
+  }
+});

--- a/app/models/stripe-subscription.js
+++ b/app/models/stripe-subscription.js
@@ -1,0 +1,10 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { belongsTo } from 'ember-data/relationships';
+
+export default Model.extend({
+  amount: attr('dollar-cents'),
+
+  project: belongsTo('project', { async: true }),
+  user: belongsTo('user', { async: true })
+});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -24,6 +24,7 @@ export default Model.extend({
   stateTransition: attr(),
 
   organizationMemberships: hasMany('organization-membership', { async: true }),
+  subscriptions: hasMany('stripe-subscription', { async: true }),
   userCategories: hasMany('user-category', { async: true }),
   userRoles: hasMany('user-role', { async: true }),
   userSkills: hasMany('user-skill', { async: true }),

--- a/app/routes/project/index.js
+++ b/app/routes/project/index.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+const {
+  inject: { service },
+  Route,
+  RSVP
+} = Ember;
+
+export default Route.extend({
+  currentUser: service(),
+
+  model() {
+    let project = this.modelFor('project');
+
+    return RSVP.hash({
+      project,
+      subscription: this._fetchCurrentUserSubscriptionFor(project)
+    });
+  },
+
+  setupController(controller, models) {
+    controller.setProperties(models);
+  },
+
+  _fetchCurrentUserSubscriptionFor(project) {
+    let user = this.get('currentUser.user');
+
+    if (user) {
+      return user.get('subscriptions').find((subscription) => {
+        subscription.belongsTo('project').id == project.get('id');
+      });
+    } else {
+      return null;
+    }
+  }
+});

--- a/app/styles/_forms.scss
+++ b/app/styles/_forms.scss
@@ -70,7 +70,6 @@ $outer-border-radius: 4px;
 .input-group-addon {
   padding: 6px 12px;
   font-size: $body-font-size-small;
-  font-weight: 700;
   line-height: 1;
   color: #333;
   text-align: center;
@@ -87,6 +86,12 @@ $outer-border-radius: 4px;
     border-bottom-right-radius: $inner-border-radius;
     border-top-right-radius: $inner-border-radius;
     border-right-width: 0;
+  }
+
+  &:last-child {
+    border-bottom-left-radius: $inner-border-radius;
+    border-top-left-radius: $inner-border-radius;
+    border-left-width: 0;
   }
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -35,9 +35,10 @@
 @import "components/comment-item";
 @import "components/create-comment-form";
 @import "components/donations/donation-progress";
-@import "components/donation-payment";
+@import "components/donations/donation-status";
 @import "components/donation-goal";
 @import "components/donation-goal-edit";
+@import "components/donation-payment";
 @import "components/drag-zone";
 @import "components/editor-with-preview";
 @import "components/error-wrapper";

--- a/app/styles/components/donation-payment.scss
+++ b/app/styles/components/donation-payment.scss
@@ -1,12 +1,14 @@
 .donation-container {
-  max-width: 400px;
+  @include span-columns(5);
+  @include shift(7/2);
+
   .donation-amount {
     background-color: $light-blue;
     border: 2px solid $border-light-blue;
     border-radius: 5px;
     padding: 15px;
 
-    h4 {
+    h3 {
       margin: 0;
     }
 

--- a/app/styles/components/donations/donation-status.scss
+++ b/app/styles/components/donations/donation-status.scss
@@ -1,0 +1,43 @@
+.donation-status {
+  .become-a-donor {
+    button {
+      width: 100%;
+    }
+  }
+
+  .create-donation {
+    display: flex;
+    flex-direction: column;
+
+    .amounts {
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    .preset-amount {
+      flex: 2;
+      flex-basis: 48%;
+      margin-bottom: 5px;
+
+      &:nth-child(even) {
+        margin-left: 2px;
+      }
+
+      &:nth-child(odd) {
+        margin-right: 2px;
+      }
+    }
+
+    .custom-amount {
+      flex: 1;
+    }
+
+    .continue {
+      flex: 1;
+    }
+  }
+
+  .show-donation {
+
+  }
+}

--- a/app/styles/templates/project/index.scss
+++ b/app/styles/templates/project/index.scss
@@ -1,3 +1,7 @@
 .project-main {
   @include span-columns(8);
 }
+
+.project-sidebar {
+  @include span-columns(4);
+}

--- a/app/templates/components/donation/donation-container.hbs
+++ b/app/templates/components/donation/donation-container.hbs
@@ -1,5 +1,5 @@
 <div class="donation-amount">
-  <h4>{{format-currency donationAmount}}</h4>
+  <h3>{{format-currency donationAmount}}</h3>
   <div class="footnote additional-content">
     given each month
     <a href="#">edit</a>

--- a/app/templates/components/donations/become-a-donor.hbs
+++ b/app/templates/components/donations/become-a-donor.hbs
@@ -1,0 +1,1 @@
+<button class="default large" {{action becomeADonor}}>Become a Donor</button>

--- a/app/templates/components/donations/create-donation.hbs
+++ b/app/templates/components/donations/create-donation.hbs
@@ -1,0 +1,16 @@
+<div class="amounts">
+{{#each presetAmounts as |presetAmount|}}
+  {{donations/donation-amount-button
+    action=(action (mut amount))
+    presetAmount=presetAmount
+    selectedAmount=amount}}
+{{/each}}
+</div>
+<div class="custom-amount">
+  <div class="input-group">
+    <span class="input-group-addon currency">$</span>
+    {{input class="amount" name="amount" type="number" min=0 placeholder="Custom amount" step=1 value=amount}}
+    <span class="input-group-addon period">per month</span>
+  </div>
+</div>
+<button class="continue default" disabled={{continueDisabled}} {{action continue amount}}>Continue</button>

--- a/app/templates/components/donations/donation-amount-button.hbs
+++ b/app/templates/components/donations/donation-amount-button.hbs
@@ -1,0 +1,1 @@
+Donate {{format-currency presetAmount trimZero=true}}

--- a/app/templates/components/donations/donation-status.hbs
+++ b/app/templates/components/donations/donation-status.hbs
@@ -1,0 +1,7 @@
+{{#if subscription}}
+  {{donations/show-donation amount=subscription.amount}}
+{{else if processStarted}}
+  {{donations/create-donation amount=15 continue=(action createDonation)}}
+{{else}}
+  {{donations/become-a-donor becomeADonor=(action (mut processStarted) true)}}
+{{/if}}

--- a/app/templates/components/donations/show-donation.hbs
+++ b/app/templates/components/donations/show-donation.hbs
@@ -1,0 +1,2 @@
+<span class="icon"></span>
+<strong class="info">You pledged {{format-currency amount trimZero=true}} each month.</strong>

--- a/app/templates/project/index.hbs
+++ b/app/templates/project/index.hbs
@@ -1,7 +1,12 @@
-{{title model.title " by " model.organization.name}}
+{{title project.title " by " project.organization.name}}
 
-{{project-details project=model expanded=true}}
-{{project-menu project=model}}
+{{project-details project=project expanded=true}}
+{{project-menu project=project}}
 <div class="project-main">
-  {{project-long-description project=model}}
+  {{project-long-description project=project}}
+</div>
+<div class="project-sidebar">
+  {{donations/donation-status
+    createDonation=(action 'saveSubscription')
+    subscription=subscription}}
 </div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -65,7 +65,7 @@ function generatePreviewMentions(schema, preview) {
 const routes = [
   'categories', 'comment-user-mentions', 'comments', 'donation-goals', 'organizations',
   'task-user-mentions', 'tasks', 'previews', 'projects', 'project-categories',
-  'slugged-routes', 'user-categories', 'users'
+  'slugged-routes', 'stripe-subscriptions', 'user-categories', 'users'
 ];
 
 export default function() {
@@ -394,6 +394,12 @@ export default function() {
 
   // GET /skills/:id
   this.get('/skills/:id');
+
+  /**
+   * Stripe subscriptions
+   */
+
+  this.post('/stripe-subscriptions');
 
   /**
   * Task user mentions

--- a/mirage/models/stripe-subscription.js
+++ b/mirage/models/stripe-subscription.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  user: belongsTo(),
+  project: belongsTo()
+});

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -2,6 +2,7 @@ import { Model, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   organizationMemberships: hasMany({ inverse: 'member' }),
+  subscriptions: hasMany('stripe-subscription'),
   userCategories: hasMany(),
   userRoles: hasMany(),
   UserSkills: hasMany()

--- a/tests/acceptance/project-about-test.js
+++ b/tests/acceptance/project-about-test.js
@@ -111,3 +111,35 @@ test('When authenticated as admin, and project has long description, it allows e
     assert.ok(projectAboutPage.projectLongDescription.editButton.isVisible, 'We can edit the description again');
   });
 });
+
+test('Allows donating to a project from the sidebar', function(assert) {
+  assert.expect(2);
+
+  let user = server.create('user');
+  let organization = createOrganizationWithSluggedRoute();
+
+  let project = server.create('project', {
+    longDescriptionBody: 'A body',
+    longDescriptionMarkdown: 'A body',
+    organization
+  });
+
+  authenticateSession(this.application, { user_id: user.id });
+
+  projectAboutPage.visit({
+    organization: organization.slug,
+    project: project.slug
+  });
+
+  andThen(() => {
+    projectAboutPage.donationStatus.becomeADonor.clickButton();
+    projectAboutPage.donationStatus.createDonation.setTo15.clickButton();
+    projectAboutPage.donationStatus.createDonation.clickContinue();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'project.donate', 'App transitioned to the donate route.');
+    let expectedURL = `/${organization.slug}/${project.slug}/donate?amount=15`;
+    assert.equal(currentURL(), expectedURL, 'URL contains amount as query parameter.');
+  });
+});

--- a/tests/integration/components/donation/donation-container-test.js
+++ b/tests/integration/components/donation/donation-container-test.js
@@ -30,6 +30,6 @@ test('it renders donation amount and frequency', function(assert) {
 
   this.render(hbs`{{donation/donation-container donationAmount=amount}}`);
 
-  let donationInfo = this.$().find('h4').eq(0);
+  let donationInfo = this.$().find('h3').eq(0);
   assert.equal(donationInfo.text().trim(), '$100.00');
 });

--- a/tests/integration/components/donations/become-a-donor-test.js
+++ b/tests/integration/components/donations/become-a-donor-test.js
@@ -1,0 +1,49 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+
+import becomeADonorComponent from '../../../pages/components/donations/become-a-donor';
+
+const {
+  K
+} = Ember;
+
+let page = PageObject.create(becomeADonorComponent);
+
+function setHandler(context, becomeADonorHandler = K) {
+  context.set('becomeADonorHandler', becomeADonorHandler);
+}
+
+moduleForComponent('donations/become-a-donor', 'Integration | Component | donations/become a donor', {
+  integration: true,
+  beforeEach() {
+    setHandler(this);
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders button', function(assert) {
+  assert.expect(1);
+
+  page.render(hbs`{{donations/become-a-donor becomeADonor=becomeADonorHandler}}`);
+
+  assert.ok(page.rendersButton, 'The component button is rendered');
+});
+
+test('it calls action when button is clicked', function(assert) {
+  assert.expect(1);
+
+  function becomeADonorHandler() {
+    assert.ok(true, 'Action was called on click.');
+  }
+
+  setHandler(this, becomeADonorHandler);
+
+  page.render(hbs`{{donations/become-a-donor becomeADonor=becomeADonorHandler}}`);
+
+  page.clickButton();
+});

--- a/tests/integration/components/donations/create-donation-test.js
+++ b/tests/integration/components/donations/create-donation-test.js
@@ -1,0 +1,80 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+
+import createDonationComponent from '../../../pages/components/donations/create-donation';
+
+const {
+  K
+} = Ember;
+
+let page = PageObject.create(createDonationComponent);
+
+function setHandler(context, continueHandler = K) {
+  context.set('continueHandler', continueHandler);
+}
+
+moduleForComponent('donations/create-donation', 'Integration | Component | donations/create donation', {
+  integration: true,
+  beforeEach() {
+    setHandler(this);
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders properly', function(assert) {
+  assert.expect(6);
+
+  page.render(hbs`{{donations/create-donation continue=continueHandler}}`);
+
+  assert.ok(page.setTo10.isRendered, 'Button for preset amount of 10 is rendered.');
+  assert.ok(page.setTo15.isRendered, 'Button for preset amount of 15 is rendered.');
+  assert.ok(page.setTo25.isRendered, 'Button for preset amount of 25 is rendered.');
+  assert.ok(page.setTo50.isRendered, 'Button for preset amount of 50 is rendered.');
+  assert.ok(page.rendersSetCustomField, 'Input for custom amount is rendered.');
+  assert.ok(page.rendersContinueButton, 'Continue button is rendered.');
+});
+
+test('preset amount buttons work', function(assert) {
+  assert.expect(4);
+
+  page.render(hbs`{{donations/create-donation continue=continueHandler}}`);
+
+  page.setTo10.clickButton();
+  assert.equal(page.customAmountValue, 10, 'Button for preset amount of 10 was clicked, so proper value should be set.');
+  page.setTo15.clickButton();
+  assert.equal(page.customAmountValue, 15, 'Button for preset amount of 15 was clicked, so proper value should be set.');
+  page.setTo25.clickButton();
+  assert.equal(page.customAmountValue, 25, 'Button for preset amount of 25 was clicked, so proper value should be set.');
+  page.setTo50.clickButton();
+  assert.equal(page.customAmountValue, 50, 'Button for preset amount of 50 was clicked, so proper value should be set.');
+});
+
+test('clicking "continue" calls action with amount as argument', function(assert) {
+  assert.expect(1);
+
+  function continueHandler(amount) {
+    assert.equal(amount, 22, 'Proper amount was sent via action.');
+  }
+
+  setHandler(this, continueHandler);
+
+  page.render(hbs`{{donations/create-donation continue=continueHandler}}`);
+
+  page.customAmount(22);
+  page.clickContinue();
+});
+
+test('buttons activate properly when custom amount is set to preset value', function(assert) {
+  assert.expect(1);
+
+  page.render(hbs`{{donations/create-donation continue=continueHandler}}`);
+
+  page.customAmount(22);
+  page.customAmount(15);
+  assert.ok(page.setTo15.isActive, 'Proper button should be active.');
+});

--- a/tests/integration/components/donations/donation-amount-button-test.js
+++ b/tests/integration/components/donations/donation-amount-button-test.js
@@ -1,0 +1,56 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+
+import donationAmountButtonComponent from '../../../pages/components/donations/donation-amount-button';
+
+const {
+  K
+} = Ember;
+
+let page = PageObject.create(donationAmountButtonComponent);
+
+function setHandler(context, { actionHandler = K } = {}) {
+  context.set('actionHandler', actionHandler);
+}
+
+moduleForComponent('donations/donation-amount-button', 'Integration | Component | donations/donation amount button', {
+  integration: true,
+  beforeEach() {
+    setHandler(this);
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it sends action with specified amount when clicked', function(assert) {
+  assert.expect(1);
+
+  let actionHandler = function(amount) {
+    assert.equal(amount, 5, 'Proper amount was sent with action');
+  };
+
+  setHandler(this, { actionHandler });
+
+  page.render(hbs`{{donations/donation-amount-button action=actionHandler presetAmount=5}}`)
+      .clickButton();
+});
+
+test('it shows as active if button is selected', function(assert) {
+  assert.expect(1);
+
+  page.render(hbs`{{donations/donation-amount-button action=actionHandler presetAmount=5 selectedAmount=5}}`);
+
+  assert.ok(page.isActive, 'Button is rendered as active');
+});
+
+test('it shows as inactive if button is not selected', function(assert) {
+  assert.expect(1);
+
+  page.render(hbs`{{donations/donation-amount-button action=actionHandler presetAmount=5 selectedAmount=10}}`);
+
+  assert.ok(page.isInactive, 'Button is rendered as inActive');
+});

--- a/tests/integration/components/donations/donation-status-test.js
+++ b/tests/integration/components/donations/donation-status-test.js
@@ -1,0 +1,68 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+
+import donationStatusComponent from '../../../pages/components/donations/donation-status';
+
+const {
+  K
+} = Ember;
+
+let page = PageObject.create(donationStatusComponent);
+
+function setHandler(context, createDonationHandler = K) {
+  context.set('createDonationHandler', createDonationHandler);
+}
+
+moduleForComponent('donations/donation-status', 'Integration | Component | donations/donation status', {
+  integration: true,
+  beforeEach() {
+    setHandler(this);
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders become-a-donor component initially', function(assert) {
+  assert.expect(1);
+
+  page.render(hbs`{{donations/donation-status becomeADonor=becomeADonorHandler}}`);
+
+  assert.ok(page.rendersBecomeADonor, 'become-a-donor subcomponent is rendered.');
+});
+
+test('it renders create-donation if the process has started', function(assert) {
+  assert.expect(1);
+
+  page.render(hbs`{{donations/donation-status createDonation=createDonationHandler processStarted=true}}`);
+
+  assert.ok(page.rendersCreateDonation, 'create-donation subcomponent is rendered.');
+});
+
+test('it renders show-donation if a subscription record is present and assigned', function(assert) {
+  assert.expect(2);
+
+  this.set('subscription', { amount: 1.500 });
+  page.render(hbs`{{donations/donation-status subscription=subscription}}`);
+
+  assert.ok(page.rendersShowDonation, 'show-donation subcomponent is rendered.');
+  assert.equal(page.showDonation.infoText, 'You pledged $1.50 each month.', 'Info text is properly rendered. Binding is correct.');
+});
+
+test('the become a donor -> set amount -> continue flow works properly', function(assert) {
+  assert.expect(1);
+
+  let createDonationHandler =  function(amount) {
+    assert.equal(amount, 25, 'Handler got called, with proper amount.');
+  };
+
+  setHandler(this, createDonationHandler);
+
+  page.render(hbs`{{donations/donation-status createDonation=createDonationHandler}}`);
+  page.becomeADonor.clickButton();
+  page.createDonation.setTo25.clickButton();
+  page.createDonation.clickContinue();
+});

--- a/tests/integration/components/donations/show-donation-test.js
+++ b/tests/integration/components/donations/show-donation-test.js
@@ -1,0 +1,28 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+
+import showDonationComponent from '../../../pages/components/donations/show-donation';
+
+let page = PageObject.create(showDonationComponent);
+
+moduleForComponent('donations/show-donation', 'Integration | Component | donations/show donation', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders proper information', function(assert) {
+  assert.expect(2);
+
+  this.set('amount', 22.500);
+
+  page.render(hbs`{{donations/show-donation amount=amount}}`);
+
+  assert.ok(page.rendersIcon, 'Icon is rendered.');
+  assert.equal(page.infoText, 'You pledged $22.50 each month.', 'Proper text is rendered.');
+});

--- a/tests/pages/components/donations/become-a-donor.js
+++ b/tests/pages/components/donations/become-a-donor.js
@@ -1,0 +1,7 @@
+import { clickable, isVisible } from 'ember-cli-page-object';
+
+export default {
+  scope: '.become-a-donor',
+  rendersButton: isVisible('button'),
+  clickButton: clickable('button.default')
+};

--- a/tests/pages/components/donations/create-donation.js
+++ b/tests/pages/components/donations/create-donation.js
@@ -1,0 +1,24 @@
+import { clickable, fillable, isVisible, value } from 'ember-cli-page-object';
+
+import donationAmountButtonComponent from './donation-amount-button';
+import Ember from 'ember';
+
+const { $: { extend } } = Ember;
+
+export default {
+  scope: '.create-donation',
+
+  rendersSetCustomField: isVisible('input[name=amount]'),
+  rendersContinueButton: isVisible('button.continue'),
+
+  clickContinue: clickable('button.continue'),
+
+  customAmount: fillable('input[name=amount]'),
+  customAmountValue: value('input[name=amount]'),
+
+  // first argument is target object, to which all other object's properties are added
+  setTo10: extend({}, donationAmountButtonComponent, { scope: '.preset-amount.10' }),
+  setTo15: extend({}, donationAmountButtonComponent, { scope: '.preset-amount.15' }),
+  setTo25: extend({}, donationAmountButtonComponent, { scope: '.preset-amount.25' }),
+  setTo50: extend({}, donationAmountButtonComponent, { scope: '.preset-amount.50' })
+};

--- a/tests/pages/components/donations/donation-amount-button.js
+++ b/tests/pages/components/donations/donation-amount-button.js
@@ -1,0 +1,11 @@
+import { clickable, hasClass, isVisible } from 'ember-cli-page-object';
+
+export default {
+  scope: '.preset-amount',
+
+  isRendered: isVisible(''),
+  isActive: hasClass('default', ''),
+  isInactive: hasClass('clear', ''),
+
+  clickButton: clickable('')
+};

--- a/tests/pages/components/donations/donation-status.js
+++ b/tests/pages/components/donations/donation-status.js
@@ -1,0 +1,16 @@
+import { isVisible } from 'ember-cli-page-object';
+import becomeADonorComponent from './become-a-donor';
+import createDonationComponent from './create-donation';
+import showDonationComponent from './show-donation';
+
+export default {
+  scope: '.donation-status',
+
+  rendersBecomeADonor: isVisible('.become-a-donor'),
+  rendersCreateDonation: isVisible('.create-donation'),
+  rendersShowDonation: isVisible('.show-donation'),
+
+  becomeADonor: becomeADonorComponent,
+  createDonation: createDonationComponent,
+  showDonation: showDonationComponent
+};

--- a/tests/pages/components/donations/show-donation.js
+++ b/tests/pages/components/donations/show-donation.js
@@ -1,0 +1,7 @@
+import { isVisible, text } from 'ember-cli-page-object';
+
+export default {
+  scope: '.show-donation',
+  rendersIcon: isVisible('.icon'),
+  infoText: text('.info')
+};

--- a/tests/pages/project/about.js
+++ b/tests/pages/project/about.js
@@ -1,13 +1,12 @@
-import {
-  create,
-  visitable
-} from 'ember-cli-page-object';
+import { create, visitable } from 'ember-cli-page-object';
+import donationStatus from '../components/donations/donation-status';
 import editorWithPreview from '../components/editor-with-preview';
 import projectLongDescription from '../components/project-long-description';
 
 export default create({
   visit: visitable(':organization/:project'),
 
+  donationStatus,
   editorWithPreview,
   projectLongDescription
 });

--- a/tests/unit/models/stripe-subscription-test.js
+++ b/tests/unit/models/stripe-subscription-test.js
@@ -1,0 +1,16 @@
+import { moduleForModel, test } from 'ember-qunit';
+import { testForAttributes } from 'code-corps-ember/tests/helpers/attributes';
+import { testForBelongsTo } from 'code-corps-ember/tests/helpers/relationship';
+
+moduleForModel('stripe-subscription', 'Unit | Model | stripe subscription', {
+  needs: ['model:project', 'model:user']
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  assert.ok(!!model);
+});
+
+testForAttributes('stripe-subscription', ['amount']);
+testForBelongsTo('stripe-subscription', 'project');
+testForBelongsTo('stripe-subscription', 'user');

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,15 +1,11 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { testForAttributes } from 'code-corps-ember/tests/helpers/attributes';
 import { testForHasMany } from '../../helpers/relationship';
-import '../../helpers/has-attributes';
-import Ember from 'ember';
-
-const { get } = Ember;
 
 moduleForModel('user', 'Unit | Model | user', {
-  // Specify the other units that are required for this test.
   needs: [
-    'model:organization',
     'model:organization-membership',
+    'model:stripe-subscription',
     'model:user-category',
     'model:user-role',
     'model:user-skill'
@@ -18,36 +14,17 @@ moduleForModel('user', 'Unit | Model | user', {
 
 test('it exists', function(assert) {
   let model = this.subject();
-  // let store = this.store();
   assert.ok(!!model);
 });
 
-test('it has all of its attributes', function(assert) {
-  let model = this.store().modelFor('user');
-  let actualAttributes = get(model, 'attributes');
-
-  let expectedAttributes = [
-    'base64PhotoData',
-    'biography',
-    'email',
-    'firstName',
-    'insertedAt',
-    'lastName',
-    'name',
-    'password',
-    'photoLargeUrl',
-    'photoThumbUrl',
-    'state',
-    'stateTransition',
-    'twitter',
-    'username',
-    'website'
-  ];
-
-  assert.hasAttributes(actualAttributes, expectedAttributes);
-});
+testForAttributes('user', [
+  'base64PhotoData', 'biography', 'email', 'firstName', 'insertedAt',
+  'lastName', 'name', 'password', 'photoLargeUrl', 'photoThumbUrl',
+  'state', 'stateTransition', 'twitter', 'username', 'website'
+]);
 
 testForHasMany('user', 'organizationMemberships');
+testForHasMany('user', 'subscriptions');
 testForHasMany('user', 'userCategories');
 testForHasMany('user', 'userRoles');
 testForHasMany('user', 'userSkills');


### PR DESCRIPTION
# What's in this PR?

Still a work in progress.

* [x] Add parent `donations/donation-status` component which renders different child component based on model.
  * If there is no donationl, render `{{donations/become-a-donor}}`
  * If there is an unsaved donation, render `{{donations/create-donation}}`
  * If there is a persisted donation, render `{{donations/show-donation}}`
* [x] Implement `{{donations/become-a-donor}}` 
* [x] Implement `{{donations/create-donation}}`
* [x] Implement  `{{donations/show-donation}}`
* [x] Add to route template
* [x] Bind to route/controller actions
* [x] Slide down when clicking "Become a Donor"
* [ ] Add icon for "you plegded x amount"
* [x] Go through tests and add missing assert descriptions
* [ ] Disable continue button if amount is blank, + tests for that behavior

## References
Progress on: #472
Progress on: #469 

## ToDos copied from issue

- [ ] Show the sub-component of donation progress #471 
- [x] Display "Become a donor" button by default
- [x] Clicking the "Become a donor" button slides down to reveal donation UI
- [x] Four buttons: "Donate $10", $15, $25, $50
- [x] Custom amount per month field that only accepts integers
- [x] Continue button that takes the amount and passes it onto the next page `/projects/donate?amount=number`
- [x] Show success state with amount you give each month: `You give $10 each month`.