### PR TITLE
Styles for card-item from tickets #675 and #676

### DIFF
--- a/app/components/donation/donation-container.js
+++ b/app/components/donation/donation-container.js
@@ -4,7 +4,7 @@ const {
   Component,
   computed,
   computed: {
-    and, gt, not, or
+    and, empty, not, or
   }
 } = Ember;
 
@@ -19,24 +19,15 @@ export default Component.extend({
   }),
   canDonate: and('hasCard', 'isNotAddingCard'),
 
-  hasCard: gt('cards.length', 0),
-  hasNoCard: not('hasCard'),
+  hasCard: not('hasNoCard'),
+  hasNoCard: empty('card'),
   isNotAddingCard: not('isAddingCard'),
 
   showCardForm: or('hasNoCard', 'isAddingCard'),
 
-  init() {
-    this._super(...arguments);
-    this.set('selectedCard', this.get('cards.firstObject'));
-  },
-
   actions: {
     addCard() {
       this.set('isAddingCard', true);
-    },
-
-    selectCard(card) {
-      this.set('selectedCard', card);
     }
   }
 });

--- a/app/styles/components/donation-payment.scss
+++ b/app/styles/components/donation-payment.scss
@@ -1,30 +1,34 @@
 .donation-container {
   @include span-columns(5);
   @include shift(7/2);
-
-  .donation-amount {
-    background-color: $light-blue;
-    border: 2px solid $border-light-blue;
-    border-radius: 5px;
-    margin: 20px 0;
-    padding: 15px;
-
-    h3 {
-      margin: 0;
-    }
-
-    .footnote {
-      display: flex;
-      justify-content: space-between;
-    }
-  }
-
   h3 {
     margin-top: 35px;
+    margin-top: 2.5em;
+    font-weight: 600; //semi-bold
   }
-
   button {
     width: 100%;
+  }
+  footer {
+    color: $light-text;
+    font-size: $body-font-size-small;
+    margin-top: 1em;
+  }
+}
+
+.donation-container__amount {
+  background-color: $light-blue;
+  border: 2px solid $border-light-blue;
+  border-radius: 5px;
+  margin: 20px 0;
+  padding: 15px;
+  h3 {
+    margin: 0;
+  }
+  footer {
+    color: $light-text;
+    font-size: $body-font-size-small;
+    margin: 0;
   }
 }
 
@@ -32,9 +36,8 @@
   &__icon-list {
     margin-bottom: 15px;
   }
-
   .cancel-add-card {
-    margin: 10px 0px;
+    margin: 10px 0;
     text-align: center;
   }
 }

--- a/app/styles/components/donation/card-item.scss
+++ b/app/styles/components/donation/card-item.scss
@@ -1,12 +1,87 @@
 .card-item {
-  display: block;
+  align-items: center;
+  background-color: $light-blue;
+  border: 1px solid $dark-blue;
+  border-radius: .25em;
+  display: flex;
+  height: 2.5em;
+  justify-content: space-between;
+  margin-bottom: .6em;
+  padding: 0 1.15em;
+}
 
-  border: 1px solid black;
-  border-radius: 3px;
-  margin: 5px 0;
-  padding: 5px;
+.card-item__brand {
+  background-size: cover;
+  border-radius: .3em;
+  height: 1.5em;
+  margin-right: .7em;
+  overflow: hidden;
+  width: 2.5em;
+}
 
-  &.selected {
-    color: red;
+.card-item__brand--amex {
+  background: url(/assets/images/icons/american-express.png) no-repeat top center;
+  @extend .card-item__brand;
+}
+
+.card-item__brand--diners {
+  background: url(/assets/images/icons/diners-club.png) no-repeat top center;
+  @extend .card-item__brand;
+}
+
+.card-item__brand--discover {
+  background: url(/assets/images/icons/discover.png) no-repeat top center;
+  @extend .card-item__brand;
+}
+
+.card-item__brand--jcb {
+  background: url(/assets/images/icons/jcb.png) no-repeat top center;
+  @extend .card-item__brand;
+}
+
+.card-item__brand--mastercard {
+  background: url(/assets/images/icons/mastercard.png) no-repeat top center;
+  @extend .card-item__brand;
+}
+
+.card-item__brand--visa {
+  background: url(/assets/images/icons/visa.png) no-repeat top center;
+  @extend .card-item__brand;
+}
+
+.card-item__info {
+  display: flex;
+  flex: 1;
+  p {
+    margin: 0;
   }
+  span {
+    font-weight: bold;
+    margin: 0;
+  }
+}
+
+.card-item__expiry {
+
+}
+
+// will move this to _buttons.scss once finished styling
+.button--small {
+  background-color: white;
+  border: 1px solid $gray;
+  border-radius: .3em;
+  color: $dark-text;
+  font-size: $body-font-size-small;
+  height: 2.5em;
+  padding: 0;
+  // width is getting overwritten by .donation-container button
+  width: 8em !important;
+  margin-bottom: 1.4em;
+  &:hover {
+    background-color: rgba($gray, .1)
+  }
+}
+
+.card-list__button--small {
+  @extend .button--small;
 }

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,5 +1,6 @@
 html {
   font-family: $body-font-family;
+  font-size: $body-font-size-normal;
 
   &.danger {
     background: $danger-color;
@@ -82,11 +83,6 @@ ul {
 
 .empty-state {
   color: $light-text;
-}
-
-.additional-content {
-  color: $light-text;
-  font-size: 12px;
 }
 
 .overflow-hidden {

--- a/app/templates/components/donation/card-item.hbs
+++ b/app/templates/components/donation/card-item.hbs
@@ -1,5 +1,22 @@
 {{#if card.isLoading}}
   Loading card...
 {{else}}
-  {{card.brand}} ending in {{card.last4}}
+  <div class="card-item__info">
+    <!-- <input type="radio" name="" checked> -->
+    {{#if (eq card.brand "American Express")}}
+      <div class="card-item__brand--amex"></div>
+    {{else if (eq card.brand "Diners Club")}}
+      <div class="card-item__brand--diners"></div>
+    {{else if (eq card.brand "Discover")}}
+      <div class="card-item__brand--discover"></div>
+    {{else if (eq card.brand "JCB")}}
+      <div class="card-item__brand--jcb"></div>
+    {{else if (eq card.brand "MasterCard")}}
+      <div class="card-item__brand--mastercard"></div>
+    {{else if (eq card.brand "Visa")}}
+      <div class="card-item__brand--visa"></div>
+    {{/if}}
+    <p><span class="card-item__brand">{{card.brand}}</span> ending in {{card.last4}}</p>
+  </div>
+  <span class="card-item__expiry">{{card.expMonth}}/{{card.expYear}}</span>
 {{/if}}

--- a/app/templates/components/donation/card-list.hbs
+++ b/app/templates/components/donation/card-list.hbs
@@ -1,0 +1,11 @@
+<h3>Select card</h3>
+
+{{#each cards as |card|}}
+  {{donation/card-item
+    card=card
+    click=(action selectCard card)
+    selectedCard=selectedCard
+  }}
+{{else}}
+  There are no cards associated with your account yet
+{{/each}}

--- a/app/templates/components/donation/donation-container.hbs
+++ b/app/templates/components/donation/donation-container.hbs
@@ -1,16 +1,15 @@
-<div class="donation-amount">
+<div class="donation-container__amount">
   <h3>{{format-currency donationAmount}}</h3>
-  <div class="footnote additional-content">
-    given each month
-  </div>
+  <footer>given each month</footer>
 </div>
 
-<h3>Payment information</h3>
-<p class="payment-information">
-  Your payment method will be charged {{format-currency donationAmount}}
-  per month to support {{projectTitle}}.
-</p>
-
+<div class="donation-container__information">
+  <h3>Payment information</h3>
+  <p>
+    Your payment method will be charged {{format-currency donationAmount}}
+    per month to support {{projectTitle}}.
+  </p>
+</div>
 
 {{#if card}}
   {{donation/card-item card=card}}
@@ -18,8 +17,9 @@
   {{#donation/credit-card
     canSubmit=canSubmitAddCard
     submit=saveCard
-    canCancel=hasCards
-    cancelAddCard=cancelAddCard}}
+    canCancel=hasCard
+    cancelAddCard=cancelAddCard
+  }}
     {{!show errors}}
     {{yield}}
   {{/donation/credit-card}}
@@ -27,16 +27,12 @@
 
 {{#if card}}
   <button class="default donate large" {{action donate donationAmount card}} disabled={{donationDisabled}}>Donate</button>
-
   {{!show errors}}
   {{yield}}
-
   <footer>
-    <p class="additional-content">
-      Your donation will repeat automatically each month.
-      You can cancel or edit your donation at any time.
-      By making this donation, you are agreeing to our
-      {{link-to "Terms of use" "terms-of-use"}}.
-    </p>
+    Your donation will repeat automatically each month.
+    You can cancel or edit your donation at any time.
+    By making this donation, you are agreeing to our
+    {{link-to "Terms of use" "terms-of-use"}}.
   </footer>
 {{/if}}

--- a/mirage/factories/donation-goal.js
+++ b/mirage/factories/donation-goal.js
@@ -1,6 +1,6 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  amount: faker.list.random(10000, 20000, 15020),
+  amount: faker.list.cycle(10000, 20000, 15020),
   description: faker.lorem.paragraph
 });

--- a/mirage/factories/stripe-platform-card.js
+++ b/mirage/factories/stripe-platform-card.js
@@ -1,0 +1,25 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+// Stripe Test Card Numbers
+// https://stripe.com/docs/testing#cards
+
+export default Factory.extend({
+  brand: faker.list.cycle(
+      'American Express',
+      'Diners Club',
+      'Discover',
+      'JCB',
+      'MasterCard',
+      'Visa'
+  ),
+  expMonth: '01',
+  expYear: '2022',
+  last4: faker.list.cycle(
+      '0005',
+      '5904',
+      '1117',
+      '0000',
+      '4444',
+      '4242'
+  )
+});

--- a/mirage/factories/task.js
+++ b/mirage/factories/task.js
@@ -12,7 +12,7 @@ export default Factory.extend({
     return i + 1;
   },
   status: 'open',
-  taskType: faker.list.random('task', 'idea', 'issue'),
+  taskType: faker.list.cycle('task', 'idea', 'issue'),
   title() {
     return faker.lorem.sentence();
   }

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -252,4 +252,6 @@ export default function(server) {
     let [category] = server.schema.categories.where({ name }).models;
     server.create('project-category', { category, project });
   });
+
+  server.createList('stripe-platform-card', 6, { user: owner });
 }

--- a/tests/integration/components/donation/card-item-test.js
+++ b/tests/integration/components/donation/card-item-test.js
@@ -19,9 +19,9 @@ moduleForComponent('donation/card-item', 'Integration | Component | donation/car
 test('it renders proper information', function(assert) {
   assert.expect(1);
 
-  this.set('card', { id: 1, brand: 'Visa', last4: 4242 });
+  this.set('card', { id: 1, brand: 'Visa', last4: 4242, expMonth: '01', expYear: '2022' });
 
   page.render(hbs`{{donation/card-item card=card}}`);
 
-  assert.equal(page.cardDescription, 'Visa ending in 4242', 'Card description is correct');
+  assert.equal(page.cardDescription, 'Visa ending in 4242 01/2022', 'Card description is correct');
 });

--- a/tests/pages/components/donation/donation-container.js
+++ b/tests/pages/components/donation/donation-container.js
@@ -18,8 +18,8 @@ export default {
 
   clickSubmit: clickable('button.donate'),
 
-  donationAmountText: text('.donation-amount'),
-  paymentInformationText: text('.payment-information'),
+  donationAmountText: text('.donation-container__amount'),
+  paymentInformationText: text('.donation-container__information'),
 
   cards: collection({
     itemScope: '.card-item',


### PR DESCRIPTION
# What's in this PR?

- updated name of class added to cards on the list from "selected" to "card-item--selected" so it follows BEM conventions;
- created new stylesheet: components/donation/card-item.scss;
- adjusted font-weight of h3 elements to match Sketch design (semi-bold instead of bold);
- added font-size to html element (14px $body-font-size-normal) so that em units can use it as a reference;
- added title and button to donation-container.hbs (see reference to #676 below)

![card-item](https://cloud.githubusercontent.com/assets/341543/20476584/4bbdfef0-af97-11e6-8833-b20252bdf31d.png)

## References

Fixes #675 
- radio buttons still need styling to match Sketch mockups

Closes #676 
- "Add Card" is static at the moment;
- style for this button has to be moved to _buttons.scss (and all buttons should be updated to BEM naming convention)
