### PR TITLE
Make signup page responsive

### DIFF
--- a/app/styles/components/signup-form.scss
+++ b/app/styles/components/signup-form.scss
@@ -5,4 +5,20 @@
   input[type="submit"] {
     width: 100%;
   }
+  @include media($lg-screen) {
+    @include shift(2);
+    @include span-columns(8);
+  }
+  @include media($sm-screen) {
+    @include shift(0);
+    @include span-columns(12);
+  }
+
+  .suggestions {
+    @include media($lg-screen) {
+      position: relative;
+      top: 5px;
+      right: -8px;
+    }
+  }
 }

--- a/app/templates/components/signup-form.hbs
+++ b/app/templates/components/signup-form.hbs
@@ -1,21 +1,23 @@
-<form>
+<div class="container">
+  <form>
 
-  <h2>Join Code Corps today.</h2>
+    <h2>Join Code Corps today.</h2>
 
-  {{#auto-focus}}
-    {{signup-username-input autofocus=true user=user usernameValidated="usernameValidated"}}
-  {{/auto-focus}}
+    {{#auto-focus}}
+      {{signup-username-input autofocus=true user=user usernameValidated="usernameValidated"}}
+    {{/auto-focus}}
 
-  {{signup-email-input user=user emailValidated="emailValidated"}}
+    {{signup-email-input user=user emailValidated="emailValidated"}}
 
-  {{signup-password-input user=user}}
+    {{signup-password-input user=user}}
 
-  <div class="input-group">
-    <input class="button default {{if hasError "has-error"}}" name="signup" type="submit" value='Sign up' {{action 'signUp'}} />
-  </div>
+    <div class="input-group">
+      <input class="button default {{if hasError "has-error"}}" name="signup" type="submit" value='Sign up' {{action 'signUp'}} />
+    </div>
 
-  {{#if error}}
-    {{error-formatter error=error}}
-  {{/if}}
+    {{#if error}}
+      {{error-formatter error=error}}
+    {{/if}}
 
-</form>
+  </form>
+</div>


### PR DESCRIPTION
# What's in this PR?
Makes signup page responsive.

Changes for smaller screens:
- widen inputs
- error messages appear below inputs

![signup](https://cloud.githubusercontent.com/assets/13618860/22964125/ddfbb70a-f30b-11e6-9609-8996886527a8.png)

