### PR TITLE
Add friendly errors to subscription process

### DIFF
--- a/app/components/error-formatter.js
+++ b/app/components/error-formatter.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { Component, computed, Object, String } = Ember;
+const { Component, computed, Object } = Ember;
 
 /**
   `error-formatter' returns a formatted error message. Place within an 'if'
@@ -54,46 +54,17 @@ export default Component.extend({
    * @return {Function}             Function which takes the error response and returns a list of messages
    */
   _findHandler(errorResponse) {
-    if (errorResponse.get('isAdapterError')) {
-      return this._findHandlerForAdapterError(errorResponse);
+    if (errorResponse.get('isFriendlyError')) {
+      return this._friendlyErrorMessages;
+    } else if (errorResponse.get('isAdapterError')) {
+      return this._adapterErrorMessages;
     } else if (errorResponse.get('error.type') === 'card_error') {
       return this._stripeCardErrorMessages;
     }
   },
 
-  /**
-   * If the error response is determined to be an adapter error, this
-   * function further determines the type of adapter error and returns
-   * the correct message formatter for it.
-   * @param  {Object} errorResponse The adapter error response received from the server
-   * @return {Function}             Function which takes the response and returns a list of messages
-   */
-  _findHandlerForAdapterError(errorResponse) {
-    let payloadContainsValidationErrors = errorResponse.errors.some((error) => error.status === 422);
-
-    if (payloadContainsValidationErrors) {
-      return this._validationErrorMessages;
-    } else {
-      return this._adapterErrorMessages;
-    }
-  },
-
-  /**
-   * Formats messages for a validation error response
-   * In most cases, we do not need this, since we do not render those elements outside
-   * a form. In some cases, however, we are creating a record in the background, so
-   * we are forced to render those errors separate from a form.
-   *
-   * @param  {Object} errorResponse The payload received from the server
-   * @return {Array}                An array of string messages
-   */
-  _validationErrorMessages(errorResponse) {
-    return (errorResponse.get('errors')).map((e) => {
-      let attributePathElements = e.source.pointer.split('/');
-      let unformattedAttributeName = attributePathElements[attributePathElements.length - 1];
-      let attributeName = String.capitalize(unformattedAttributeName);
-      return `${attributeName} ${e.detail}`;
-    });
+  _friendlyErrorMessages(errorResponse) {
+    return [errorResponse.get('message')];
   },
 
   /**

--- a/app/utils/friendly-error.js
+++ b/app/utils/friendly-error.js
@@ -1,0 +1,6 @@
+import { AdapterError } from 'ember-data/adapters/errors';
+
+export default function FriendlyError(message, errors) {
+  this.isFriendlyError = true;
+  AdapterError.call(this, errors, message);
+}

--- a/tests/acceptance/project-donate-test.js
+++ b/tests/acceptance/project-donate-test.js
@@ -85,7 +85,7 @@ test('It requires authentication', function(assert) {
   });
 });
 
-test('Allows adding a card and donating (creating a subscription)', function(assert) {
+test('Allows creating a card and donating (creating a subscription)', function(assert) {
   assert.expect(8);
 
   stubStripe(this, stripeMockSuccess);
@@ -132,7 +132,7 @@ test('Allows adding a card and donating (creating a subscription)', function(ass
   });
 });
 
-test('Shows stripe errors when creating card token fails', function(assert) {
+test('Shows stripe errors when creating a card token fails', function(assert) {
   assert.expect(3);
 
   stubStripe(this, stripeMockFailure);
@@ -167,7 +167,99 @@ test('Shows stripe errors when creating card token fails', function(assert) {
   });
 });
 
-test('Shows validation errors when creating subscription fails', function(assert) {
+test('Shows error indicating problem with stripe customer if that part of the process fails', function(assert) {
+  assert.expect(3);
+
+  stubStripe(this, stripeMockSuccess);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { 'user_id': user.id });
+
+  let organization = createOrganizationWithSluggedRoute();
+  let project = server.create('project', { organization });
+
+  projectDonatePage.visit({
+    amount: 10,
+    organization: organization.slug,
+    project: project.slug
+  });
+
+  server.post('/stripe-platform-customers', function() {
+    return new Mirage.Response(500, {}, {
+      errors: [{
+        id: 'INTERNAL_SERVER_ERROR',
+        title: 'Internal server error',
+        detail: 'is invalid',
+        status: 500
+      }]
+    });
+  });
+
+  andThen(() => {
+    projectDonatePage.creditCard.cardNumber.fillIn('4242-4242-4242-4242');
+    projectDonatePage.creditCard.cardCVC.fillIn('123');
+    projectDonatePage.creditCard.cardMonth.selectOption('12');
+    projectDonatePage.creditCard.cardYear.selectOption('2020');
+  });
+
+  andThen(() => {
+    projectDonatePage.creditCard.clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'project.donate');
+    assert.equal(projectDonatePage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectDonatePage.errorFormatter.errors(0).message, 'There was a problem in connecting your account with our payment processor. Please try again.');
+  });
+});
+
+test('Shows error indicating problem with stripe card if that part of the process fails', function(assert) {
+  assert.expect(3);
+
+  stubStripe(this, stripeMockSuccess);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { 'user_id': user.id });
+
+  let organization = createOrganizationWithSluggedRoute();
+  let project = server.create('project', { organization });
+
+  projectDonatePage.visit({
+    amount: 10,
+    organization: organization.slug,
+    project: project.slug
+  });
+
+  server.post('/stripe-platform-cards', function() {
+    return new Mirage.Response(500, {}, {
+      errors: [{
+        id: 'INTERNAL_SERVER_ERROR',
+        title: 'Internal server error',
+        detail: 'is invalid',
+        status: 500
+      }]
+    });
+  });
+
+  andThen(() => {
+    projectDonatePage.creditCard.cardNumber.fillIn('4242-4242-4242-4242');
+    projectDonatePage.creditCard.cardCVC.fillIn('123');
+    projectDonatePage.creditCard.cardMonth.selectOption('12');
+    projectDonatePage.creditCard.cardYear.selectOption('2020');
+  });
+
+  andThen(() => {
+    projectDonatePage.creditCard.clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'project.donate');
+    assert.equal(projectDonatePage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectDonatePage.errorFormatter.errors(0).message, 'There was a problem in using your payment information. Please try again.');
+  });
+});
+
+test('Shows subscription validation errors if that part of the process fails due to validation', function(assert) {
   assert.expect(4);
 
   stubStripe(this, stripeMockSuccess);
@@ -192,10 +284,7 @@ test('Shows validation errors when creating subscription fails', function(assert
   });
 
   andThen(() => {
-    let done = assert.async();
-
     server.post('/stripe-connect-subscriptions', function() {
-      done();
       return new Mirage.Response(422, {}, {
         errors: [{
           id: 'VALIDATION_ERROR',
@@ -215,6 +304,52 @@ test('Shows validation errors when creating subscription fails', function(assert
     assert.notOk(server.schema.stripeConnectSubscriptions.findBy({ quantity: 1000 }), 'Subscription was not created.');
     assert.equal(currentRouteName(), 'project.donate');
     assert.equal(projectDonatePage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
-    assert.equal(projectDonatePage.errorFormatter.errors(0).message, 'Quantity is invalid', 'Correct error is displayed.');
+    assert.equal(projectDonatePage.errorFormatter.errors(0).message, "The amount you've set for your monthly donation is invalid.", 'Correct error is displayed.');
+  });
+});
+
+test('Shows error indicating problem with creating subscription if that part of the process fails', function(assert) {
+  assert.expect(3);
+
+  stubStripe(this, stripeMockSuccess);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { 'user_id': user.id });
+
+  let organization = createOrganizationWithSluggedRoute();
+  let project = server.create('project', { organization });
+
+  projectDonatePage.visit({
+    amount: 10,
+    organization: organization.slug,
+    project: project.slug
+  });
+
+  server.post('/stripe-connect-subscriptions', function() {
+    return new Mirage.Response(500, {}, {
+      errors: [{
+        id: 'INTERNAL_SERVER_ERROR',
+        title: 'Internal server error',
+        detail: 'is invalid',
+        status: 500
+      }]
+    });
+  });
+
+  andThen(() => {
+    projectDonatePage.creditCard.cardNumber.fillIn('4242-4242-4242-4242');
+    projectDonatePage.creditCard.cardCVC.fillIn('123');
+    projectDonatePage.creditCard.cardMonth.selectOption('12');
+    projectDonatePage.creditCard.cardYear.selectOption('2020');
+  });
+
+  andThen(() => {
+    projectDonatePage.creditCard.clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'project.donate');
+    assert.equal(projectDonatePage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectDonatePage.errorFormatter.errors(0).message, 'There was a problem in setting up your monthly donation. Please try again.');
   });
 });

--- a/tests/integration/components/error-formatter-test.js
+++ b/tests/integration/components/error-formatter-test.js
@@ -4,6 +4,9 @@ import PageObject from 'ember-cli-page-object';
 
 import errorFormatterComponent from '../../pages/components/error-formatter';
 
+import { AdapterError } from 'ember-data/adapters/errors';
+import FriendlyError from 'code-corps-ember/utils/friendly-error';
+
 let page = PageObject.create(errorFormatterComponent);
 
 moduleForComponent('error-formatter', 'Integration | Component | error formatter', {
@@ -15,31 +18,6 @@ moduleForComponent('error-formatter', 'Integration | Component | error formatter
     page.removeContext();
   }
 });
-
-const mockAdapterError = {
-  isAdapterError: true,
-  errors: [
-    { title: 'First', detail: 'error' },
-    { title: 'Second', detail: 'error' }
-  ]
-};
-
-const mockValidationErrors = {
-  isAdapterError: true,
-  errors: [
-    {
-      id: 'VALIDATION_ERROR',
-      source: { pointer: 'data/attributes/amount' },
-      detail: 'is all wrong',
-      status: 422
-    }, {
-      id: 'VALIDATION_ERROR',
-      source: { pointer: 'data/attributes/description' },
-      detail: "is bad, m'kay?",
-      status: 422
-    }
-  ]
-};
 
 const mockStripeError = {
   error: {
@@ -53,21 +31,27 @@ const mockStripeError = {
 test('it formats adapter error properly', function(assert) {
   assert.expect(3);
 
-  this.set('error', mockAdapterError);
+  let adapterError = new AdapterError([
+    { id: 'INTERNAL_SERVER_ERROR', title: 'First', detail: 'error' },
+    { id: 'INTERNAL_SERVER_ERROR', title: 'Second', detail: 'error' }
+  ]);
+
+  this.set('error', adapterError);
   page.render(hbs`{{error-formatter error=error}}`);
   assert.equal(page.errors().count, 2, 'Each error message is rendered');
   assert.equal(page.errors(0).text, 'First: error', 'First message is rendered');
   assert.equal(page.errors(1).text, 'Second: error', 'Second message is rendered');
 });
 
-test('it formats adapter validation error properly', function(assert) {
-  assert.expect(3);
+test('it formats friendly errors properly', function(assert) {
+  assert.expect(2);
 
-  this.set('error', mockValidationErrors);
+  let friendlyError = new FriendlyError('A friendly error');
+
+  this.set('error', friendlyError);
   page.render(hbs`{{error-formatter error=error}}`);
-  assert.equal(page.errors().count, 2, 'Each error message is rendered');
-  assert.equal(page.errors(0).text, 'Amount is all wrong', 'First message is rendered');
-  assert.equal(page.errors(1).text, "Description is bad, m'kay?", 'Second message is rendered');
+  assert.equal(page.errors().count, 1, 'Error message is rendered');
+  assert.equal(page.errors(0).text, 'A friendly error', 'Message text is rendered');
 });
 
 test('it formats stripe card error properly', function(assert) {


### PR DESCRIPTION
# What's in this PR?

* If the stripe card token creation fails, we display an error from stripe
* If the customer creation process fails, we display 
```
'There was a problem in connecting your account with our payment processor. We are looking into it.'
```
* If the platform card creation process fails, we display
```
`There was a problem in using your payment information. We are looking into it.`
```
* If the actual subscription creation process fails, this can be due to validation (quantity is wrong) or some other reason. If validation, we display:
```
"The amount you've set for your monthly donation is invalid."
```
* If it's due to some other reason, we display:
```
'There was a problem in setting up your monthly donation. We are looking into it.';
```

I've created a `FriendlyError` class for this purpose, which inherits the built-in `DS.AdapterError` class.

I've removed support for validation errors in `error-formatter`. It was clunky, buggy, and was only used in this route. Support for inline validation errors is not affected by this. It's supported by ember, built-in.

## References
Fixes #800

