### PR TITLE
Render donation goal related errors properly

### DIFF
--- a/app/controllers/project/donate.js
+++ b/app/controllers/project/donate.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import FriendlyError from 'code-corps-ember/utils/friendly-error';
+import { isValidationError } from 'code-corps-ember/utils/error-utils';
 
 const {
   Controller,
@@ -13,16 +14,6 @@ const {
 const CUSTOMER_CREATION_ERROR = 'There was a problem in connecting your account with our payment processor. Please try again.';
 const CARD_CREATION_ERROR = 'There was a problem in using your payment information. Please try again.';
 const SUBSCRIPTION_CREATION_ERROR = 'There was a problem in setting up your monthly donation. Please try again.';
-
-function isValidationError(payload) {
-  if (!payload.isAdapterError) {
-    return false;
-  }
-
-  let errors = payload.errors || [];
-
-  return errors.some((e) => e.id == 'VALIDATION_ERROR');
-}
 
 export default Controller.extend({
   amount: null,

--- a/app/styles/components/donation-goal-edit.scss
+++ b/app/styles/components/donation-goal-edit.scss
@@ -21,5 +21,10 @@
       border-width: 0 1px;
       border-radius: 0;
     }
+
+  }
+
+  .error {
+    clear: left;
   }
 }

--- a/app/templates/components/donation-goal-edit.hbs
+++ b/app/templates/components/donation-goal-edit.hbs
@@ -3,6 +3,9 @@
   {{input class="amount" name="amount" type="number" placeholder="Custom amount" value=amount}}
   <span class="period">per month</span>
 </div>
+{{#each donationGoal.errors.amount as |error|}}
+  <p class="error">{{error.message}}</p>
+{{/each}}
 <div class="input-group">
   {{textarea
     class="description"
@@ -10,6 +13,10 @@
     placeholder="Tell your donors what this goal will allow you to do. Be specific, but make it interesting!"
     value=description}}
 </div>
+{{#each donationGoal.errors.description as |error|}}
+  <p class="error">{{error.message}}</p>
+{{/each}}
+
 <div class="input-group">
   <button class="default save" {{action save (hash amount=amount description=description)}}>
     {{#if donationGoal.isNew}}Create Goal{{else}}Save changes{{/if}}

--- a/app/templates/project/settings/donations.hbs
+++ b/app/templates/project/settings/donations.hbs
@@ -17,6 +17,9 @@
       </div>
     {{/if}}
   {{/if}}
+  {{#if error}}
+    {{error-formatter error=error}}
+  {{/if}}
 </div>
 
 <div class="settings-sidebar">

--- a/app/utils/error-utils.js
+++ b/app/utils/error-utils.js
@@ -1,0 +1,19 @@
+/**
+ * Figures out if an error payload received from the server
+ * contains validation errors and thus is a validation error payload
+ *
+ * This is done by checking for presence of a `source` property in
+ * any of the received error objects.
+ *
+ * @param  {DS.AdapterError}  payload An instance of a `DS.AdapterError`
+ * @return {Boolean}          `true` if the payload is a validaton error payload
+ */
+export function isValidationError(payload) {
+  if (!payload.isAdapterError) {
+    return false;
+  }
+
+  let errors = payload.errors || [];
+
+  return errors.some((e) => e.source);
+}

--- a/tests/pages/project/settings/donations.js
+++ b/tests/pages/project/settings/donations.js
@@ -4,9 +4,11 @@ import {
   collection,
   create,
   fillable,
+  text,
   visitable
 } from 'ember-cli-page-object';
 import donationProgress from 'code-corps-ember/tests/pages/components/donations/donation-progress';
+import errorFormatter from 'code-corps-ember/tests/pages/components/error-formatter';
 
 export default create({
   visit: visitable(':organization/:project/settings/donations'),
@@ -26,9 +28,17 @@ export default create({
       amount: fillable('input[name=amount]'),
       description: fillable('textarea[name=description]'),
       clickSave: clickable('.save'),
-      clickCancel: clickable('.cancel')
+      clickCancel: clickable('.cancel'),
+      validationErrors: collection({
+        itemScope: '.error',
+        item: {
+          message: text('')
+        }
+      })
     }
   }),
+
+  errorFormatter,
 
   stripeConnectButton: {
     scope: '.stripe-connect',


### PR DESCRIPTION
# What's in this PR?

Adds field-based validation error rendering for the donation goals page.

Also adds displaying of other generic server-side errors as a friendly error message.

I also realised our `isValidationError` helper on the `project.donate` page was wrong in assuming our server payload would contain a title set to `VALIDATION_ERROR`. Instead, it is now checking if any of the errors in the payload contains a `source` property. 

The helper has also been moved into a separate module, since it's now also being used on the `project.donations` page.

## References
Fixes #813