### PR TITLE
Comment out setting of bearer key. It was being set to a bad value. I…

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -48,7 +48,6 @@ module.exports = function(deployTarget) {
       sentryOrganizationSlug: process.env.STAGING_SENTRY_ORGANIZATION_SLUG,
       sentryProjectSlug: process.env.STAGING_SENTRY_PROJECT_SLUG,
       sentryApiKey: process.env.STAGING_SENTRY_API_KEY,
-      sentryBearerApiKey: process.env.STAGING_SENTRY_API_KEY,
     }
   }
 
@@ -65,7 +64,6 @@ module.exports = function(deployTarget) {
       sentryOrganizationSlug: process.env.PRODUCTION_SENTRY_ORGANIZATION_SLUG,
       sentryProjectSlug: process.env.PRODUCTION_SENTRY_PROJECT_SLUG,
       sentryApiKey: process.env.PRODUCTION_SENTRY_API_KEY,
-      sentryBearerApiKey: process.env.PRODUCTION_SENTRY_API_KEY,
     }
   }
 


### PR DESCRIPTION
# What's in this PR?

ember-cli-deploy-sentry, since 0.5.0, supports bearer auth. We were setting the bearer api key to the identical value as the API key in our environments. Up to 0.5.0, this value was completely ignored, since the feature was unsupported by the package.

Now that it is supported, it detects the value, which is incorrect (same as our API key) and tries to use bearer auth and fails to deploy.

This PR fixes that by simply removing the bearer auth config setting. If we want bearer auth, we should create tokens and set it up again.