### PR TITLE
#784 - Redirect to Project Page if User Already Has a Subscription

### DIFF
--- a/app/routes/project/donate.js
+++ b/app/routes/project/donate.js
@@ -2,7 +2,20 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import Ember from 'ember';
 
 const {
+  computed: { alias },
+  inject: { service },
   Route
 } = Ember;
 
-export default Route.extend(AuthenticatedRouteMixin, {});
+export default Route.extend(AuthenticatedRouteMixin, {
+  currentUser: service(),
+  user: alias('currentUser.user'),
+  project: alias('model'),
+
+  afterModel() {
+    let subscriptions = this.get('user.stripeConnectSubscriptions');
+    let subscribedToProject = subscriptions.find(function(subscription) {
+      return subscription.get('stripeConnectPlan.project') == this.get('project');
+    });
+  }
+});

--- a/mirage/models/project.js
+++ b/mirage/models/project.js
@@ -1,7 +1,6 @@
 import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-  currentDonationGoal: belongsTo('donation-goal'),
   donationGoals: hasMany(),
   organization: belongsTo(),
   tasks: hasMany(),

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -4,7 +4,7 @@ export default Model.extend({
   organizationMemberships: hasMany({ inverse: 'member' }),
   stripePlatformCard: belongsTo('stripe-platform-card'),
   stripePlatformCustomer: belongsTo('stripe-platform-customer'),
-  subscriptions: hasMany('stripe-connect-subscription'),
+  stripeConnectSubscriptions: hasMany('stripe-connect-subscription'),
   userCategories: hasMany(),
   userRoles: hasMany(),
   userSkills: hasMany()

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -182,10 +182,20 @@ export default function(server) {
     title: 'Code Corps'
   });
 
+  let stripeConnectPlan = server.create('stripe-connect-plan', {
+    project
+  });
+
   let owner = createUserWithSluggedRoute(server, {
     email: 'owner@codecorps.org',
     password: 'password',
     username: 'codecorps-owner'
+  });
+
+  server.create('stripe-connect-subscription', {
+    quantity: 1000,
+    stripeConnectPlan,
+    user: owner
   });
 
   server.create('organization-membership', {


### PR DESCRIPTION
This is still a work in progress, but the idea is to put in a check in the `afterModel` hook of the `donate` route for whether the current user has a stripe subscription for a project already. If so, redirect to the project page.

So far, the `user.stripeConnectSubscriptions` collection seems to be available, but I am having trouble traversing the object graph when inspecting an individual subscription in the find loop. Maybe mirage isn't setting up the obejcts properly?

Also updated errors in the mirage models. 

Will Fix #784 
