### PR TITLE
Fix task-card unassignment

### DIFF
--- a/app/components/task-card.js
+++ b/app/components/task-card.js
@@ -93,24 +93,29 @@ export default Component.extend({
   },
 
   actions: {
+    buildSelection(option, select) {
+      if (option === select.selected) {
+        return null;
+      }
+      return option;
+    },
+
+    async changeUser(user) {
+      let { task, taskAssignment } = getProperties(this, 'task', 'taskAssignment');
+
+      if (user) {
+        return taskAssignment.assign(task, user);
+      } else {
+        return taskAssignment.unassign(task);
+      }
+    },
+
     searchUsers(query) {
       let { currentUserId, store, taskUserId }
         = getProperties(this, 'currentUserId', 'store', 'taskUserId');
       return store.query('user', { query }).then((users) => {
         return createTaskUserOptions(users.toArray(), currentUserId, taskUserId);
       });
-    },
-
-    async selectUser(user) {
-      let { task, taskAssignment } = getProperties(this, 'task', 'taskAssignment');
-
-      let taskIsAssignedToUser = await taskAssignment.isAssignedTo(task, user);
-
-      if (taskIsAssignedToUser) {
-        return taskAssignment.unassign(task);
-      } else {
-        return taskAssignment.assign(task, user);
-      }
     },
 
     stopClickPropagation(e) {

--- a/app/services/task-assignment.js
+++ b/app/services/task-assignment.js
@@ -10,13 +10,13 @@ const {
 export default Service.extend({
   store: service(),
 
-  async isAssignedTo(task, user) {
-    return await get(task, 'userTask.user.id') === get(user, 'id');
-  },
-
   async assign(task, user) {
     let userTask = await get(task, 'userTask');
     return userTask ? this._update(userTask, user) : this._create(user, task);
+  },
+
+  async isAssignedTo(task, user) {
+    return await get(task, 'userTask.user.id') === get(user, 'id');
   },
 
   async unassign(task) {

--- a/app/templates/components/task-card.hbs
+++ b/app/templates/components/task-card.hbs
@@ -18,12 +18,13 @@
   </p>
   {{#power-select
     beforeOptionsComponent=(component "power-select/before-options" selectRemoteController=selectRemoteController)
+    buildSelection=(action "buildSelection")
     class="select-inline"
     disabled=userSelectDisabled
     dropdownClass="select-inline-dropdown"
     loadingMessage=""
     matchTriggerWidth=false
-    onchange=(action "selectUser")
+    onchange=(action "changeUser")
     options=userOptions
     placeholderComponent=(component "task-card/user/unselected-item" click=(action "stopClickPropagation") task=task)
     registerAPI=(action (mut selectRemoteController))


### PR DESCRIPTION
# What's in this PR?

Uses the as-yet undocumented `buildSelection` in `ember-power-select` to deselect a user by passing `null` in order to unassign.