### PR TITLE
add cancel button to add-card form

### DIFF
--- a/app/components/donation/credit-card.js
+++ b/app/components/donation/credit-card.js
@@ -52,13 +52,7 @@ export default Component.extend({
   }),
 
   init() {
-    let date = new Date();
-    let currentMonth = `0${date.getMonth() + 1}`.slice(-2);
-    this.set('month', currentMonth);
-    let currentYear = date.getFullYear();
-    this.set('year', currentYear);
-    let years = this.generateYears(currentYear);
-    this.set('years', years);
+    this.setFreshDate();
     this._super(...arguments);
   },
 
@@ -69,6 +63,22 @@ export default Component.extend({
       years.push(currentYear++);
     }
     return years;
+  },
+
+  setFreshDate() {
+    let date = new Date();
+    let currentMonth = `0${date.getMonth() + 1}`.slice(-2);
+    this.set('month', currentMonth);
+    let currentYear = date.getFullYear();
+    this.set('year', currentYear);
+    let years = this.generateYears(currentYear);
+    this.set('years', years);
+  },
+
+  clearForm() {
+    this.set('cvc', '');
+    this.set('cardNumber', '');
+    this.setFreshDate();
   },
 
   _afterSubmit() {
@@ -85,6 +95,13 @@ export default Component.extend({
       let onSubmit = this.get('submit');
 
       onSubmit(cardAttrs).finally(() => this._afterSubmit());
+    },
+
+    cancel() {
+      let cancelAddCard = this.get('cancelAddCard');
+
+      this.clearForm();
+      cancelAddCard();
     }
   }
 });

--- a/app/controllers/project/donate.js
+++ b/app/controllers/project/donate.js
@@ -4,6 +4,7 @@ const {
   Controller,
   computed: { alias, bool, not },
   inject: { service },
+  set,
   RSVP
 } = Ember;
 
@@ -30,7 +31,7 @@ export default Controller.extend({
                  .then((stripeResponse) => this._createCardForPlatformCustomer(stripeResponse))
                  .then((stripeCard) => this._addCard(stripeCard))
                  .catch((reason) => this._handleError(reason))
-                 .finally(() => this._updateAddingCardState());
+                 .finally(() => this._updateAddingCardState(false));
     },
 
     donate(amount, stripeCard) {
@@ -40,6 +41,10 @@ export default Controller.extend({
       return this._createSubscription(amount, stripeCard)
                  .then(() => this._transitionToThankYou())
                  .catch((reason) => this._handleError(reason));
+    },
+
+    cancelAddCard() {
+      this._updateAddingCardState(false);
     }
   },
 
@@ -109,8 +114,8 @@ export default Controller.extend({
     };
   },
 
-  _updateAddingCardState() {
-    this.set('isAddingCard', false);
+  _updateAddingCardState(value) {
+    set(this, 'isAddingCard', value);
   },
 
   _clearErrors() {

--- a/app/styles/components/donation-payment.scss
+++ b/app/styles/components/donation-payment.scss
@@ -32,6 +32,11 @@
   &__icon-list {
     margin-bottom: 15px;
   }
+
+  .cancel-add-card {
+    margin: 10px 0px;
+    text-align: center;
+  }
 }
 
 select.month {

--- a/app/templates/components/donation/credit-card.hbs
+++ b/app/templates/components/donation/credit-card.hbs
@@ -40,14 +40,16 @@
 </div>
 
 <button
-  class="button {{unless preventSubmit "default"}} large"
+  class="button {{unless preventSubmit "default"}} large submit-card"
   disabled={{preventSubmit}}
   {{action "submit"}}>
   {{#if isSubmitting}}Adding...{{else}}Add Card{{/if}}
 </button>
 
 {{#if canCancel}}
-  <a {{action "cancel"}}>Cancel</a>
+  <div class="cancel-add-card">
+    <a {{action "cancel"}}>Cancel</a>
+  </div>
 {{/if}}
 
 {{#unless isSubmitting}}

--- a/app/templates/components/donation/donation-container.hbs
+++ b/app/templates/components/donation/donation-container.hbs
@@ -13,7 +13,11 @@
 
 
 {{#if showCardForm}}
-  {{#donation/credit-card canSubmit=canSubmitAddCard submit=saveCard canCancel=hasCards}}
+  {{#donation/credit-card
+    canSubmit=canSubmitAddCard
+    submit=saveCard
+    canCancel=hasCards
+    cancelAddCard=cancelAddCard}}
     {{!show errors}}
     {{yield}}
   {{/donation/credit-card}}

--- a/app/templates/project/donate.hbs
+++ b/app/templates/project/donate.hbs
@@ -1,5 +1,6 @@
 {{project-header project=project}}
 {{#donation/donation-container
+  cancelAddCard=(action 'cancelAddCard')
   cards=user.stripePlatformCards
   donate=(action 'donate')
   donationAmount=amount

--- a/tests/acceptance/project-donate-test.js
+++ b/tests/acceptance/project-donate-test.js
@@ -103,10 +103,10 @@ test('Allows adding a card and donating (creating a subscription)', function(ass
   });
 
   andThen(() => {
-    projectDonatePage.creditCard.cardNumber('4242-4242-4242-4242');
-    projectDonatePage.creditCard.cardCVC('123');
-    projectDonatePage.creditCard.cardMonth('12');
-    projectDonatePage.creditCard.cardYear('2020');
+    projectDonatePage.creditCard.cardNumber.fillIn('4242-4242-4242-4242');
+    projectDonatePage.creditCard.cardCVC.fillIn('123');
+    projectDonatePage.creditCard.cardMonth.selectOption('12');
+    projectDonatePage.creditCard.cardYear.selectOption('2020');
   });
 
   andThen(() => {
@@ -155,10 +155,10 @@ test('Shows stripe errors when creating card token fails', function(assert) {
   });
 
   andThen(() => {
-    projectDonatePage.creditCard.cardNumber('4242-4242-4242-4242');
-    projectDonatePage.creditCard.cardCVC('123');
-    projectDonatePage.creditCard.cardMonth('12');
-    projectDonatePage.creditCard.cardYear('2020');
+    projectDonatePage.creditCard.cardNumber.fillIn('4242-4242-4242-4242');
+    projectDonatePage.creditCard.cardCVC.fillIn('123');
+    projectDonatePage.creditCard.cardMonth.selectOption('12');
+    projectDonatePage.creditCard.cardYear.selectOption('2020');
   });
 
   andThen(() => {
@@ -190,10 +190,10 @@ test('Shows validation errors when creating subscription fails', function(assert
   });
 
   andThen(() => {
-    projectDonatePage.creditCard.cardNumber('4242-4242-4242-4242');
-    projectDonatePage.creditCard.cardCVC('123');
-    projectDonatePage.creditCard.cardMonth('12');
-    projectDonatePage.creditCard.cardYear('2020');
+    projectDonatePage.creditCard.cardNumber.fillIn('4242-4242-4242-4242');
+    projectDonatePage.creditCard.cardCVC.fillIn('123');
+    projectDonatePage.creditCard.cardMonth.selectOption('12');
+    projectDonatePage.creditCard.cardYear.selectOption('2020');
   });
 
   andThen(() => {

--- a/tests/integration/components/donation/credit-card-test.js
+++ b/tests/integration/components/donation/credit-card-test.js
@@ -15,14 +15,26 @@ const {
   run
 } = Ember;
 
-let setHandler = function(context, submitHandler = K) {
-  context.set('submitHandler', submitHandler);
+let setHandler = function(context, handlerName, handler = K) {
+  context.set(handlerName, handler);
+};
+
+let getFreshDates = function() {
+  let date = new Date();
+  let currentMonth = `0${date.getMonth() + 1}`.slice(-2);
+  let currentYear = date.getFullYear();
+
+  return {
+    month: currentMonth,
+    year: currentYear
+  };
 };
 
 moduleForComponent('donation/credit-card', 'Integration | Component | donation/credit card', {
   integration: true,
   beforeEach() {
-    setHandler(this);
+    setHandler(this, 'submitHandler');
+    setHandler(this, 'cancelHandler');
     page.setContext(this);
   },
   afterEach() {
@@ -54,7 +66,7 @@ test('it sends submit with credit card fields when button is clicked', function(
     });
   };
 
-  setHandler(this, submitHandler);
+  setHandler(this, 'submitHandler', submitHandler);
 
   stubService(this, 'stripe', {
     card: {
@@ -64,14 +76,62 @@ test('it sends submit with credit card fields when button is clicked', function(
     }
   });
 
-  page.render(hbs`{{donation/credit-card canDonate=canDonate submit=submitHandler}}`)
-      .cardNumber(expectedProps.cardNumber)
-      .cardMonth(expectedProps.month)
-      .cardYear(expectedProps.year)
-      .cardCVC(expectedProps.cvc)
-      .clickSubmit();
+  page.render(hbs`{{donation/credit-card canDonate=canDonate submit=submitHandler}}`);
+  page.cardNumber.fillIn(expectedProps.cardNumber);
+  page.cardMonth.selectOption(expectedProps.month);
+  page.cardCVC.fillIn(expectedProps.cvc);
+  page.cardYear.selectOption(expectedProps.year);
+  page.clickSubmit();
 
   wait().then(() => {
     done();
   });
+});
+
+test('cancel link should show if canCancel is true', function(assert) {
+  assert.expect(1);
+  page.render(hbs`{{donation/credit-card canCancel=true}}`);
+  assert.ok(page.isCancelVisible, 'cancel link should be visible');
+});
+
+test('cancel link should not show if canCancel is false', function(assert) {
+  assert.expect(1);
+  page.render(hbs`{{donation/credit-card canCancel=false}}`);
+  assert.notOk(page.isCancelVisible, 'cancel link should not be visible');
+});
+
+test('cancel clears the form fields and sends the proper action', function(assert) {
+  assert.expect(9);
+
+  let cancelHandler = function() {
+    assert.ok(true, 'credit-cards component should call this from the cancel action');
+  };
+
+  let testInput = {
+    cardNumber: '4242 4242 4242 4242',
+    cardMonth: '12',
+    cardYear: '2016',
+    cardCVC: '422'
+  };
+
+  setHandler(this, 'cancelHandler', cancelHandler);
+
+  page.render(hbs`{{donation/credit-card canCancel=true cancelAddCard=cancelHandler}}`);
+  page.cardCVC.fillIn(testInput.cardCVC);
+  page.cardMonth.selectOption(testInput.cardMonth);
+  page.cardNumber.fillIn(testInput.cardNumber);
+  page.cardYear.selectOption(testInput.cardYear);
+
+  assert.equal(page.cardCVC.value, testInput.cardCVC);
+  assert.equal(page.cardMonth.value, testInput.cardMonth);
+  assert.equal(page.cardNumber.value, testInput.cardNumber);
+  assert.equal(page.cardYear.value, testInput.cardYear);
+
+  page.clickCancel();
+
+  let freshDates = getFreshDates();
+  assert.equal(page.cardCVC.value, '');
+  assert.equal(page.cardMonth.value, freshDates.month);
+  assert.equal(page.cardNumber.value, '');
+  assert.equal(page.cardYear.value, freshDates.year);
 });

--- a/tests/integration/components/donation/donation-container-test.js
+++ b/tests/integration/components/donation/donation-container-test.js
@@ -129,12 +129,11 @@ test('it handles adding a card correctly', function(assert) {
       cards=cards donate=donateHandler donationAmount=amount projectTitle=projectTitle saveCard=saveCardHandler }}
   `);
 
-  page.creditCard
-      .cardNumber(cardDetails.cardNumber)
-      .cardMonth(cardDetails.month)
-      .cardYear(cardDetails.year)
-      .cardCVC(cardDetails.cvc)
-      .clickSubmit();
+  page.creditCard.cardNumber.fillIn(cardDetails.cardNumber);
+  page.creditCard.cardMonth.selectOption(cardDetails.month);
+  page.creditCard.cardYear.selectOption(cardDetails.year);
+  page.creditCard.cardCVC.fillIn(cardDetails.cvc);
+  page.creditCard.clickSubmit();
 });
 
 test('it handles donating correctly', function(assert) {

--- a/tests/pages/components/donation/credit-card.js
+++ b/tests/pages/components/donation/credit-card.js
@@ -1,15 +1,37 @@
-import { clickable, fillable, is, selectable, text } from 'ember-cli-page-object';
+import { clickable, fillable, is, isVisible, selectable, text, value } from 'ember-cli-page-object';
 
 export default {
   scope: '.credit-card-form',
 
-  cardCVC: fillable('[name=card-cvc]'),
-  cardNumber: fillable('[name=card-number]'),
-  cardMonth: selectable('select.month'),
-  cardYear: selectable('select.year'),
+  isCancelVisible: isVisible('.cancel-add-card a'),
 
-  clickSubmit: clickable('button'),
+  cardCVC: {
+    scope: '[name=card-cvc]',
+    fillIn: fillable(),
+    value: value()
+  },
 
-  submitButtonText: text('button'),
+  cardMonth: {
+    scope: 'select.month',
+    selectOption: selectable(),
+    value: value()
+  },
+
+  cardNumber: {
+    scope: '[name=card-number]',
+    fillIn: fillable(),
+    value: value()
+  },
+
+  cardYear: {
+    scope: 'select.year',
+    selectOption: selectable(),
+    value: value()
+  },
+
+  clickSubmit: clickable('button.submit-card'),
+  clickCancel: clickable('div.cancel-add-card a'),
+
+  submitButtonText: text('button.submit-card'),
   submitDisabled: is(':disabled', 'button')
 };


### PR DESCRIPTION
# What's in this PR?
Adding cancel button to add-card form.

**This is still in progress**
I still have to add tests, but I am going to sleep right away.
To test up until now, I had added some hardcoded cards to the template and added an add-card button to toggle the `isAddingCard` property. I removed all that for the PR. Will update with tests.

## References
Fixes #677