### PR TITLE
Redirect user to projects.index from projects.donate, if donation already exist

### DIFF
--- a/app/components/category-item.js
+++ b/app/components/category-item.js
@@ -113,14 +113,7 @@ export default Component.extend({
    * @private
    */
   _flashError(message) {
-    let flashMessages = get(this, 'flashMessages');
-    flashMessages.clearMessages();
-    return flashMessages.add({
-      message,
-      type: 'danger',
-      fixed: true,
-      sticky: false,
-      timeout: 5000
-    });
+    let options = { fixed: true, sticky: false, timeout: 5000 };
+    get(this, 'flashMessages').clearMessages().danger(message, options);
   }
 });

--- a/app/components/member-list-item.js
+++ b/app/components/member-list-item.js
@@ -30,14 +30,7 @@ export default Component.extend({
   },
 
   _flashSuccess(message) {
-    let flashMessages = get(this, 'flashMessages');
-    flashMessages.clearMessages();
-    return flashMessages.add({
-      message,
-      type: 'success',
-      fixed: true,
-      sticky: false,
-      timeout: 5000
-    });
+    let options = { fixed: true, sticky: false, timeout: 5000 };
+    get(this, 'flashMessages').clearMessages().success(message, options);
   }
 });

--- a/app/components/organization-settings-form.js
+++ b/app/components/organization-settings-form.js
@@ -13,9 +13,8 @@ export default Component.extend({
 
   actions: {
     save() {
-      let flashMessages = get(this, 'flashMessages');
       get(this, 'organization').save().then(() => {
-        flashMessages.success('Organization updated successfully');
+        get(this, 'flashMessages').clearMessages().success('Organization updated successfully');
       });
     }
   }

--- a/app/components/project-settings-form.js
+++ b/app/components/project-settings-form.js
@@ -13,10 +13,8 @@ export default Component.extend({
 
   actions: {
     save() {
-      let flashMessages = get(this, 'flashMessages');
-
       this.get('project').save().then(() => {
-        flashMessages.success('Project updated successfully');
+        get(this, 'flashMessages').clearMessages().success('Project updated successfully');
       });
     }
   }

--- a/app/components/role-item.js
+++ b/app/components/role-item.js
@@ -49,14 +49,7 @@ export default Component.extend({
   },
 
   _flashError(message) {
-    let flashMessages = get(this, 'flashMessages');
-    flashMessages.clearMessages();
-    return flashMessages.add({
-      message,
-      type: 'danger',
-      fixed: true,
-      sticky: false,
-      timeout: 5000
-    });
+    let options = { fixed: true, sticky: false, timeout: 5000 };
+    get(this, 'flashMessages').clearMessages().danger(message, options);
   }
 });

--- a/app/components/user-settings-form.js
+++ b/app/components/user-settings-form.js
@@ -33,10 +33,8 @@ export default Component.extend({
       @method save
      */
     save() {
-      let flashMessages = get(this, 'flashMessages');
-
-      this.get('user').save().then(function() {
-        flashMessages.success('Profile updated successfully');
+      this.get('user').save().then(() => {
+        get(this, 'flashMessages').clearMessages().success('Profile updated successfully');
       });
     }
   }

--- a/app/controllers/project/donate.js
+++ b/app/controllers/project/donate.js
@@ -14,6 +14,7 @@ const {
 const CUSTOMER_CREATION_ERROR = 'There was a problem in connecting your account with our payment processor. Please try again.';
 const CARD_CREATION_ERROR = 'There was a problem in using your payment information. Please try again.';
 const SUBSCRIPTION_CREATION_ERROR = 'There was a problem in setting up your monthly donation. Please try again.';
+const SUBSCRIPTION_VALIDATION_ERROR = "The amount you've set for your monthly donation is invalid.";
 
 export default Controller.extend({
   amount: null,
@@ -132,13 +133,8 @@ export default Controller.extend({
   },
 
   _handleSubscriptionCreationError(response) {
-    let friendlyError;
-
-    if (isValidationError(response)) {
-      friendlyError = new FriendlyError('The amount you\'ve set for your monthly donation is invalid.');
-    } else {
-      friendlyError = new FriendlyError(SUBSCRIPTION_CREATION_ERROR);
-    }
+    let message = isValidationError(response) ? SUBSCRIPTION_VALIDATION_ERROR : SUBSCRIPTION_CREATION_ERROR;
+    let friendlyError = new FriendlyError(message);
 
     return RSVP.reject(friendlyError);
   },

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -170,12 +170,6 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   actions: {
-    didTransition() {
-      // Clear flash messages on every transition
-      this.get('flashMessages').clearMessages();
-      return true; // Bubble the event
-    },
-
     willTransition(transition) {
       if (this._shouldTransitionToOnboardingRoute(transition)) {
         this._abortAndFixHistory(transition);

--- a/app/routes/project/donate.js
+++ b/app/routes/project/donate.js
@@ -2,7 +2,37 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import Ember from 'ember';
 
 const {
-  Route
+  get,
+  inject: { service },
+  Route,
+  RSVP
 } = Ember;
 
-export default Route.extend(AuthenticatedRouteMixin, {});
+const ALREADY_A_SUBSCRIBER = "You're already supporting this project.";
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  flashMessages: service(),
+  userSubscriptions: service(),
+
+  model() {
+    let project = this.modelFor('project');
+
+    return RSVP.hash({
+      project,
+      subscription: this.get('userSubscriptions').fetchForProject(project)
+    });
+  },
+
+  afterModel({ project, subscription }) {
+    if (subscription) {
+      get(this, 'flashMessages').success(ALREADY_A_SUBSCRIBER);
+      this.transitionTo('project', project);
+    } else {
+      this._super.call(...arguments);
+    }
+  },
+
+  setupController(controller, models) {
+    controller.setProperties(models);
+  }
+});

--- a/app/routes/project/index.js
+++ b/app/routes/project/index.js
@@ -7,35 +7,18 @@ const {
 } = Ember;
 
 export default Route.extend({
-  currentUser: service(),
+  userSubscriptions: service(),
 
   model() {
     let project = this.modelFor('project');
 
     return RSVP.hash({
       project,
-      subscription: this._fetchCurrentUserSubscriptionFor(project)
+      subscription: this.get('userSubscriptions').fetchForProject(project)
     });
   },
 
   setupController(controller, models) {
     controller.setProperties(models);
-  },
-
-  _fetchCurrentUserSubscriptionFor(project) {
-    let user = this.get('currentUser.user');
-
-    if (user) {
-      let subscriptions = user.get('stripeConnectSubscriptions');
-      let planId = project.belongsTo('stripeConnectPlan').id();
-      return RSVP.hash({ subscriptions, planId }).then(({ subscriptions, planId }) => {
-        let subscription = subscriptions.find((subscription) => {
-          return subscription.belongsTo('stripeConnectPlan').id() === planId;
-        });
-        return RSVP.resolve(subscription);
-      });
-    } else {
-      return null;
-    }
   }
 });

--- a/app/services/user-subscriptions.js
+++ b/app/services/user-subscriptions.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+const {
+  computed,
+  inject: { service },
+  RSVP,
+  Service
+} = Ember;
+
+export default Service.extend({
+  currentUser: service(),
+  store: service(),
+
+  user: computed.alias('currentUser.user'),
+
+  fetchForProject(project) {
+    let user = this.get('user');
+
+    if (user) {
+      let subscriptions = user.get('stripeConnectSubscriptions');
+      let planId = project.belongsTo('stripeConnectPlan').id();
+      return RSVP.hash({ subscriptions, planId }).then(({ subscriptions, planId }) => {
+        let subscription = subscriptions.find((subscription) => {
+          return subscription.belongsTo('stripeConnectPlan').id() === planId;
+        });
+        return RSVP.resolve(subscription);
+      });
+    } else {
+      return null;
+    }
+  }
+});

--- a/mirage/models/project.js
+++ b/mirage/models/project.js
@@ -1,7 +1,6 @@
 import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-  currentDonationGoal: belongsTo('donation-goal'),
   donationGoals: hasMany(),
   organization: belongsTo(),
   tasks: hasMany(),

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -4,7 +4,7 @@ export default Model.extend({
   organizationMemberships: hasMany({ inverse: 'member' }),
   stripePlatformCard: belongsTo('stripe-platform-card'),
   stripePlatformCustomer: belongsTo('stripe-platform-customer'),
-  subscriptions: hasMany('stripe-connect-subscription'),
+  stripeConnectSubscriptions: hasMany('stripe-connect-subscription'),
   userCategories: hasMany(),
   userRoles: hasMany(),
   userSkills: hasMany()

--- a/tests/helpers/flash-message.js
+++ b/tests/helpers/flash-message.js
@@ -1,6 +1,23 @@
 import Ember from 'ember';
 import FlashObject from 'ember-cli-flash/flash/object';
 
-const { K } = Ember;
+const { getOwner, K } = Ember;
 
 FlashObject.reopen({ init: K });
+
+export function getFlashMessageCount(context) {
+  return getTestContainer(context).lookup('service:flash-messages').get('queue').length;
+}
+
+export function getFlashMessageAt(index, context) {
+  return getTestContainer(context).lookup('service:flash-messages').get('queue')[index];
+}
+
+function getTestContainer(context) {
+  if (context.application) { // acceptance test
+    return context.application.__container__;
+
+  } else { // integration/unit test
+    return getOwner(context);
+  }
+}

--- a/tests/integration/components/category-item-test.js
+++ b/tests/integration/components/category-item-test.js
@@ -3,6 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 import stubService from 'code-corps-ember/tests/helpers/stub-service';
+import { getFlashMessageCount, getFlashMessageAt } from 'code-corps-ember/tests/helpers/flash-message';
 
 const {
   getOwner,
@@ -15,6 +16,7 @@ moduleForComponent('category-item', 'Integration | Component | category item', {
   integration: true,
   beforeEach() {
     mockUserCategory.set('categoryId', defaultCategoryId);
+    getOwner(this).lookup('service:flash-messages').registerTypes(['danger']);
   }
 });
 
@@ -124,58 +126,50 @@ test('it works for removing selected categories', function(assert) {
 
 test('it creates a flash message on an error when adding', function(assert) {
   let done = assert.async();
-  assert.expect(7);
+  assert.expect(4);
 
   stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
   this.set('category', unselectedCategory);
-
-  stubService(this, 'flash-messages', {
-    clearMessages() {
-      assert.ok(true);
-    },
-    add(object) {
-      assert.ok(object.message.indexOf(unselectedCategory.name) !== -1);
-      assert.equal(object.type, 'danger');
-      assert.equal(object.fixed, true);
-      assert.equal(object.sticky, false);
-      assert.equal(object.timeout, 5000);
-    }
-  });
 
   this.render(hbs`{{category-item category=category}}`);
 
   this.$('button').click();
   wait().then(() => {
     assert.notOk(this.$('span').hasClass('button-spinner'));
+
+    assert.equal(getFlashMessageCount(this), 1, 'One message is shown');
+
+    let flash = getFlashMessageAt(0, this);
+    let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
+    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+    assert.ok(flash.message.indexOf(unselectedCategory.name) !== -1, 'Message text includes the category name');
+
     done();
   });
 });
 
 test('it creates a flash message on an error when removing', function(assert) {
   let done = assert.async();
-  assert.expect(7);
+  assert.expect(4);
 
   stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
   this.set('category', selectedCategory);
-
-  stubService(this, 'flash-messages', {
-    clearMessages() {
-      assert.ok(true);
-    },
-    add(object) {
-      assert.ok(object.message.indexOf(selectedCategory.name) !== -1);
-      assert.equal(object.type, 'danger');
-      assert.equal(object.fixed, true);
-      assert.equal(object.sticky, false);
-      assert.equal(object.timeout, 5000);
-    }
-  });
 
   this.render(hbs`{{category-item category=category}}`);
 
   this.$('button').click();
   wait().then(() => {
     assert.notOk(this.$('span').hasClass('button-spinner'));
+
+    assert.equal(getFlashMessageCount(this), 1, 'One message is shown');
+
+    let flash = getFlashMessageAt(0, this);
+    let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
+    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+    assert.ok(flash.message.indexOf(selectedCategory.name) !== -1, 'Message text includes the category name');
+
     done();
   });
 });

--- a/tests/integration/components/organization-settings-form-test.js
+++ b/tests/integration/components/organization-settings-form-test.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import stubService from 'code-corps-ember/tests/helpers/stub-service';
+import { getFlashMessageCount } from 'code-corps-ember/tests/helpers/flash-message';
 
-const { RSVP } = Ember;
+const { getOwner, RSVP } = Ember;
 
 moduleForComponent('organization-settings-form', 'Integration | Component | organization settings form', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
+  }
 });
 
 let organization = {
@@ -45,13 +48,9 @@ test('it calls save on organization when save button is clicked', function(asser
 
   this.set('organization', organization);
 
-  stubService(this, 'flash-messages', {
-    success() {
-      assert.ok(true, 'Flash message service was called');
-    }
-  });
-
   this.render(hbs`{{organization-settings-form organization=organization}}`);
 
   this.$('.save').click();
+
+  assert.equal(getFlashMessageCount(this), 1, 'A flash message was shown');
 });

--- a/tests/integration/components/project-settings-form-test.js
+++ b/tests/integration/components/project-settings-form-test.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import stubService from 'code-corps-ember/tests/helpers/stub-service';
+import { getFlashMessageCount } from 'code-corps-ember/tests/helpers/flash-message';
 
-const { RSVP } = Ember;
+const { getOwner, RSVP } = Ember;
 
 moduleForComponent('project-settings-form', 'Integration | Component | project settings form', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
+  }
 });
 
 let project = {
@@ -45,13 +48,9 @@ test('it calls save on project when save button is clicked', function(assert) {
 
   this.set('project', project);
 
-  stubService(this, 'flash-messages', {
-    success() {
-      assert.ok(true, 'Flash message service was called');
-    }
-  });
-
   this.render(hbs`{{project-settings-form project=project}}`);
 
   this.$('.save').click();
+
+  assert.equal(getFlashMessageCount(this), 1, 'A flash message was shown');
 });

--- a/tests/integration/components/role-item-test.js
+++ b/tests/integration/components/role-item-test.js
@@ -3,6 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 import stubService from 'code-corps-ember/tests/helpers/stub-service';
+import { getFlashMessageCount, getFlashMessageAt } from 'code-corps-ember/tests/helpers/flash-message';
 
 const {
   getOwner,
@@ -77,6 +78,7 @@ moduleForComponent('role-item', 'Integration | Component | role item', {
   integration: true,
   beforeEach() {
     mockUserRole.set('roleId', defaultRoleId);
+    getOwner(this).lookup('service:flash-messages').registerTypes(['danger']);
   }
 });
 
@@ -120,58 +122,50 @@ test('it works for removing selected roles', function(assert) {
 
 test('it creates a flash message on an error when adding', function(assert) {
   let done = assert.async();
-  assert.expect(7);
+  assert.expect(4);
 
   stubService(this, 'user-roles', mockUserRolesServiceForErrors);
   this.set('role', unselectedRole);
-
-  stubService(this, 'flash-messages', {
-    clearMessages() {
-      assert.ok(true);
-    },
-    add(object) {
-      assert.ok(object.message.indexOf(unselectedRole.name) !== -1);
-      assert.equal(object.type, 'danger');
-      assert.equal(object.fixed, true);
-      assert.equal(object.sticky, false);
-      assert.equal(object.timeout, 5000);
-    }
-  });
 
   this.render(hbs`{{role-item role=role}}`);
 
   this.$('button').click();
   wait().then(() => {
     assert.notOk(this.$('span').hasClass('button-spinner'));
+
+    assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
+
+    let flash = getFlashMessageAt(0, this);
+    let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
+    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+    assert.ok(flash.message.indexOf(unselectedRole.name) !== -1, 'Message text includes the role name');
+
     done();
   });
 });
 
 test('it creates a flash message on an error when removing', function(assert) {
   let done = assert.async();
-  assert.expect(7);
+  assert.expect(4);
 
   stubService(this, 'user-roles', mockUserRolesServiceForErrors);
   this.set('role', selectedRole);
-
-  stubService(this, 'flash-messages', {
-    clearMessages() {
-      assert.ok(true);
-    },
-    add(object) {
-      assert.ok(object.message.indexOf(selectedRole.name) !== -1);
-      assert.equal(object.type, 'danger');
-      assert.equal(object.fixed, true);
-      assert.equal(object.sticky, false);
-      assert.equal(object.timeout, 5000);
-    }
-  });
 
   this.render(hbs`{{role-item role=role}}`);
 
   this.$('button').click();
   wait().then(() => {
     assert.notOk(this.$('span').hasClass('button-spinner'));
+
+    assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
+
+    let flash = getFlashMessageAt(0, this);
+    let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
+    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+    assert.ok(flash.message.indexOf(selectedRole.name) !== -1, 'Message text includes the role name');
+
     done();
   });
 });

--- a/tests/integration/components/user-settings-form-test.js
+++ b/tests/integration/components/user-settings-form-test.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import stubService from 'code-corps-ember/tests/helpers/stub-service';
+import { getFlashMessageCount } from 'code-corps-ember/tests/helpers/flash-message';
 
-const { RSVP } = Ember;
+const { getOwner, RSVP } = Ember;
 
 moduleForComponent('user-settings-form', 'Integration | Component | user settings form', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
+  }
 });
 
 test('it renders', function(assert) {
@@ -51,13 +54,9 @@ test('it calls save on user when save button is clicked', function(assert) {
 
   this.set('user', user);
 
-  stubService(this, 'flash-messages', {
-    success() {
-      assert.ok(true, 'Flash message service was called');
-    }
-  });
-
   this.render(hbs`{{user-settings-form user=user}}`);
 
   this.$('.save').click();
+
+  assert.equal(getFlashMessageCount(this), 1, 'A flash message was shown');
 });

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,7 +1,4 @@
 import { moduleFor, test } from 'ember-qunit';
-import Ember from 'ember';
-
-const { getOwner } = Ember;
 
 moduleFor('route:application', 'Unit | Route | application', {
   // Specify the other units that are required for this test.
@@ -12,18 +9,7 @@ moduleFor('route:application', 'Unit | Route | application', {
   ]
 });
 
-test('it clears flash messages on transition', function(assert) {
-  assert.expect(2);
-
-  let typesUsed = ['success'];
-  let flashMessages = getOwner(this).lookup('service:flash-messages');
-  flashMessages.registerTypes(typesUsed);
-
+test('it exists', function(assert) {
   let route = this.subject();
-
-  flashMessages.success('Success!');
-  assert.equal(flashMessages.get('queue.length'), 1);
-
-  route.send('didTransition');
-  assert.equal(flashMessages.get('queue.length'), 0);
+  assert.ok(route);
 });


### PR DESCRIPTION
# What's in this PR?

Changes the flow on the donate page to redirect to main project route if donation already exists. 

Since it reuses the same logic as the `project.index` route to find the user's subscription for the current project, I moved that logic into a service.

I also added a flash message, but it doesn't seem to work for some reason. Flash messages do not seem to be broken, but I couldn't find a problem. Any pointers are welcome.


## References
Fixes #798 