### PR TITLE
Introduce serializer override for patch requests on connect account and minor fixes

### DIFF
--- a/app/serializers/stripe-connect-account.js
+++ b/app/serializers/stripe-connect-account.js
@@ -4,5 +4,15 @@ export default ApplicationSerializer.extend({
   attrs: {
     legalEntitySsnLast4: { key: 'legal-entity-ssn-last-4' },
     legalEntitySsnLast4Provided: { key: 'legal-entity-ssn-last-4-provided' }
+  },
+
+  /**
+   * Overrides default serializeAttributes so it only serializes changed attributes,
+   * instead of the default behavior, which is all of them.
+   */
+  serializeAttribute(snapshot, json, key) {
+    if (snapshot.changedAttributes()[key] || snapshot.record.get('isNew')) {
+      this._super(...arguments);
+    }
   }
 });


### PR DESCRIPTION
Minor fixes in account setup process.

# What's in this PR?

Pr introduces an override for the connect account serializer, so patch requests from now on will only send dirty attributes, instead of the whole model. We may want to consider introducing this into all our `stripeX`model serializers, since behavior and issues will likely be similar.

Also introduced some minor fixes into the payments controller:
* there was a call to a renamed function that got left behind
* we didn't clear errors on subsequent requests

## References
Fixes #934 