### PR TITLE
Add Terms of Use parameters and UI to account creation

### DIFF
--- a/app/components/payments/create-account.js
+++ b/app/components/payments/create-account.js
@@ -1,7 +1,17 @@
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { Component, get } = Ember;
 
 export default Component.extend({
-  classNames: ['create-account', 'account-setup__section']
+  classNames: ['create-account', 'account-setup__section'],
+
+  actions: {
+    submit() {
+      let country = get(this, 'country');
+      let tosAcceptanceDate = Date.now();
+
+      let onSubmit = get(this, 'onCreateStripeConnectAccount');
+      onSubmit({ country, tosAcceptanceDate });
+    }
+  }
 });

--- a/app/controllers/project/settings/donations/payments.js
+++ b/app/controllers/project/settings/donations/payments.js
@@ -6,6 +6,7 @@ const {
   Controller,
   get,
   inject: { service },
+  merge,
   RSVP,
   set
 } = Ember;
@@ -25,11 +26,11 @@ export default Controller.extend({
   stripeConnectAccount: alias('project.organization.stripeConnectAccount'),
 
   actions: {
-    onCreateStripeConnectAccount(country) {
+    onCreateStripeConnectAccount(properties) {
       set(this, 'isBusy', true);
 
       get(this, 'project.organization')
-        .then((organization) => this._createStripeAccount(organization, country))
+        .then((organization) => this._createStripeAccount(organization, properties))
         .catch((reason) => this._handleError(reason))
         .finally(() => set(this, 'isBusy', false));
     },
@@ -83,9 +84,11 @@ export default Controller.extend({
 
   // creating account
 
-  _createStripeAccount(organization, country) {
+  _createStripeAccount(organization, properties) {
+    let accountProperties = merge(properties, { organization });
+
     return get(this, 'store')
-      .createRecord('stripe-connect-account', { organization, country })
+      .createRecord('stripe-connect-account', accountProperties)
       .save()
       .then(RSVP.resolve)
       .catch(() => this._wrapError(ACCOUNT_CREATION_ERROR));

--- a/app/models/stripe-connect-account.js
+++ b/app/models/stripe-connect-account.js
@@ -56,6 +56,7 @@ export default Model.extend({
   supportEmail: attr(),
   supportPhone: attr(),
   supportUrl: attr(),
+  tosAcceptanceDate: attr(),
   transfersEnabled: attr(),
   updatedAt: attr(),
   verificationDisabledReason: attr(),

--- a/app/templates/components/payments/create-account.hbs
+++ b/app/templates/components/payments/create-account.hbs
@@ -6,7 +6,8 @@
     </div>
   </div>
   <div class="input-group">
-    <button class="default" {{action onCreateStripeConnectAccount country}} disabled={{isBusy}}>
+    <p>By registering your account, you agree to our {{link-to "Terms of Use" "terms"}} and the <a href="https://stripe.com/connect-account/legal" target="_blank">Stripe Connected Account Agreement.</a></p>
+    <button class="default" {{action 'submit'}} disabled={{isBusy}}>
       Create Account
     </button>
   </div>

--- a/tests/integration/components/payments/create-account-test.js
+++ b/tests/integration/components/payments/create-account-test.js
@@ -28,11 +28,24 @@ moduleForComponent('payments/create-account', 'Integration | Component | payment
   }
 });
 
-test('it sends properties with submit action', function(assert) {
-  assert.expect(1);
+test('it renders "Terms of Service" acceptance info', function(assert) {
+  assert.expect(2);
 
-  setHandler(this, (country) => {
-    assert.equal(country, 'US', 'Correct parameter was sent out with action.');
+  renderPage();
+
+  // This is some pretty specific testing we have here, but I think, for legal purposes, it makes sense for tests to ensure
+  // no one clears the element containing this text by accident.
+  let legalText = 'By registering your account, you agree to our Terms of Use and the Stripe Connected Account Agreement.';
+  assert.ok(page.text.indexOf(legalText) > -1, 'The wording for the legal text is present');
+  assert.ok(page.rendersStripeLegal, 'The link to Stripe legal information is rendered');
+});
+
+test('it sends properties with submit action', function(assert) {
+  assert.expect(2);
+
+  setHandler(this, (properties) => {
+    assert.equal(properties.country, 'US', 'Correct parameter was sent out with action.');
+    assert.ok(properties.tosAcceptanceDate, 'The ToS acceptance date was sent with action');
   });
 
   renderPage();

--- a/tests/pages/components/payments/create-account.js
+++ b/tests/pages/components/payments/create-account.js
@@ -1,4 +1,4 @@
-import { clickable, is } from 'ember-cli-page-object';
+import { clickable, is, isVisible } from 'ember-cli-page-object';
 
 export default {
   scope: '.create-account',
@@ -6,5 +6,6 @@ export default {
   clickSubmit: clickable('button'),
 
   countrySelectIsDisabled: is(':disabled', 'select'),
+  rendersStripeLegal: isVisible('a[href="https://stripe.com/connect-account/legal"][target="_blank"]'),
   submitButtonIsDisabled: is(':disabled', 'button')
 };

--- a/tests/unit/models/stripe-connect-account-test.js
+++ b/tests/unit/models/stripe-connect-account-test.js
@@ -65,6 +65,7 @@ testForAttributes('stripe-connect-account', [
   'supportEmail',
   'supportPhone',
   'supportUrl',
+  'tosAcceptanceDate',
   'transfersEnabled',
   'updatedAt',
   'verificationDisabledReason',


### PR DESCRIPTION
# What's in this PR?

Adds UI to the account create component indicating that, by creating the account, the user accepts our own and Stripe's terms of use.

Also adds behavior to the component, so that a `tosAcceptanceDate` parameter is sent while creating the account.

## References
Fixes #925