### PR TITLE
#957 - Last 4 input allows too many characters

### DIFF
--- a/app/templates/components/payments/funds-recipient/details-form.hbs
+++ b/app/templates/components/payments/funds-recipient/details-form.hbs
@@ -99,7 +99,7 @@
   <div class="input-section__label">SSN Last 4</div>
   <div class="input-section__content">
     <div class="input-group">
-      {{input type="text" name="legal-entity-ssn-last-4" value=stripeConnectAccount.legalEntitySsnLast4}}
+      {{input type="text" name="legal-entity-ssn-last-4" maxlength="4" value=stripeConnectAccount.legalEntitySsnLast4}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Data Validation for ssn-last-4
Set max length for input for ssn-last-4 to 4 chars. In order to prevent users from entering more than 4 characters. 


## References
Progress on: #957 

cc: @rileytaylor, I wasn't able to load the screen to create an organization based on how the local site is setup. Were you able to see this validation error locally or only in production? I would love any guidance as to how to view the user-facing page associated with creating accounts. I tried logging in as `admin` and `owner` with the mirage data but still was not able to access that page. 
