### PR TITLE
Fix issues with organization membership reloading

### DIFF
--- a/app/abilities/organization.js
+++ b/app/abilities/organization.js
@@ -9,19 +9,17 @@ const {
 export default Ability.extend({
   credentials: service(),
 
-  isAtLeastAdmin: or('membership.isAdmin', 'membership.isOwner'),
-  userCanJoinOrganization: empty('membership'),
-  userCanLeaveOrganization: or('membership.isContributor', 'membership.isAdmin'),
-  userIsMemberInOrganization: notEmpty('membership'),
-
-  isAtLeastContributor: or('membership.isContributor', 'membership.isAdmin', 'membership.isOwner'),
-
-  canJoin: alias('userCanJoinOrganization'),
-  canManage: alias('isAtLeastAdmin'),
-
   canCreateIssueTask: true,
   canCreateIdeaTask: true,
   canCreateTaskTask: alias('isAtLeastContributor'),
+  canJoin: alias('userCanJoinOrganization'),
+  canManage: alias('isAtLeastAdmin'),
+
+  isAtLeastAdmin: or('membership.isAdmin', 'membership.isOwner'),
+  isAtLeastContributor: or('membership.isContributor', 'membership.isAdmin', 'membership.isOwner'),
+  userCanJoinOrganization: empty('membership'),
+  userCanLeaveOrganization: or('membership.isContributor', 'membership.isAdmin'),
+  userIsMemberInOrganization: notEmpty('membership'),
 
   membership: alias('credentials.membership'),
   organization: alias('model')

--- a/app/components/organization-menu.js
+++ b/app/components/organization-menu.js
@@ -1,12 +1,9 @@
 import Ember from 'ember';
 
 const {
-  Component,
-  inject: { service }
+  Component
 } = Ember;
 
 export default Component.extend({
-  classNames: ['organization-menu', 'horizontal-menu'],
-
-  credentials: service()
+  classNames: ['organization-menu', 'horizontal-menu']
 });

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -3,7 +3,11 @@ import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import Ember from 'ember';
 
-const { computed } = Ember;
+const {
+  computed: {
+    alias, filterBy, gt, mapBy
+  }
+} = Ember;
 
 export default Model.extend({
   base64IconData: attr(),
@@ -17,9 +21,9 @@ export default Model.extend({
   projects: hasMany('project', { async: true }),
   stripeConnectAccount: belongsTo('stripe-connect-account', { async: true }),
 
-  hasPendingMembers: computed.gt('pendingMembersCount', 0),
-  organizationMembers: computed.mapBy('organizationMemberships', 'member'),
-  pendingMembersCount: computed.alias('pendingMemberships.length'),
-  pendingMemberships: computed.filterBy('organizationMemberships', 'isPending'),
-  totalMembersCount: computed.alias('organizationMembers.length')
+  hasPendingMembers: gt('pendingMembersCount', 0),
+  organizationMembers: mapBy('organizationMemberships', 'member'),
+  pendingMembersCount: alias('pendingMemberships.length'),
+  pendingMemberships: filterBy('organizationMemberships', 'isPending'),
+  totalMembersCount: alias('organizationMembers.length')
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -7,7 +7,8 @@ const {
   get,
   inject: { service },
   isPresent,
-  Route
+  Route,
+  set
 } = Ember;
 
 export default Route.extend(ApplicationRouteMixin, {
@@ -153,7 +154,7 @@ export default Route.extend(ApplicationRouteMixin, {
   beforeModel(transition) {
     return this._loadCurrentUser().then(() => {
       if (this._shouldTransitionToOnboardingRoute(transition)) {
-        return this.transitionTo(this.get('onboardingRoute'));
+        return this.transitionTo(get(this, 'onboardingRoute'));
       } else {
         return this._super(...arguments);
       }
@@ -195,31 +196,31 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   _attemptTransition() {
-    if (this.get('isOnboarding')) {
-      this.transitionTo(this.get('onboardingRoute'));
+    if (get(this, 'isOnboarding')) {
+      this.transitionTo(get(this, 'onboardingRoute'));
     } else {
-      let attemptedTransition = this.get('session.attemptedTransition');
+      let attemptedTransition = get(this, 'session.attemptedTransition');
       if (isPresent(attemptedTransition)) {
         attemptedTransition.retry();
-        this.set('session.attemptedTransition', null);
+        set(this, 'session.attemptedTransition', null);
       } else {
         this.transitionTo('projects-list');
       }
     }
   },
 
-  _loadCurrentUser() {
-    return this.get('currentUser').loadCurrentUser();
+  _invalidateSession() {
+    get(this, 'session').invalidate();
   },
 
-  _invalidateSession() {
-    this.get('session').invalidate();
+  _loadCurrentUser() {
+    return get(this, 'currentUser').loadCurrentUser();
   },
 
   _shouldTransitionToOnboardingRoute(transition) {
-    let isOnboarding = this.get('isOnboarding');
+    let isOnboarding = get(this, 'isOnboarding');
 
-    let onboardingRoutes = this.get('onboarding.routes');
+    let onboardingRoutes = get(this, 'onboarding.routes');
     let targetRoute = transition.targetName;
     let isTransitionToOnboardingRoute = (onboardingRoutes.indexOf(targetRoute) > -1);
 

--- a/app/routes/organizations/slugged-route/settings.js
+++ b/app/routes/organizations/slugged-route/settings.js
@@ -3,6 +3,7 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import { CanMixin } from 'ember-can';
 
 const {
+  get,
   Route,
   inject: { service }
 } = Ember;
@@ -13,7 +14,7 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
 
   beforeModel() {
     let organization = this.modelFor('organizations.slugged-route');
-    return this.get('credentials.membershipPromise').then((membership) => {
+    return get(this, 'credentials.membershipPromise').then((membership) => {
       if (this.cannot('manage organization', organization, { membership })) {
         return this.transitionTo('index');
       } else {

--- a/app/routes/organizations/slugged-route/settings.js
+++ b/app/routes/organizations/slugged-route/settings.js
@@ -14,7 +14,7 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
 
   beforeModel() {
     let organization = this.modelFor('organizations.slugged-route');
-    return get(this, 'credentials.membershipPromise').then((membership) => {
+    return get(this, 'credentials').fetchMembership().then((membership) => {
       if (this.cannot('manage organization', organization, { membership })) {
         return this.transitionTo('index');
       } else {

--- a/app/routes/project/settings.js
+++ b/app/routes/project/settings.js
@@ -3,6 +3,7 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import { CanMixin } from 'ember-can';
 
 const {
+  get,
   Route,
   inject: { service }
 } = Ember;
@@ -12,9 +13,9 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
   session: service(),
 
   beforeModel() {
-    if (this.get('session.isAuthenticated')) {
+    if (get(this, 'session.isAuthenticated')) {
       let organization = this.modelFor('project.organization');
-      return this.get('credentials.membershipPromise').then((membership) => {
+      return get(this, 'credentials.membershipPromise').then((membership) => {
         if (this.cannot('manage organization', organization, { membership })) {
           return this.transitionTo('index');
         } else {

--- a/app/routes/project/settings.js
+++ b/app/routes/project/settings.js
@@ -15,7 +15,7 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
   beforeModel() {
     if (get(this, 'session.isAuthenticated')) {
       let organization = this.modelFor('project.organization');
-      return get(this, 'credentials.membershipPromise').then((membership) => {
+      return get(this, 'credentials').fetchMembership().then((membership) => {
         if (this.cannot('manage organization', organization, { membership })) {
           return this.transitionTo('index');
         } else {

--- a/app/services/credentials.js
+++ b/app/services/credentials.js
@@ -20,7 +20,7 @@ export default Service.extend({
 
   membership: computed('memberships', 'user', {
     get() {
-      get(this, 'membershipPromise').then((membership) => {
+      this.fetchMembership().then((membership) => {
         set(this, 'membership', membership);
       });
       return null;
@@ -32,18 +32,21 @@ export default Service.extend({
 
   // Memberships may not be loaded, so we need to wait for them to resolve
   // Can be useful in routing when we need it loaded to prevent a transition
-  membershipPromise: computed('memberships', 'user', function() {
-    let memberships = get(this, 'memberships');
-    let fulfilled = get(this, 'memberships.isFulfilled');
-    if (fulfilled) {
-      let membership = memberships.find((membership) => this._findMembership(membership));
-      return RSVP.resolve(membership);
-    } else {
-      return memberships.then((memberships) => {
-        return memberships.find((membership) => this._findMembership(membership));
-      });
-    }
-  }),
+  fetchMembership() {
+    return new RSVP.Promise((resolve) => {
+      let memberships = get(this, 'memberships');
+      let fulfilled = get(this, 'memberships.isFulfilled');
+      if (fulfilled) {
+        let membership = memberships.find((membership) => this._findMembership(membership));
+        resolve(membership);
+      } else {
+        memberships.then((memberships) => {
+          let membership = memberships.find((membership) => this._findMembership(membership));
+          resolve(membership);
+        });
+      }
+    });
+  },
 
   memberships: alias('organization.organizationMemberships'),
 

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -5,7 +5,8 @@ const {
   inject: { service },
   isEmpty,
   RSVP,
-  Service
+  Service,
+  set
 } = Ember;
 
 export default Service.extend({
@@ -15,10 +16,10 @@ export default Service.extend({
 
   loadCurrentUser() {
     return new RSVP.Promise((resolve, reject) => {
-      let userId = this.get('session.session.authenticated.user_id');
+      let userId = get(this, 'session.session.authenticated.user_id');
       if (!isEmpty(userId)) {
         return get(this, 'store').findRecord('user', userId).then((user) => {
-          this.set('user', user);
+          set(this, 'user', user);
           this._identifyUser(user);
           resolve(user);
         }, reject);
@@ -31,14 +32,14 @@ export default Service.extend({
   _identifyUser(user) {
     // Segment
     get(this, 'metrics').identify({
-      distinctId: user.get('id'),
-      biography: user.get('biography'),
-      insertedAt: user.get('insertedAt'),
-      email: user.get('email'),
-      name: user.get('name'),
-      state: user.get('state'),
-      username: user.get('username'),
-      website: user.get('website')
+      distinctId: get(user, 'id'),
+      biography: get(user, 'biography'),
+      insertedAt: get(user, 'insertedAt'),
+      email: get(user, 'email'),
+      name: get(user, 'name'),
+      state: get(user, 'state'),
+      username: get(user, 'username'),
+      website: get(user, 'website')
     });
   }
 });

--- a/app/templates/components/organization-settings-menu.hbs
+++ b/app/templates/components/organization-settings-menu.hbs
@@ -1,6 +1,6 @@
 <ul>
   {{#if session.isAuthenticated}}
-    {{#if (can 'manage organization')}}
+    {{#if (can 'manage organization' organization)}}
       <li>
         {{#link-to 'organizations.slugged-route.settings.profile' organization.slug}}
           Organization Profile

--- a/app/templates/components/project-details.hbs
+++ b/app/templates/components/project-details.hbs
@@ -13,7 +13,7 @@
   <div class="right">
     <p class="join-project">
     {{#if session.isAuthenticated}}
-      {{#if (can "join organization" project.organization membership=credentials.membership)}}
+      {{#if (can "join organization" project.organization)}}
         <button class="default small" {{action 'joinProject'}}>Join project</button>
       {{/if}}
       {{#if credentials.userMembershipIsPending}}

--- a/app/templates/components/project-long-description.hbs
+++ b/app/templates/components/project-long-description.hbs
@@ -1,7 +1,7 @@
 {{#if descriptionIsBlank}}
   <div class="long-description empty">
     <div class="long-description-inner">
-      {{#if (can "manage organization" project.organization membership=credentials.membership)}}
+      {{#if (can "manage organization" project.organization)}}
         <div class="no-description user-can-add">
           <h3>Add your project description.</h3>
           <div class="box-icon"></div>
@@ -27,7 +27,7 @@
     {{#unless inEditMode}}
       <div class="long-description-header">
         <h3>About this project</h3>
-        {{#if (can "manage organization" project.organization membership=credentials.membership)}}
+        {{#if (can "manage organization" project.organization)}}
           <button class="clear small" name="edit" {{action 'edit'}}>Edit description</button>
         {{/if}}
       </div>
@@ -36,7 +36,7 @@
   </div>
 {{/if}}
 
-{{#if (can "manage organization" project.organization membership=credentials.membership)}}
+{{#if (can "manage organization" project.organization)}}
   {{#if shouldDisplayEditor}}
     <div class="long-description-editor">
       {{editor-with-preview input=project.longDescriptionMarkdown isLoading=project.isSaving modifiedSubmit="save"}}

--- a/app/templates/components/project-menu.hbs
+++ b/app/templates/components/project-menu.hbs
@@ -1,7 +1,7 @@
 <li>{{link-to 'About' 'project.index' project}}</li>
 <li>{{#link-to 'project.tasks' project}}Tasks {{#if project.hasOpenTasks}}<span class="info">{{project.openTasksCount}}</span>{{/if}}{{/link-to}}</li>
 {{#if session.isAuthenticated}}
-  {{#if (can "manage organization" project.organization membership=credentials.membership)}}
+  {{#if (can "manage organization" project.organization)}}
     <li class="contributors">
       {{#link-to 'project.settings.contributors' project}}Contributors {{#if project.hasPendingMembers}}<span class="info"><strong>{{project.pendingMembersCount}}</strong> pending</span>{{/if}}{{/link-to}}
     </li>

--- a/app/templates/components/project-settings-menu.hbs
+++ b/app/templates/components/project-settings-menu.hbs
@@ -1,6 +1,6 @@
 <ul>
   {{#if session.isAuthenticated}}
-    {{#if (can "manage organization" project.organization membership=credentials.membership) }}
+    {{#if (can "manage organization" project.organization) }}
       <li>
         {{link-to "Contributors" "project.settings.contributors" project.slug}}
       </li>

--- a/app/templates/components/task-new-form.hbs
+++ b/app/templates/components/task-new-form.hbs
@@ -2,13 +2,13 @@
 <div class="task-new-form-body">
   <div class="input-group task-type {{task.taskType}}">
     <select autofocus="autofocus" tabindex="1" class={{task.taskType}} name="task-type" onchange={{action (mut task.taskType) value="target.value"}} value={{task.taskType}}>
-      {{#if (can "create task task in organization" organization membership=credentials.membership)}}
+      {{#if (can "create task task in organization" organization)}}
         <option value="task" selected={{eq task.taskType 'task'}}>Task</option>
       {{/if}}
-      {{#if (can "create issue task in organization" organization membership=credentials.membership)}}
+      {{#if (can "create issue task in organization" organization)}}
         <option value="issue" selected={{eq task.taskType 'issue'}}>Issue</option>
       {{/if}}
-      {{#if (can "create idea task in organization" organization membership=credentials.membership)}}
+      {{#if (can "create idea task in organization" organization)}}
         <option value="idea" selected={{eq task.taskType 'idea'}}>Idea</option>
       {{/if}}
     </select>

--- a/tests/acceptance/organization-test.js
+++ b/tests/acceptance/organization-test.js
@@ -1,13 +1,8 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
 import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
-import Ember from 'ember';
 import createOrganizationWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-organization-with-slugged-route';
 import organizationPage from '../pages/organization';
-
-const {
-  run
-} = Ember;
 
 moduleForAcceptance('Acceptance | Organization');
 
@@ -55,15 +50,13 @@ test('an admin can navigate to settings', function(assert) {
 
   andThen(() => {
     assert.ok(organizationPage.projectsMenuItemIsActive, 'The organization projects menu is active');
-    run.next(() => {
-      organizationPage.clickSettingsMenuItem();
-      andThen(() => {
-        assert.ok(organizationPage.settingsMenuItemIsActive, 'The organization settings menu is active');
-        assert.equal(organizationPage.settingsForm.isVisible, true, 'The organization settings form renders');
-      });
-    });
+    organizationPage.clickSettingsMenuItem();
   });
 
+  andThen(() => {
+    assert.ok(organizationPage.settingsMenuItemIsActive, 'The organization settings menu is active');
+    assert.equal(organizationPage.settingsForm.isVisible, true, 'The organization settings form renders');
+  });
 });
 
 test('anyone can navigate to projects', function(assert) {

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -284,7 +284,7 @@ test('Paging and filtering uses query parameters', function(assert) {
 });
 
 test('A user can join the organization of the project', function(assert) {
-  assert.expect(5);
+  assert.expect(4);
 
   let project = createProjectWithSluggedRoute();
   let projectURL = `/${project.organization.slug}/${project.slug}/`;
@@ -305,25 +305,9 @@ test('A user can join the organization of the project', function(assert) {
     joinButton.click();
   });
 
-  server.post('/organization-memberships', (db, request) => {
-    let { attributes, relationships } = JSON.parse(request.requestBody).data;
-    assert.equal(attributes.role, 'pending');
-    assert.equal(relationships.member.data.id, user.id);
-    assert.equal(relationships.organization.data.id, project.organization.id);
-
-    return {
-      data: {
-        id: 1,
-        type: 'organization-membership',
-        attributes,
-        relationships
-      }
-    };
-  });
-
   andThen(() => {
     let joinButton = projectTasksIndexPage.projectDetails.joinProjectButton;
-    assert.equal(joinButton.text, 'Membership Pending', 'The button to join has changed to pending');
+    assert.equal(joinButton.text, 'Membership pending', 'The button to join has changed to pending');
     assert.ok(joinButton.disabled, 'Button should be disabled.');
   });
 });

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -305,14 +305,11 @@ test('A user can join the organization of the project', function(assert) {
     joinButton.click();
   });
 
-  let done = assert.async();
-
   server.post('/organization-memberships', (db, request) => {
     let { attributes, relationships } = JSON.parse(request.requestBody).data;
     assert.equal(attributes.role, 'pending');
     assert.equal(relationships.member.data.id, user.id);
     assert.equal(relationships.organization.data.id, project.organization.id);
-    done();
 
     return {
       data: {
@@ -322,5 +319,11 @@ test('A user can join the organization of the project', function(assert) {
         relationships
       }
     };
+  });
+
+  andThen(() => {
+    let joinButton = projectTasksIndexPage.projectDetails.joinProjectButton;
+    assert.equal(joinButton.text, 'Membership Pending', 'The button to join has changed to pending');
+    assert.ok(joinButton.disabled, 'Button should be disabled.');
   });
 });

--- a/tests/pages/components/project-details.js
+++ b/tests/pages/components/project-details.js
@@ -7,7 +7,8 @@ export default {
 
   joinProjectButton: {
     scope: '.join-project button',
-    href: attribute('href')
+    href: attribute('href'),
+    disabled: attribute('disabled')
   },
 
   signUpLink: {


### PR DESCRIPTION
# What's in this PR?

Fixes #824.

The issue is directly related to https://github.com/minutebase/ember-can/issues/20, which I missed somehow when trying to see if there were related issues.

The complexity of this service grew to rely on being promise-aware due to `beforeModel()` hooks in routes that prevent transitions. Those worked fine, but the computed properties throughout the application's templates did not.

This also works with Mirage now. 👏 

There are a few things I'm not satisfied with in the current implementation, that can maybe go into a separate issue to refactor later now that this is working, in order from smallest to largest refactorings:

- We could maybe stand to rewrite the promise logic and see if we can collapse the API from `membership` and `membershipPromise` into a single API. I'm not sure this is possible given the `ember-can` issue above.
- This service is poorly named. `credentials` does not really make clear what we're doing here, which is checking for organization permissions. Maybe even just `organization-permissions` would be a better name.
- We're acting like this is something akin to the `onboarding` service, which is application-wide, a design decision driven by being on a project route or organization route. On the route? Set the current organization in the service. This doesn't reflect other use cases, though, like checking for organization permissions in a list of organizations. Suggest that we consider thinking more functionally here.
- I'm not entirely positive that the Ember application should even be responsible for any of the complexity here. I would like to consider hiding most of the complex permission logic inside of the user via the JWT. Updates to the user's data would then reflect in organization permissions.