### PR TITLE
Added prompt on navigating away from task creation

### DIFF
--- a/app/routes/project/tasks/new.js
+++ b/app/routes/project/tasks/new.js
@@ -52,6 +52,20 @@ export default Route.extend(AuthenticatedRouteMixin, {
           this.controllerFor('project.tasks.new').set('error', error);
         }
       });
+    },
+
+    willTransition(transition) {
+      let task = get(this, 'controller.task');
+
+      // prompt to confirm if the user did not save
+      if (get(task, ('isNew'))) {
+        let confirmed = window.confirm('You will lose any unsaved information if you leave this page. Are you sure?');
+        if (confirmed) {
+          task.destroyRecord();
+        } else {
+          transition.abort();
+        }
+      }
     }
   }
 });

--- a/tests/pages/components/task-board.js
+++ b/tests/pages/components/task-board.js
@@ -1,3 +1,9 @@
+import { collection } from 'ember-cli-page-object';
+import taskListCards from 'code-corps-ember/tests/pages/components/task-list-cards';
+
 export default {
-  scope: '.task-board'
+  scope: '.task-board',
+  taskLists: collection({
+    item: taskListCards
+  })
 };

--- a/tests/pages/project/tasks/index.js
+++ b/tests/pages/project/tasks/index.js
@@ -3,8 +3,9 @@ import {
   create,
   visitable
 } from 'ember-cli-page-object';
-import projectDetails from '../../components/project-details';
-import projectMenu from '../../components/project-menu';
+import projectDetails from 'code-corps-ember/tests/pages/components/project-details';
+import projectMenu from 'code-corps-ember/tests/pages/components/project-menu';
+import taskBoard from 'code-corps-ember/tests/pages/components/task-board';
 
 export default create({
   visit: visitable(':organization/:project/tasks'),
@@ -22,7 +23,9 @@ export default create({
   },
 
   clickNewTask: clickable('.new-task'),
+  clickCancel: clickable('.cancel'),
 
   projectDetails,
-  projectMenu
+  projectMenu,
+  taskBoard
 });

--- a/tests/pages/project/tasks/new.js
+++ b/tests/pages/project/tasks/new.js
@@ -6,22 +6,25 @@ import {
   visitable
 } from 'ember-cli-page-object';
 
-export default create({
-  visit: visitable(':organization/:project/tasks/new'),
+import projectMenu from 'code-corps-ember/tests/pages/components/project-menu';
 
+export default create({
   clickPreviewTask: clickable('.preview'),
+  clickSubmit: clickable('[name=submit]'),
+
+  errors: collection({
+    scope: '.error'
+  }),
 
   taskTitle: fillable('[name=title]'),
   taskMarkdown: fillable('[name=markdown]'),
   taskType: fillable('[name=task-type]'),
 
-  clickSubmit: clickable('[name=submit]'),
+  projectMenu,
 
   previewBody: {
     scope: '.body-preview'
   },
 
-  errors: collection({
-    scope: '.error'
-  })
+  visit: visitable(':organization/:project/tasks/new')
 });


### PR DESCRIPTION
# What's in this PR?

This PR adds a basic confirmation prompt when navigating away from the task creation page.
- destroys new record if confirmed
- aborts transition if not confirmed

## References
Fixes #991
