### PR TITLE
Rework funds-recipient into a wrapper

### DIFF
--- a/app/components/payments/funds-recipient.js
+++ b/app/components/payments/funds-recipient.js
@@ -1,40 +1,18 @@
 import Ember from 'ember';
 
 const {
-  Component, get, set
+  Component,
+  computed,
+  get
 } = Ember;
 
 export default Component.extend({
-  tagName: 'form',
+  classNameBindings: ['statusClass'],
   classNames: ['funds-recipient'],
 
-  init() {
-    this.setProperties(get(this, 'fundsRecipient'));
-    set(this, 'dobDay', 1);
-    set(this, 'dobMonth', 1);
-    set(this, 'dobYear', 2016);
-    set(this, 'country', 'US');
-    this._super(...arguments);
-  },
+  status: computed.alias('account.recipientStatus'),
 
-  actions: {
-    setBusinessType(value) {
-      set(this, 'businessType', value);
-    },
-
-    setRecipientType(value) {
-      set(this, 'recipientType', value);
-    },
-
-    submit() {
-      let fundsRecipient = this.getProperties(
-        'recipientType',
-        'businessType', 'businessName', 'businessEin',
-        'firstName', 'lastName', 'ssnLast4',
-        'dobDay', 'dobMonth', 'dobYear',
-        'address1', 'address2', 'city', 'state', 'country', 'zip'
-      );
-      this.sendAction('recipientInformationSubmitted', fundsRecipient);
-    }
-  }
+  statusClass: computed('status', function() {
+    return `account-setup__section--${get(this, 'status')}`;
+  })
 });

--- a/app/templates/components/payments/account-setup.hbs
+++ b/app/templates/components/payments/account-setup.hbs
@@ -3,7 +3,10 @@
 {{payments/contact-info email=email}}
 
 {{payments/funds-recipient
-  fundsRecipient=fundsRecipient
-  recipientInformationSubmitted=(action onRecipientInformationSubmitted email)}}
+  account=account
+  isBusy=isBusy
+  onRecipientDetailsSubmitted=(action onRecipientDetailsSubmitted)
+  onVerificationDocumentSubmitted=(action onVerificationDocumentSubmitted)
+  onPersonalIdNumberSubmitted=(action onPersonalIdNumberSubmitted)}}
 
 {{payments/bank-account account=account isBusy=isBusy submit=(action onBankAccountInformationSubmitted)}}

--- a/app/templates/components/payments/funds-recipient.hbs
+++ b/app/templates/components/payments/funds-recipient.hbs
@@ -1,65 +1,37 @@
-<div class="input-group">
-  <label for="recipient-type">Recipient Type</label>
-  <select onchange={{action (mut recipientType) value="target.value"}} name="recipient-type" value={{recipientType}}>
-    <option value="individual">Individual</option>
-    <option value="company">Business</option>
-  </select>
-</div>
+<aside>
+  {{#if (eq status 'verified')}}
+    <span></span>
+  {{/if}}
+  <h1>Funds Recipient</h1>
+</aside>
 
-{{#if (eq recipientType 'company')}}
-  <div class="input-group">
-    <label for="business-name">Business Name</label>
-    {{input type="text" name="business-name" value=businessName}}
-  </div>
-  <div class="input-group">
-    <label for="business-ein">Business EIN</label>
-    {{input type="text" name="business-ein" value=businessEin}}
-  </div>
+{{#if (eq status 'required')}}
+  <section class="details-form">
+    TODO: details-form-component goes here
+  </section>
 {{/if}}
 
+{{#if (eq status 'verifying')}}
+  <section class="verification-document">
+    TODO: verification-document component goes here
+  </section>
+  <section class="personal-id-number">
+    TODO: personal-id-number component goes here
+  </section>
+{{/if}}
 
-{{!identity}}
+{{#if (eq status 'verified')}}
+  <section>
+    <div class="funds-recipient__individual-name">
+      <label>Name</label>
+      <p>{{account.individualName}}</p>
+    </div>
 
-<div class="input-group">
-  <label for="first-name">First Name</label>
-  {{input type="text" name="first-name" value=firstName}}
-</div>
-<div class="input-group">
-  <label for="last-name">Last Name</label>
-  {{input type="text" name="last-name" value=lastName}}
-</div>
-<div class="input-group">
-  {{select/birth-date day=dobDay month=dobMonth year=dobYear}}
-</div>
-<div class="input-group">
-  <div class="input-group">
-    <label for="address-1">Address 1</label>
-    {{input type="text" name="address-1" value=address1}}
-  </div>
-  <div class="input-group">
-    <label for="address-2">Address 2</label>
-    {{input type="text" name="address-2" value=address2}}
-  </div>
-  <div class="input-group">
-    <label for="city">City</label>
-    {{input type="text" name="city" value=city}}
-  </div>
-  <div class="input-group">
-    <label for="state">State</label>
-    {{select/state-select state=state}}
-  </div>
-  <div class="input-group">
-    <label for="zip">Postal Code</label>
-    {{input type="text" name="zip" value=zip}}
-  </div>
-  <div class="input-group">
-    <label for="country">Country</label>
-    {{select/country-select country=country}}
-  </div>
-</div>
-<div class="input-group">
-  <label for="ssn-last4">SSN Last 4</label>
-  {{input type="text" name="ssn-last4" value=ssnLast4}}
-</div>
-
-<input class="default" type="submit" {{action "submit"}} value="Submit information" />
+    {{#if (eq account.recipientType 'business')}}
+      <div class="funds-recipient__business-name">
+        <label>Business Name</label>
+        <p>{{account.businessName}}</p>
+      </div>
+    {{/if}}
+  </section>
+{{/if}}

--- a/app/templates/project/settings/donations/payments.hbs
+++ b/app/templates/project/settings/donations/payments.hbs
@@ -1,8 +1,11 @@
 {{payments/account-setup
-  account=project.organization.stripeConnectAccount
+  account=stripeConnectAccount
+  email=user.email
   isBusy=isBusy
   onBankAccountInformationSubmitted=(action 'onBankAccountInformationSubmitted')
-  onRecipientInformationSubmitted=(action 'onRecipientInformationSubmitted' project.organization)
+  onPersonalIdNumberSubmitted=(action 'onPersonalIdNumberSubmitted')
+  onRecipientDetailsSubmitted=(action 'onRecipientDetailsSubmitted')
+  onVerificationDocumentSubmitted=(action 'onVerificationDocumentSubmitted')
   organizationName=project.organization.name
 }}
 {{#if error}}

--- a/tests/integration/components/payments/account-setup-test.js
+++ b/tests/integration/components/payments/account-setup-test.js
@@ -12,13 +12,32 @@ const {
 let page = PageObject.create(accountSetupComponent);
 
 function setHandlers(context, {
-  onRecipientInformationSubmittedHandler = K,
-  onBankAccountInformationSubmittedHandler = K
+  onRecipientDetailsSubmitted = K,
+  onVerificationDocumentSubmitted = K,
+  onPersonalIdNumberSubmitted = K,
+  onBankAccountInformationSubmitted = K
 } = {}) {
   context.setProperties({
-    onRecipientInformationSubmittedHandler,
-    onBankAccountInformationSubmittedHandler
+    onRecipientDetailsSubmitted,
+    onVerificationDocumentSubmitted,
+    onPersonalIdNumberSubmitted,
+    onBankAccountInformationSubmitted
   });
+}
+
+function renderPage() {
+  page.render(hbs`
+    {{payments/account-setup
+      account=account
+      email=email
+      isBusy=isBusy
+      onRecipientDetailsSubmitted=onRecipientDetailsSubmitted
+      onVerificationDocumentSubmitted=onVerificationDocumentSubmitted
+      onPersonalIdNumberSubmitted=onPersonalIdNumberSubmitted
+      onBankAccountInformationSubmitted=onBankAccountInformationSubmitted
+      organizationName=project.organization.name
+    }}
+  `);
 }
 
 moduleForComponent('payments/account-setup', 'Integration | Component | payments/account setup', {
@@ -32,37 +51,13 @@ moduleForComponent('payments/account-setup', 'Integration | Component | payments
   }
 });
 
-test('it renders', function(assert) {
-  page.render(hbs`
-    {{payments/account-setup
-      onRecipientInformationSubmitted=onRecipientInformationSubmittedHandler
-      onBankAccountInformationSubmitted=onBankAccountInformationSubmittedHandler}}
-  `);
-  assert.equal(this.$('.account-setup').length, 1, 'Component renders');
+test('it renders all subcomponents', function(assert) {
+  assert.expect(2);
+  renderPage();
+
+  assert.ok(page.rendersFundsRecipient, 'Funds recipient subpcomponent is rendered.');
+  assert.ok(page.rendersBankAccount, 'Bank account subcomponent is rendered.');
 });
 
 // TODO: Write tests, remove 'it renders' test
-//
-// test('it renders correctly for individual', function(assert) {
-//   assert.expect(0);
 
-//   page.render(hbs`{{payments/account-setup accountInformationSubmitted=submitHandler}}`);
-// });
-
-// test('it renders correctly for business', function(assert) {
-//   assert.expect(0);
-
-//   page.render(hbs`{{payments/account-setup accountInformationSubmitted=submitHandler}}`);
-// });
-
-// test('it submits correctly for individual', function(assert) {
-//   assert.expect(0);
-
-//   page.render(hbs`{{payments/account-setup accountInformationSubmitted=submitHandler}}`);
-// });
-
-// test('it submits correctly for business', function(assert) {
-//   assert.expect(0);
-
-//   page.render(hbs`{{payments/account-setup accountInformationSubmitted=submitHandler}}`);
-// });

--- a/tests/integration/components/payments/funds-recipient-test.js
+++ b/tests/integration/components/payments/funds-recipient-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import PageObject from 'ember-cli-page-object';
@@ -6,9 +7,29 @@ import fundsRecipientComponent from '../../../pages/components/payments/funds-re
 
 let page = PageObject.create(fundsRecipientComponent);
 
+const {
+  setProperties,
+  K
+} = Ember;
+
+function setHandlers(context, { detailsHandler = K, documentHandler = K, idHandler = K }) {
+  setProperties(context, { detailsHandler, documentHandler, idHandler });
+}
+
+function renderPage() {
+  page.render(
+    hbs`{{payments/funds-recipient
+          account=account
+          onRecipientDetailsSubmitted=detailsHandler
+          onVerificationDocumentSubmitted=documentHandler
+          onPersonalIdNumberSubmitted=idHandler}}`
+  );
+}
+
 moduleForComponent('payments/funds-recipient', 'Integration | Component | payments/funds recipient', {
   integration: true,
   beforeEach() {
+    setHandlers(this, {});
     page.setContext(this);
   },
   afterEach() {
@@ -16,11 +37,99 @@ moduleForComponent('payments/funds-recipient', 'Integration | Component | paymen
   }
 });
 
-test('it renders', function(assert) {
-  page.render(hbs`{{payments/funds-recipient}}`);
-  assert.equal(this.$('.funds-recipient').length, 1, 'Component renders');
+test('it renders correctly when "pending"', function(assert) {
+  assert.expect(1);
+
+  let account = { recipientStatus: 'pending_requirement' };
+  this.set('account', account);
+
+  renderPage();
+
+  assert.ok(page.rendersPending, 'Component is rendered in pending mode.');
 });
 
-// TODO: Write tests, remove 'it renders' test
+test('it renders correctly when "required"', function(assert) {
+  assert.expect(2);
 
-// test('it sends out recipient info parameters on submit')
+  let account = { recipientStatus: 'required' };
+  this.set('account', account);
+
+  renderPage();
+
+  assert.ok(page.rendersRequired, 'Component is rendered in required mode.');
+  assert.ok(page.rendersDetailsForm, 'Component renders the details form subcomponent.');
+});
+
+test('it renders correctly when "verifying"', function(assert) {
+  assert.expect(3);
+
+  let account = { recipientStatus: 'verifying' };
+  this.set('account', account);
+
+  renderPage();
+
+  assert.ok(page.rendersVerifying, 'Component is rendered in verifying mode.');
+  assert.ok(page.rendersVerificationDocument, 'Component renders the verification document subcomponent.');
+  assert.ok(page.rendersPersonalIdNumber, 'Component renders the personal id number subcomponent.');
+});
+
+test('it renders correctly when "verified"', function(assert) {
+  assert.expect(2);
+
+  let account = {
+    recipientStatus: 'verified',
+    individualName: 'Joe Individual'
+  };
+  this.set('account', account);
+
+  renderPage();
+
+  assert.ok(page.rendersVerified, 'Component is rendered in verified mode.');
+  assert.equal(page.individualNameText, 'Joe Individual', 'Component renders the name of the registered individual.');
+});
+
+test('it renders correctly when "verified" for business', function(assert) {
+  assert.expect(3);
+
+  let account = {
+    recipientStatus: 'verified',
+    individualName: 'Joe Individual',
+    businessName: 'Company Inc.',
+    recipientType: 'business'
+  };
+  this.set('account', account);
+
+  renderPage();
+
+  assert.ok(page.rendersVerified, 'Component is rendered in verified mode.');
+  assert.ok(page.individualNameText, 'Joe Individual', 'Component renders the name of the registered individual.');
+  assert.ok(page.businessNameText, 'Company Inc.', 'Component renders the name of the registered business.');
+});
+
+// TODO: These need to be implemented once subcomponents are done and pass out actions
+// test('it passes out submit action from details subcomponent', function(assert) {
+//   assert.expect(1);
+
+//   let account = { recipientStatus: 'required' };
+//   this.set('account', account);
+
+//   renderPage();
+// });
+
+// test('it passes out submit action from document upload subcomponent', function(assert) {
+//   assert.expect(1);
+
+//   let account = { recipientStatus: 'verifying' };
+//   this.set('account', account);
+
+//   renderPage();
+// });
+
+// test('it passes out submit action from personal id number subcomponent', function(assert) {
+//   assert.expect(1);
+
+//   let account = { recipientStatus: 'verifying' };
+//   this.set('account', account);
+
+//   renderPage();
+// });

--- a/tests/pages/components/payments/account-setup.js
+++ b/tests/pages/components/payments/account-setup.js
@@ -1,9 +1,14 @@
+import { isVisible } from 'ember-cli-page-object';
+
 import bankAccountComponent from './bank-account';
 import contactInfoComponent from './contact-info';
 import fundsRecipientComponent from './funds-recipient';
 
 export default {
   scope: '.account-setup',
+
+  rendersFundsRecipient: isVisible('.funds-recipient'),
+  rendersBankAccount: isVisible('.bank-account'),
 
   bankAccount: bankAccountComponent,
   contactInfo: contactInfoComponent,

--- a/tests/pages/components/payments/funds-recipient.js
+++ b/tests/pages/components/payments/funds-recipient.js
@@ -1,3 +1,17 @@
+import { hasClass, isVisible, text } from 'ember-cli-page-object';
+
 export default {
-  scope: '.funds-recipient'
+  scope: '.funds-recipient',
+
+  rendersPending: hasClass('account-setup__section--pending_requirement'),
+  rendersRequired: hasClass('account-setup__section--required'),
+  rendersVerifying: hasClass('account-setup__section--verifying'),
+  rendersVerified: hasClass('account-setup__section--verified'),
+
+  rendersDetailsForm: isVisible('.details-form'),
+  rendersVerificationDocument: isVisible('.verification-document'),
+  rendersPersonalIdNumber: isVisible('.personal-id-number'),
+
+  individualNameText: text('.funds-recipient__individual-name p'),
+  businessNameText: text('.funds-recipient__business-name p')
 };


### PR DESCRIPTION
# What's in this PR?

Rewrites funds-recipient component into a wrapper based on requirements in 868.

I'm not assuming usage of `route-action` due to me not trying to test it yet. If we want to use it in this PR and the respective subcomponents, it should be trivial to remove the `passthrough`.

For now, instead of rendering subcomponents, we just render placeholders with appropriate class names.

There are no styles yet. Part of the styles can be taken over from #888. The rest can be done in a separate issue, or here.

## References
Fixes #868