### PR TITLE
Fix details form behavior on account setup

### DIFF
--- a/app/components/payments/funds-recipient/details-form.js
+++ b/app/components/payments/funds-recipient/details-form.js
@@ -4,6 +4,7 @@ const {
   Component,
   computed: { equal },
   get,
+  isEmpty,
   set,
   setProperties
 } = Ember;
@@ -24,7 +25,7 @@ export default Component.extend({
       let stripeConnectAccount = get(this, 'stripeConnectAccount');
 
       if (get(this, 'isIndividual')) {
-        stripeConnectAccount.setProperties({
+        setProperties(stripeConnectAccount, {
           legalEntityBusinessName: null,
           legalEntityBusinessTaxId: null
         });
@@ -38,21 +39,21 @@ export default Component.extend({
   _setDefaults() {
     let stripeConnectAccount = get(this, 'stripeConnectAccount');
 
-    if (get(stripeConnectAccount, 'legalEntityType') === null) {
+    if (isEmpty(get(stripeConnectAccount, 'legalEntityType'))) {
       set(stripeConnectAccount, 'legalEntityType', 'individual');
     }
 
-    if (get(stripeConnectAccount, 'legalEntityAddressState') == null) {
+    if (isEmpty(get(stripeConnectAccount, 'legalEntityAddressState'))) {
       set(stripeConnectAccount, 'legalEntityAddressState', 'CA');
     }
 
-    if (get(stripeConnectAccount, 'legalEntityAddressCountry') == null) {
+    if (isEmpty(get(stripeConnectAccount, 'legalEntityAddressCountry'))) {
       set(stripeConnectAccount, 'legalEntityAddressCountry', 'US');
     }
 
     let legalEntityDobDay = get(stripeConnectAccount, 'legalEntityDobDay') || 1;
     let legalEntityDobMonth = get(stripeConnectAccount, 'legalEntityDobMonth') || 1;
-    let legalEntityDobYear = get(stripeConnectAccount, 'legalEntityDobYear') || new Date().getUTCFullYear() - 13;
+    let legalEntityDobYear = get(stripeConnectAccount, 'legalEntityDobYear') || new Date().getUTCFullYear();
 
     setProperties(stripeConnectAccount, { legalEntityDobDay, legalEntityDobMonth, legalEntityDobYear });
   }

--- a/app/components/payments/funds-recipient/details-form.js
+++ b/app/components/payments/funds-recipient/details-form.js
@@ -4,7 +4,8 @@ const {
   Component,
   computed: { equal },
   get,
-  set
+  set,
+  setProperties
 } = Ember;
 
 export default Component.extend({
@@ -15,10 +16,7 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let stripeConnectAccount = get(this, 'stripeConnectAccount');
-    if (get(stripeConnectAccount, 'legalEntityType') === null) {
-      set(this, 'stripeConnectAccount.legalEntityType', 'individual');
-    }
+    this._setDefaults();
   },
 
   actions: {
@@ -37,9 +35,25 @@ export default Component.extend({
     }
   },
 
-  onBirthDateChanged(day, month, year) {
-    set(this, 'stripeConnectAccount.legalEntityDobDay', day);
-    set(this, 'stripeConnectAccount.legalEntityDobMonth', month);
-    set(this, 'stripeConnectAccount.legalEntityDobYear', year);
+  _setDefaults() {
+    let stripeConnectAccount = get(this, 'stripeConnectAccount');
+
+    if (get(stripeConnectAccount, 'legalEntityType') === null) {
+      set(stripeConnectAccount, 'legalEntityType', 'individual');
+    }
+
+    if (get(stripeConnectAccount, 'legalEntityAddressState') == null) {
+      set(stripeConnectAccount, 'legalEntityAddressState', 'CA');
+    }
+
+    if (get(stripeConnectAccount, 'legalEntityAddressCountry') == null) {
+      set(stripeConnectAccount, 'legalEntityAddressCountry', 'US');
+    }
+
+    let legalEntityDobDay = get(stripeConnectAccount, 'legalEntityDobDay') || 1;
+    let legalEntityDobMonth = get(stripeConnectAccount, 'legalEntityDobMonth') || 1;
+    let legalEntityDobYear = get(stripeConnectAccount, 'legalEntityDobYear') || new Date().getUTCFullYear() - 13;
+
+    setProperties(stripeConnectAccount, { legalEntityDobDay, legalEntityDobMonth, legalEntityDobYear });
   }
 });

--- a/app/components/select/birth-date.js
+++ b/app/components/select/birth-date.js
@@ -30,7 +30,7 @@ export default Component.extend({
 
   yearOptions: computed(function() {
     let thisYear = moment().year();
-    return range(thisYear - 120, thisYear - 13).reverse();
+    return range(thisYear - 120, thisYear).reverse();
   }),
 
   update(property, value) {

--- a/app/components/select/birth-date.js
+++ b/app/components/select/birth-date.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 import moment from 'moment';
+import { range } from 'code-corps-ember/utils/array-utils';
 
 const {
   Component,
+  computed,
   get,
   getProperties,
   set
@@ -11,40 +13,58 @@ const {
 export default Component.extend({
   classNames: ['select-birth-date'],
 
-  monthOptions: function() {
-    return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12].map((i) => {
-      return {
-        number: i,
-        text: moment.months(i - 1)
-      };
-    });
-  }.property(),
+  selectedMoment: computed('month', 'year', function() {
+    let { month, year } = getProperties(this, 'month', 'year');
+    return moment(`${year}-${month}`, 'Y-M');
+  }),
 
-  dayOptions: function() {
-    let results = [];
-    for (let i = 1; i <= 31; i++) {
-      results.push(i);
-    }
-    return results;
-  }.property(),
+  monthOptions: computed(function() {
+    return moment.months().map(this._formatMonth);
+  }),
 
-  yearOptions: function() {
+  dayOptions: computed('selectedMoment', function() {
+    let selectedMoment = get(this, 'selectedMoment');
+    let maxDay = selectedMoment.daysInMonth();
+    return range(1, maxDay);
+  }),
+
+  yearOptions: computed(function() {
     let thisYear = moment().year();
-    let results = [];
-    return (function() {
-      for (let i = thisYear, ref = thisYear - 120; thisYear <= ref ? i <= ref : i >= ref; thisYear <= ref ? i++ : i--) {
-        results.push(i);
-      }
-      return results;
-    }).apply(this);
-  }.property(),
+    return range(thisYear - 120, thisYear - 13).reverse();
+  }),
 
   update(property, value) {
     set(this, property, value);
-    let { selectedDay, selectedMonth, selectedYear }
-      = getProperties(this, 'selectedDay', 'selectedMonth', 'selectedYear');
 
-    let onChange = get(this, 'onChange');
-    onChange(selectedDay, selectedMonth, selectedYear);
+    if (property === 'month') {
+      this._constrainDay();
+    }
+
+    if (property === 'year') {
+      this._constrainDay();
+      this._constrainMonth();
+    }
+  },
+
+  _constrainDay() {
+    let day = get(this, 'day');
+    let days = get(this, 'dayOptions');
+    let maxDay = days[days.length - 1];
+    if (day > maxDay) {
+      set(this, 'day', maxDay);
+    }
+  },
+
+  _constrainMonth() {
+    let month = get(this, 'month');
+    let months = get(this, 'monthOptions');
+    let maxMonth = months[months.length - 1];
+    if (month > maxMonth.number) {
+      set(this, 'month', maxMonth.number);
+    }
+  },
+
+  _formatMonth(name, index) {
+    return { text: name, number: index + 1 };
   }
 });

--- a/app/templates/components/payments/funds-recipient/details-form.hbs
+++ b/app/templates/components/payments/funds-recipient/details-form.hbs
@@ -49,7 +49,6 @@
         day=stripeConnectAccount.legalEntityDobDay
         month=stripeConnectAccount.legalEntityDobMonth
         year=stripeConnectAccount.legalEntityDobYear
-        onChange=(action onBirthDateChanged)
       }}
     </div>
   </div>

--- a/app/templates/components/select/birth-date.hbs
+++ b/app/templates/components/select/birth-date.hbs
@@ -1,17 +1,17 @@
 <div>
-  {{#x-select value=month on-change=(action update 'selectedMonth') as |xs|}}
+  {{#x-select value=month action=(action update 'month') as |xs|}}
     {{#each monthOptions as |monthOption|}}
       {{#xs.option value=monthOption.number}}{{monthOption.text}}{{/xs.option}}
     {{/each}}
   {{/x-select}}
 
-  {{#x-select value=day on-change=(action update 'selectedDay') as |xs|}}
+  {{#x-select value=day action=(action update 'day') as |xs|}}
     {{#each dayOptions as |dayOption|}}
       {{#xs.option value=dayOption}}{{dayOption}}{{/xs.option}}
     {{/each}}
   {{/x-select}}
 
-  {{#x-select value=year  on-change=(action update 'selectedYear') as |xs|}}
+  {{#x-select value=year  action=(action update 'year') as |xs|}}
     {{#each yearOptions as |yearOption|}}
       {{#xs.option value=yearOption}}{{yearOption}}{{/xs.option}}
     {{/each}}

--- a/app/utils/array-utils.js
+++ b/app/utils/array-utils.js
@@ -1,0 +1,7 @@
+export function range(start, end) {
+  let range = [];
+  for (let i = start; i <= end; i++) {
+    range.push(i);
+  }
+  return range;
+}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -405,12 +405,9 @@ export default function() {
    */
 
   this.post('/stripe-connect-accounts', function(schema) {
-    let { country } = this.normalizedRequestAttrs();
-    let stripeConnectAccount = schema.create('stripeConnectAccount', {
-      country,
-      recipientStatus: 'required'
-    });
-    return stripeConnectAccount;
+    let attrs = this.normalizedRequestAttrs();
+    attrs.recipientStatus = 'required';
+    return schema.create('stripeConnectAccount', attrs);
   });
 
   this.get('/stripe-connect-accounts/:id');

--- a/tests/helpers/fill-in-file-input.js
+++ b/tests/helpers/fill-in-file-input.js
@@ -13,8 +13,6 @@ export default function fillInFileInput(selector, file) {
     target: { files: [{ name, type }] }
   });
 
-  console.log(event);
-
   // Stub readAsDataURL function
   let stub = sinon.stub(FileReader.prototype, 'readAsDataURL', function() {
     this.onload({ target: { result: content } });

--- a/tests/integration/components/select/birth-date-test.js
+++ b/tests/integration/components/select/birth-date-test.js
@@ -6,24 +6,18 @@ import PageObject from 'ember-cli-page-object';
 
 const {
   getProperties,
-  set,
-  setProperties
+  set
 } = Ember;
 
 let page = PageObject.create(selectBirthDateComponent);
 
-function setHandler(context, onChange = function() {}) {
-  set(context, 'onChange', onChange);
-}
-
 function renderPage() {
-  page.render(hbs`{{select/birth-date month=month day=day year=year onChange=onChange}}`);
+  page.render(hbs`{{select/birth-date month=month day=day year=year}}`);
 }
 
 moduleForComponent('select/birth-date', 'Integration | Component | select/birth date', {
   integration: true,
   beforeEach() {
-    setHandler(this);
     page.setContext(this);
   },
   afterEach() {
@@ -34,21 +28,21 @@ moduleForComponent('select/birth-date', 'Integration | Component | select/birth 
 test('it sets the month strings correctly', function(assert) {
   assert.expect(1);
 
+  set(this, 'day', 1);
+  set(this, 'month', 1);
+  set(this, 'year', 2016);
+
   renderPage();
 
-  assert.equal(page.month.text, 'January February March April May June July August September October December');
+  assert.equal(page.month.text, 'January February March April May June July August September October November December');
 });
 
 test('it sets to the correct date', function(assert) {
   assert.expect(1);
 
-  this.set('day', 1);
-  this.set('month', 1);
-  this.set('year', 2016);
-
-  setHandler(this, (day, month, year) => {
-    setProperties(this, { day, month, year });
-  });
+  set(this, 'day', 1);
+  set(this, 'month', 1);
+  set(this, 'year', 2016);
 
   renderPage();
 
@@ -59,6 +53,6 @@ test('it sets to the correct date', function(assert) {
   assert.deepEqual(
     getProperties(this, 'day', 'month', 'year'),
     { day: 13, month: 4, year: 1970 },
-    'Each selection change is reported correctly'
+    'Each selection change is passed out correctly'
   );
 });

--- a/tests/unit/utils/array-utils-test.js
+++ b/tests/unit/utils/array-utils-test.js
@@ -1,0 +1,10 @@
+import { range } from 'code-corps-ember/utils/array-utils';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | array-utils');
+
+test('range returns an array of integers defined by parameters', function(assert) {
+  assert.deepEqual(range(1, 1), [1]);
+  assert.deepEqual(range(1, 2), [1, 2]);
+  assert.deepEqual(range(1, 5), [1, 2, 3, 4, 5]);
+});


### PR DESCRIPTION
# What's in this PR?

The upgrade of emberx-select contained a bug which this PR should fix. Upon initial load, even though the UI made it seem to be the case, the selects actually weren't setting their bound properties (as they really shouldn't implicitly). This PR explicitly sets these so payment details can now be properly submitted.

While I was at it, I modified the birth date component so that the month and day dropdowns are populated dynamically, based on the yer and the relationship to the current date.

This means

- the day dropdown will contains 30, 31, 28 or 29 days depending on the selected month and/or year
- if the current year is selected, the day and month will contain values at most up to the current date, so the user will not be able to select a date in the future.