### PR TITLE
Fix issue with ember-page-title causing tests to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ember-metrics": "0.7.0",
     "ember-modal-dialog": "0.8.8",
     "ember-moment": "7.2.0",
-    "ember-page-title": "^3.0.10",
+    "ember-page-title": "^3.1.2",
     "ember-radio-button": "^1.0.7",
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "^2.0.0",
@@ -91,7 +91,6 @@
     "ember-uploader": "1.2.2",
     "emberx-select": "2.2.3",
     "eslint-plugin-ember-suave": "^1.0.0",
-    "loader.js": "^4.0.10",
-    "phantomjs": "^1.9.20"
+    "loader.js": "^4.0.10"
   }
 }


### PR DESCRIPTION
# What's in this PR?

Cloning the repo and running an NPM install was causing two issues for me, which I spent most of the day resolving

1. We explicitly use phantomjs 1.9.20, which is failing to start on my MacBook (sierra). Removing that dependency resolves that issue. 1.9.20 is generally not supported any more, so I don't think we should be using it.
2. Regardless of phantomjs, tests are failing due to an issue I opened in ember-page-object (https://github.com/tim-evans/ember-page-title/issues/48). In the issue description, I described a workaround, which I applied here.
