### PR TITLE
Prevent UI popping during subscription process

### DIFF
--- a/app/components/donation/credit-card.js
+++ b/app/components/donation/credit-card.js
@@ -81,7 +81,6 @@ export default Component.extend({
 
   actions: {
     submit() {
-      this.set('isSubmitting', true);
       let cardAttrs = this.getProperties('cvc', 'cardNumber', 'year', 'month');
       let onSubmit = this.get('submit');
 

--- a/app/components/donation/credit-card.js
+++ b/app/components/donation/credit-card.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const {
   Component,
   computed,
-  computed: { and, not, or },
+  computed: { and, not },
   inject: { service }
 } = Ember;
 
@@ -20,10 +20,8 @@ export default Component.extend({
    */
   stripe: service(),
 
-  cardInvalid: not('cardValid'),
   cardValid: and('isCardNumberValid', 'isCVCValid', 'isExpiryValid'),
-
-  isBusyOrInvalid: or('isBusy', 'cardInvalid'),
+  isInvalid: not('cardValid'),
 
   date: computed('month', 'year', function() {
     let month = this.get('month');

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -36,6 +36,7 @@
 @import "components/comment-item";
 @import "components/create-comment-form";
 @import "components/donation/card-item";
+@import "components/donation/donation-container";
 @import "components/donations/donation-progress";
 @import "components/donations/donation-status";
 @import "components/donation-goal";

--- a/app/styles/components/donation/donation-container.scss
+++ b/app/styles/components/donation/donation-container.scss
@@ -1,0 +1,10 @@
+.donation-container {
+  .loading-indicator {
+    text-align: center;
+
+    div {
+      display: inline-block;
+      vertical-align: middle;
+    }
+  }
+}

--- a/app/templates/components/donation/credit-card.hbs
+++ b/app/templates/components/donation/credit-card.hbs
@@ -17,7 +17,6 @@
 </div>
 
 <div class="input-group">
-
   <div class="row">
     <label>
       <span>Expiration</span>
@@ -40,14 +39,11 @@
   </div>
 </div>
 
-<button
-  class="button {{unless isBusyOrInvalid "default"}} large submit-card"
-  disabled={{isBusyOrInvalid}}
-  {{action "submit"}}>
-  {{#if isBusy}}Processing...{{else}}Donate{{/if}}
+<button class="button {{unless isInvalid "default"}} large submit-card" disabled={{isInvalid}} {{action "submit"}}>
+  Donate
 </button>
 
-{{#unless isBusy}}
-  {{!validation errors can be passed in from parent, using a block}}
-  {{yield}}
-{{/unless}}
+
+{{!validation errors can be passed in from parent, using a block}}
+{{yield}}
+

--- a/app/templates/components/donation/donation-container.hbs
+++ b/app/templates/components/donation/donation-container.hbs
@@ -11,21 +11,27 @@
   </p>
 </div>
 
-{{#if card}}
-  {{donation/card-item card=card}}
+{{#if isBusy}}
+  <div class="loading-indicator">
+    <div class="spinner small"></div>
+    <div>Processing...</div>
+  </div>
 {{else}}
-  {{#donation/credit-card isBusy=isBusy submit=(action saveAndDonate)}}
+  {{#if card}}
+    {{donation/card-item card=card}}
+  {{else}}
+    {{#donation/credit-card isBusy=isBusy submit=(action saveAndDonate)}}
+      {{!show errors}}
+      {{yield}}
+    {{/donation/credit-card}}
+  {{/if}}
+
+  {{#if card}}
+    <button class="button {{unless isBusy "default"}} large donate" {{action donate}} disabled={{isBusy}}>Donate</button>
     {{!show errors}}
     {{yield}}
-  {{/donation/credit-card}}
+  {{/if}}
 {{/if}}
-
-{{#if card}}
-  <button class="button {{unless isBusy "default"}} large donate" {{action donate}} disabled={{isBusy}}>Donate</button>
-  {{!show errors}}
-  {{yield}}
-{{/if}}
-
 <footer>
   Your donation will repeat automatically each month.
   You can cancel or edit your donation at any time.

--- a/app/templates/components/donation/donation-container.hbs
+++ b/app/templates/components/donation/donation-container.hbs
@@ -20,14 +20,14 @@
   {{#if card}}
     {{donation/card-item card=card}}
   {{else}}
-    {{#donation/credit-card isBusy=isBusy submit=(action saveAndDonate)}}
+    {{#donation/credit-card submit=(action saveAndDonate)}}
       {{!show errors}}
       {{yield}}
     {{/donation/credit-card}}
   {{/if}}
 
   {{#if card}}
-    <button class="button {{unless isBusy "default"}} large donate" {{action donate}} disabled={{isBusy}}>Donate</button>
+    <button class="button default large donate" {{action donate}}>Donate</button>
     {{!show errors}}
     {{yield}}
   {{/if}}

--- a/tests/integration/components/donation/credit-card-test.js
+++ b/tests/integration/components/donation/credit-card-test.js
@@ -57,23 +57,6 @@ test('it sends submit with credit card fields when button is clicked', function(
   page.clickSubmit();
 });
 
-test('it renders button as disabled and "Processing" when busy', function(assert) {
-  assert.expect(2);
-
-  stubService(this, 'stripe', {
-    card: {
-      validateCardNumber: () => true,
-      validateCVC: () => true,
-      validateExpiry: () => true
-    }
-  });
-
-  page.render(hbs`{{donation/credit-card isBusy=true submit=submitHandler}}`);
-
-  assert.ok(page.submitDisabled, 'Submit button is disabled');
-  assert.equal(page.submitButtonText, 'Processing...', 'Submit button changed text');
-});
-
 test('it renders button as disabled and "Donate" when card is invalid', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
# What's in this PR?

Closes #811

This makes it so while anything is happening in the background on the donate page, both the card form and the card item display are replaced by a "Processing..." indicator, which includes a loading spinner.

Since the change eliminates the need for some logic in the credit-card component (namely, the busy state), commit 260044f also removes all of that code.

If this behavior is not an acceptable solution, the only alternative I can think of is to show the form **until** the whole process is done, provided the form was there at the start, or show the card item until the process is done, provided the card item was there to begin with.

The problem with that is, it would significantly complicate the logic. In order to achieve that, we should

* revert 260044f
* remove the `isBusy` wrapping from the template
* on `templates/project/donate`, replace `{{#donation/donation-container
  card=user.stripePlatformCard`with just `card=card`
* in `routes/project/donate`,  add a `model` hook that explicitly loads the project and the user's card. Then add a `setupController` hook that sets the two properties on the controller. That way, the card wont be set automatically and the UI wont switch from the form to the card half-way through.

If the current solution is acceptable, finalizing this PR is a matter of setting the right style (in case the current spinner with "Processing..." is not good).

If the proposed alternative is the way to go, then the process id described above. I don't think it would break any tests to do it that way, but as explained, it slightly complicates things.