### PR TITLE
Issue #506: Fixes pagination when on last page

### DIFF
--- a/app/components/pager-control.js
+++ b/app/components/pager-control.js
@@ -119,6 +119,13 @@ export default Component.extend({
         lower: 1,
         upper: totalPages
       };
+    } else if (this.get('onLastPage')) {
+      let currentPage = this.get('currentPage');
+
+      return {
+        lower: currentPage - (pagesToShow - 1),
+        upper: currentPage
+      };
     } else {
       let centerPage = this.get('centerPage');
       let range = Math.floor(pagesToShow / 2);

--- a/tests/integration/components/pager-control-test.js
+++ b/tests/integration/components/pager-control-test.js
@@ -94,3 +94,21 @@ test('If we are currently on the last page, the next page button does not render
 
   assert.equal(this.$('.next-page').length, 0, 'The button does not render');
 });
+
+test('If we are on the last page, and the pagesToShow are less than or equal to the totalPages', function(assert) {
+  this.set('options', {
+    pageSize: 5,
+    totalRecords: 7,
+    currentPage: 7,
+    totalPages: 7
+  });
+
+  this.render(hbs`{{pager-control options=options}}`);
+
+  assert.equal(this.$('.next-page').length, 0, 'The next page button does not render');
+  assert.equal(this.$('.previous-page').length, 1, 'It renders the previous page button');
+
+  assert.equal(this.$('.page').length, 5, 'Total pages is > 5 (pagesToShow), so all 5 page buttons are rendered');
+  assert.equal(this.$('.page:first').text().trim(), '3', 'First rendered page button is page 3');
+  assert.equal(this.$('.page:last').text().trim(), '7', 'Last rendered page button is that of the last possible page (7)');
+});


### PR DESCRIPTION
# What's in this PR?

- Fix bug where range of pages to show is incorrect when the total
  number of pages is >= the max number of pages to be shown at once, and
  the user is on the last page.
- Add a test to enforce proper behavior in aforementioned scenario.

## References
Fixes [#506](https://github.com/code-corps/code-corps-ember/issues/506)