### PR TITLE
Add account status verification to donation goals page

### DIFF
--- a/app/controllers/project/settings/donations.js
+++ b/app/controllers/project/settings/donations.js
@@ -75,6 +75,10 @@ export default Controller.extend({
       }
     },
 
+    reloadAccount() {
+      get(this, 'stripeConnectAccount').reload();
+    },
+
     /**
      * Action which commits changes to a donation goal.
      *

--- a/app/templates/components/donation-goals.hbs
+++ b/app/templates/components/donation-goals.hbs
@@ -43,8 +43,8 @@
   {{/if}}
 {{/each}}
 
-<p>
 {{#if canAdd}}
-  <button class="clear add" {{action add project}}>Add Goal</button>
+  <p>
+    <button class="clear add" {{action add project}}>Add Goal</button>
+  </p>
 {{/if}}
-</p>

--- a/app/templates/project/settings/donations.hbs
+++ b/app/templates/project/settings/donations.hbs
@@ -1,12 +1,23 @@
 <div class="settings-main">
   {{#if stripeConnectAccount}}
-    {{donation-goals
-      add=(action 'addDonationGoal')
-      cancel=(action 'cancelDonationGoal')
-      edit=(action 'editDonationGoal')
-      project=project
-      save=(action 'saveDonationGoal')
-      activateDonations=(action 'activateDonations' project)}}
+    {{#if stripeConnectAccount.chargesEnabled}}
+      {{donation-goals
+        add=(action 'addDonationGoal')
+        cancel=(action 'cancelDonationGoal')
+        edit=(action 'editDonationGoal')
+        project=project
+        save=(action 'saveDonationGoal')
+        activateDonations=(action 'activateDonations' project)}}
+    {{else}}
+      <h3>Awaiting Stripe verification...</h3>
+      <p>Your organization is now connected to stripe, but stripe still needs to verify your account</p>
+      <button
+        {{action 'reloadAccount'}}
+        class="{{unless stripeConnectAccount.isReloading "default"}} refresh"
+        disabled={{stripeConnectAccount.isReloading}}>
+        {{#if stripeConnectAccount.isReloading}}Refreshing...{{else}}Refresh status{{/if}}
+      </button>
+    {{/if}}
   {{else}}
     {{#if stripeAuth}}
       <div class="header-section">

--- a/tests/acceptance/project-donation-goals-test.js
+++ b/tests/acceptance/project-donation-goals-test.js
@@ -36,12 +36,40 @@ test('it redirects to project list page if user is not allowed to manage donatio
   });
 });
 
+test('it allows refreshing account if account does not have charges enabled yet', function(assert) {
+  assert.expect(3);
+
+  let project = createProjectWithSluggedRoute();
+  let { organization } = project;
+  let account = organization.createStripeConnectAccount({ chargesEnabled: false });
+
+  authenticateAsMemberOfRole(this.application, server, organization, 'owner');
+
+  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
+
+  andThen(() => {
+    server.get('stripe-connect-accounts/:id', function() {
+      assert.ok(true, 'Refresh was called');
+      account.chargesEnabled = true;
+
+      return account;
+    });
+
+    assert.equal(projectSettingsDonationsPage.editedDonationGoals().count, 0, 'Form is not visible');
+    projectSettingsDonationsPage.clickRefreshAccount();
+  });
+
+  andThen(() => {
+    assert.equal(projectSettingsDonationsPage.editedDonationGoals().count, 1, 'Form is now visible');
+  });
+});
+
 test('it renders existing donation goals', function(assert) {
   assert.expect(1);
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 3, { project });
   server.createList('donation-goal', 2);
 
@@ -59,7 +87,7 @@ test('it sets up a new unsaved donation goal if there are no donation goals, whi
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
@@ -87,7 +115,7 @@ test('it is possible to add a donation goal when donation goals already exists',
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 1, { project });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
@@ -116,7 +144,7 @@ test('it allows editing of existing donation goals', function(assert) {
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 1, { project });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
@@ -145,7 +173,7 @@ test('cancelling edit of an unsaved new goal removes that goal from the list', f
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 1, { project });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
@@ -169,7 +197,7 @@ test('cancelling edit of an unsaved existing goal keeps that goal in the list', 
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 1, { project });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
@@ -193,7 +221,7 @@ test('it allows activating donations for the project', function(assert) {
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 1, { project });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
@@ -220,7 +248,7 @@ test('it shows donation progress if donations are active', function(assert) {
     organization
   });
 
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
   server.createList('donation-goal', 1, { project });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
@@ -240,7 +268,7 @@ test('it does not show donation progress if donations are not active', function(
     donationsActive: false,
     organization
   });
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
@@ -256,7 +284,7 @@ test('it renders validation errors', function(assert) {
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 
@@ -300,7 +328,7 @@ test('it renders other errors', function(assert) {
 
   let project = createProjectWithSluggedRoute();
   let { organization } = project;
-  organization.createStripeConnectAccount();
+  organization.createStripeConnectAccount({ chargesEnabled: true });
 
   authenticateAsMemberOfRole(this.application, server, organization, 'owner');
 

--- a/tests/pages/project/settings/donations.js
+++ b/tests/pages/project/settings/donations.js
@@ -47,5 +47,6 @@ export default create({
 
   clickActivateDonationGoals: clickable('.activate-donations'),
   clickAddNew: clickable('.add'),
+  clickRefreshAccount: clickable('.refresh'),
   clickStripeConnectButton: clickable('.stripe-connect')
 });


### PR DESCRIPTION
# What's in this PR?

This adds a button to the `project.settings.donations` route, labeled "Refresh status".

Clicking this button triggers a reload of the `stripeConnectAccount` record for the project's organization.

This button is only visible if there is already a `stripeConnectAccount` record for the current organization, and if the `chargesEnabled` property of that account is set to false. 

The button is shown **instead** of the donation goal management UI (list and forms), so the user will not be able to add or edit donation goals, or create a plan for the project, until `stripeConnectAccount.chargesEnabled` value is `true`.

## References
Fixes #816

