### PR TITLE
Make start/interests responsive

### DIFF
--- a/app/styles/components/categories-list.scss
+++ b/app/styles/components/categories-list.scss
@@ -1,5 +1,7 @@
 .categories-list {
-  flex: 1;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
   margin-bottom: 2em;
   width: 100%;
 }

--- a/app/styles/components/category-item.scss
+++ b/app/styles/components/category-item.scss
@@ -1,8 +1,10 @@
 .category-item {
-  @include omega(5n);
-  @include span-columns(2.4);
-
   text-align: center;
+  width: 20%;
+  @include media($lg-screen) { width: 25%; }
+  @include media($md-screen) { width: 33%; }
+  @include media($sm-screen) { width: 50%; }
+  @include media($xs-screen) { width: 100%; }
 
   button {
     text-align: left;


### PR DESCRIPTION
# What's in this PR?
Makes start/interests page responsive.

## Changes:
- Use percent widths for .category-items to avoid issue with `@include span-columns` gutters.

![screen shot 2017-02-18 at 7 53 02 pm](https://cloud.githubusercontent.com/assets/13618860/23099130/891948e0-f614-11e6-808b-c4dcc5858a04.png)
![screen shot 2017-02-18 at 7 53 17 pm](https://cloud.githubusercontent.com/assets/13618860/23099131/8abc87a2-f614-11e6-89ca-0bd933e8d66b.png)

