### PR TITLE
Show donation progress only when donation goals are active

### DIFF
--- a/app/models/project.js
+++ b/app/models/project.js
@@ -9,6 +9,7 @@ export default Model.extend({
   base64IconData: attr(),
   closedTasksCount: attr('number'),
   description: attr(),
+  donationsActive: attr(),
   iconLargeUrl: attr(),
   iconThumbUrl: attr(),
   longDescriptionBody: attr(),

--- a/app/templates/project/index.hbs
+++ b/app/templates/project/index.hbs
@@ -8,17 +8,19 @@
 </div>
 
 <div class="project-sidebar">
-  <div class="project-sidebar__section">
-    <h3>Donations</h3>
-    {{donations/donation-progress
-      amountDonated=project.totalMonthlyDonated
-      donationGoal=project.currentDonationGoal
-    }}
-    {{donations/donation-status
-      createDonation=(action 'saveSubscription')
-      subscription=subscription
-    }}
-  </div>
+  {{#if project.donationsActive}}
+    <div class="project-sidebar__section">
+      <h3>Donations</h3>
+      {{donations/donation-progress
+        amountDonated=project.totalMonthlyDonated
+        donationGoal=project.currentDonationGoal
+      }}
+      {{donations/donation-status
+        createDonation=(action 'saveSubscription')
+        subscription=subscription
+      }}
+    </div>
+  {{/if}}
 
   <div class="project-sidebar__section">
     {{organization-members count=project.organization.totalMembersCount members=project.organization.organizationMembers}}

--- a/app/templates/project/settings/donations.hbs
+++ b/app/templates/project/settings/donations.hbs
@@ -20,7 +20,7 @@
 </div>
 
 <div class="settings-sidebar">
-  {{#if project.donationGoals}}
+  {{#if project.donationsActive}}
     <h3>Current goal</h3>
     {{donations/donation-progress
       amountDonated=project.totalMonthlyDonated

--- a/tests/acceptance/project-about-test.js
+++ b/tests/acceptance/project-about-test.js
@@ -112,6 +112,29 @@ test('When authenticated as admin, and project has long description, it allows e
   });
 });
 
+test('Does not show donation progress sidebar if donations are not active', function(assert) {
+  assert.expect(1);
+
+  let user = server.create('user');
+  let organization = createOrganizationWithSluggedRoute();
+
+  let project = server.create('project', {
+    donationsActive: false,
+    organization
+  });
+
+  authenticateSession(this.application, { user_id: user.id });
+
+  projectAboutPage.visit({
+    organization: organization.slug,
+    project: project.slug
+  });
+
+  andThen(() => {
+    assert.notOk(projectAboutPage.donationProgress.isVisible, 'The donation progress is not visible.');
+  });
+});
+
 test('Allows donating to a project from the sidebar', function(assert) {
   assert.expect(2);
 
@@ -119,6 +142,7 @@ test('Allows donating to a project from the sidebar', function(assert) {
   let organization = createOrganizationWithSluggedRoute();
 
   let project = server.create('project', {
+    donationsActive: true,
     longDescriptionBody: 'A body',
     longDescriptionMarkdown: 'A body',
     organization

--- a/tests/acceptance/project-donation-goals-test.js
+++ b/tests/acceptance/project-donation-goals-test.js
@@ -1,8 +1,9 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
 import { authenticateAsMemberOfRole } from 'code-corps-ember/tests/helpers/authentication';
+import createOrganizationWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-organization-with-slugged-route';
 import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
-import projectDonationGoalsPage from '../pages/project/settings/donations';
+import projectSettingsDonationsPage from '../pages/project/settings/donations';
 
 moduleForAcceptance('Acceptance | Project Donation Goals');
 
@@ -12,7 +13,7 @@ test('it requires authentication', function(assert) {
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
     assert.equal(currentRouteName(), 'login', 'User was redirected to project route');
@@ -27,7 +28,7 @@ test('it redirects to project list page if user is not allowed to manage donatio
 
   authenticateAsMemberOfRole(this.application, server, organization, 'admin');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.index', 'User was redirected to project list route');
@@ -45,10 +46,10 @@ test('it renders existing donation goals', function(assert) {
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.donationGoals().count, 3, 'All project donation goals are rendered');
+    assert.equal(projectSettingsDonationsPage.donationGoals().count, 3, 'All project donation goals are rendered');
   });
 });
 
@@ -61,11 +62,11 @@ test('it sets up a new unsaved donation goal if there are no donation goals, whi
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.editedDonationGoals().count, 1, 'A single edited donation goal form is rendered');
-    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    assert.equal(projectSettingsDonationsPage.editedDonationGoals().count, 1, 'A single edited donation goal form is rendered');
+    let form = projectSettingsDonationsPage.editedDonationGoals(0);
 
     form.amount(200);
     form.description('Lorem ipsum');
@@ -73,7 +74,7 @@ test('it sets up a new unsaved donation goal if there are no donation goals, whi
   });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
     assert.equal(server.schema.donationGoals.all().models.length, 1, 'Donation goal has been saved.');
     // mirage doesn't support custom transforms, so we search by cents amount
     assert.ok(server.schema.donationGoals.findBy({ amount: 20000, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
@@ -90,11 +91,11 @@ test('it is possible to add a donation goal when donation goals already exists',
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectDonationGoalsPage.clickAddNew();
-    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    projectSettingsDonationsPage.clickAddNew();
+    let form = projectSettingsDonationsPage.editedDonationGoals(0);
 
     form.amount(200);
     form.description('Lorem ipsum');
@@ -102,7 +103,7 @@ test('it is possible to add a donation goal when donation goals already exists',
   });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.donationGoals().count, 2, 'Both donation goals are rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals().count, 2, 'Both donation goals are rendered.');
     assert.equal(server.schema.donationGoals.all().models.length, 2, 'Donation goal has been saved.');
     // mirage doesn't support custom transforms, so we search by cents amount
     assert.ok(server.schema.donationGoals.findBy({ amount: 20000, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
@@ -119,19 +120,19 @@ test('it allows editing of existing donation goals', function(assert) {
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectDonationGoalsPage.donationGoals(0).clickEdit();
+    projectSettingsDonationsPage.donationGoals(0).clickEdit();
 
-    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals(0);
     form.amount(200.50);
     form.description('Lorem ipsum');
     form.clickSave();
   });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
     assert.equal(server.schema.donationGoals.all().models.length, 1, 'Donation goal has been saved as update.');
     // mirage doesn't support custom transforms, so we search by cents amount
     assert.ok(server.schema.donationGoals.findBy({ amount: 20050, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
@@ -148,17 +149,17 @@ test('cancelling edit of an unsaved new goal removes that goal from the list', f
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectDonationGoalsPage.clickAddNew();
+    projectSettingsDonationsPage.clickAddNew();
 
-    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals(0);
     form.clickCancel();
   });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'New goal is not rendered anymore.');
+    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'New goal is not rendered anymore.');
   });
 });
 
@@ -172,17 +173,17 @@ test('cancelling edit of an unsaved existing goal keeps that goal in the list', 
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectDonationGoalsPage.donationGoals(0).clickEdit();
+    projectSettingsDonationsPage.donationGoals(0).clickEdit();
 
-    let form = projectDonationGoalsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals(0);
     form.clickCancel();
   });
 
   andThen(() => {
-    assert.equal(projectDonationGoalsPage.donationGoals().count, 1, 'Existing goal is still rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'Existing goal is still rendered.');
   });
 });
 
@@ -196,15 +197,55 @@ test('it allows activating donations for the project', function(assert) {
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
-  projectDonationGoalsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
 
   andThen(() => {
-    projectDonationGoalsPage.clickActivateDonationGoals();
+    projectSettingsDonationsPage.clickActivateDonationGoals();
   });
 
   andThen(() => {
     assert.equal(server.schema.stripeConnectPlans.all().models.length, 1, 'A single plan was created.');
     let plan = server.schema.stripeConnectPlans.first();
     assert.equal(plan.projectId, project.id, 'Project was correctly assigned to created plan.');
+  });
+});
+
+test('it shows donation progress if donations are active', function(assert) {
+  assert.expect(1);
+
+  let organization = createOrganizationWithSluggedRoute();
+  let project = server.create('project', {
+    donationsActive: true,
+    organization
+  });
+
+  organization.createStripeConnectAccount();
+  server.createList('donation-goal', 1, { project });
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    assert.ok(projectSettingsDonationsPage.donationProgress.isVisible, 'It shows donation progress.');
+  });
+});
+
+test('it does not show donation progress if donations are not active', function(assert) {
+  assert.expect(1);
+
+  let organization = createOrganizationWithSluggedRoute();
+  let project = server.create('project', {
+    donationsActive: false,
+    organization
+  });
+  organization.createStripeConnectAccount();
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    assert.notOk(projectSettingsDonationsPage.donationProgress.isVisible, 'It does not show donation progress.');
   });
 });

--- a/tests/pages/project/about.js
+++ b/tests/pages/project/about.js
@@ -1,4 +1,5 @@
 import { create, visitable } from 'ember-cli-page-object';
+import donationProgress from '../components/donations/donation-progress';
 import donationStatus from '../components/donations/donation-status';
 import editorWithPreview from '../components/editor-with-preview';
 import projectLongDescription from '../components/project-long-description';
@@ -6,6 +7,7 @@ import projectLongDescription from '../components/project-long-description';
 export default create({
   visit: visitable(':organization/:project'),
 
+  donationProgress,
   donationStatus,
   editorWithPreview,
   projectLongDescription

--- a/tests/pages/project/settings/donations.js
+++ b/tests/pages/project/settings/donations.js
@@ -6,9 +6,12 @@ import {
   fillable,
   visitable
 } from 'ember-cli-page-object';
+import donationProgress from 'code-corps-ember/tests/pages/components/donations/donation-progress';
 
 export default create({
   visit: visitable(':organization/:project/settings/donations'),
+
+  donationProgress,
 
   donationGoals: collection({
     itemScope: '.donation-goals .donation-goal',

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -28,9 +28,10 @@ test('it exists', function(assert) {
 });
 
 testForAttributes('project', [
-  'base64IconData', 'closedTasksCount', 'description', 'iconLargeUrl',
-  'iconThumbUrl', 'longDescriptionBody', 'longDescriptionMarkdown',
-  'openTasksCount', 'slug', 'title', 'totalMonthlyDonated'
+  'base64IconData', 'closedTasksCount', 'description', 'donationsActive',
+  'iconLargeUrl', 'iconThumbUrl', 'longDescriptionBody',
+  'longDescriptionMarkdown', 'openTasksCount', 'slug', 'title',
+  'totalMonthlyDonated'
 ]);
 
 testForBelongsTo('project', 'organization');


### PR DESCRIPTION
# What's in this PR?

Shows donation progress only when the donation goals are active, both on the project's about page and on the settings donations page.

## References
Fixes #791 