### PR TITLE
Fix safari project card responsive issue

### DIFF
--- a/app/styles/layout/_header.scss
+++ b/app/styles/layout/_header.scss
@@ -10,9 +10,14 @@
 
 .site-header {
   border-bottom: 1px solid #EEE;
-  display: flex;
+  display: block;
   height: 53px;
   padding: 0 10px;
+}
+
+.nav-container {
+  display: flex;
+  justify-content: space-between;
 }
 
 .header__logo {
@@ -56,6 +61,7 @@
 .header-navigation__options {
   display: flex;
   justify-content: flex-end;
+  white-space: nowrap;
 
   li {
     display: inline-block;

--- a/app/templates/components/navigation-menu.hbs
+++ b/app/templates/components/navigation-menu.hbs
@@ -1,42 +1,44 @@
-{{#if navigationMenu.isDefault}}
-  <nav class="header-navigation--left">
-    <ul class="header-navigation__options">
-      <li>{{#link-to 'projects-list'}}Projects{{/link-to}}</li>
-      <li><a href="https://blog.codecorps.org">Blog</a></li>
-    </ul>
-  </nav>
-{{/if}}
-
-{{#if navigationMenu.isOnboarding}}
-  <div class="header-navigation--left"></div>
-{{/if}}
-
-<nav class="header-navigation--middle">
-  <h1 class="header__logo">
-    {{#link-to 'index' }}Code Corps{{/link-to}}
-  </h1>
-</nav>
-
-{{#if navigationMenu.isDefault}}
-  {{#if session.isAuthenticated}}
-    <nav class="header-navigation--right">
-      {{user-menu user=currentUser.user class="header-navigation__options" }}
-    </nav>
-  {{else}}
-    <nav class="header-navigation--right">
+<div class="nav-container">
+  {{#if navigationMenu.isDefault}}
+    <nav class="header-navigation--left">
       <ul class="header-navigation__options">
-        <li>{{#link-to 'signup' class="signup"}}Sign up{{/link-to}}</li>
-        <li>{{#link-to 'login' class="login"}}Sign in{{/link-to}}</li>
+        <li>{{#link-to 'projects-list'}}Projects{{/link-to}}</li>
+        <li><a href="https://blog.codecorps.org">Blog</a></li>
       </ul>
     </nav>
   {{/if}}
-{{/if}}
 
-{{#if navigationMenu.isOnboarding}}
-  <div class="header-navigation--onboarding header-navigation--right">
-    <div class="onboarding__progress">
-      {{progress-bar-container percentage=onboarding.progressPercentage}}
+  {{#if navigationMenu.isOnboarding}}
+    <div class="header-navigation--left"></div>
+  {{/if}}
+
+  <nav class="header-navigation--middle">
+    <h1 class="header__logo">
+      {{#link-to 'index' }}Code Corps{{/link-to}}
+    </h1>
+  </nav>
+
+  {{#if navigationMenu.isDefault}}
+    {{#if session.isAuthenticated}}
+      <nav class="header-navigation--right">
+        {{user-menu user=currentUser.user class="header-navigation__options" }}
+      </nav>
+    {{else}}
+      <nav class="header-navigation--right">
+        <ul class="header-navigation__options">
+          <li>{{#link-to 'signup' class="signup"}}Sign up{{/link-to}}</li>
+          <li>{{#link-to 'login' class="login"}}Sign in{{/link-to}}</li>
+        </ul>
+      </nav>
+    {{/if}}
+  {{/if}}
+
+  {{#if navigationMenu.isOnboarding}}
+    <div class="header-navigation--onboarding header-navigation--right">
+      <div class="onboarding__progress">
+        {{progress-bar-container percentage=onboarding.progressPercentage}}
+      </div>
+      <p class="onboarding__steps">Step {{onboarding.currentStepNumber}} of {{onboarding.totalSteps}}</p>
     </div>
-    <p class="onboarding__steps">Step {{onboarding.currentStepNumber}} of {{onboarding.totalSteps}}</p>
-  </div>
-{{/if}}
+  {{/if}}
+</div>


### PR DESCRIPTION
# What's in this PR?
Fixes flexbox issue with project cards on Safari

Changes:
- Add flexbox container around nav-bar
- Make "header" `display: block` to prevent project cards from overlapping

## References #1037
