### PR TITLE
Task assignment tests, page objects, bug fixes

### DIFF
--- a/app/components/task-card.js
+++ b/app/components/task-card.js
@@ -70,8 +70,7 @@ export default Component.extend({
     let { currentUserId, taskUserId, users }
       = getProperties(this, 'currentUserId', 'taskUserId', 'users');
     if (users) {
-      // TODO: Replace content here!
-      return createTaskUserOptions(users.mapBy('content'), currentUserId, taskUserId);
+      return createTaskUserOptions(users, currentUserId, taskUserId);
     } else {
       return [];
     }
@@ -100,7 +99,7 @@ export default Component.extend({
       return option;
     },
 
-    async changeUser(user) {
+    changeUser(user) {
       let { task, taskAssignment } = getProperties(this, 'task', 'taskAssignment');
 
       if (user) {

--- a/tests/integration/components/task-card-test.js
+++ b/tests/integration/components/task-card-test.js
@@ -4,13 +4,34 @@ import PageObject from 'ember-cli-page-object';
 import taskCardComponent from 'code-corps-ember/tests/pages/components/task-card';
 import moment from 'moment';
 import { Ability } from 'ember-can';
+import Ember from 'ember';
+import DS from 'ember-data';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
+
+const { RSVP, set, setProperties } = Ember;
+const { PromiseObject } = DS;
 
 let page = PageObject.create(taskCardComponent);
+
+function renderPage() {
+  page.render(hbs`
+    {{task-card
+      clickedTask=clickedTask
+      members=members
+      task=task
+      taskUser=taskUser
+    }}`);
+}
+
+function setHandler(context, clickedTaskHandler = function() {}) {
+  set(context, 'clickedTaskHandler', clickedTaskHandler);
+}
 
 moduleForComponent('task-card', 'Integration | Component | task card', {
   integration: true,
   beforeEach() {
     page.setContext(this);
+    setHandler(this);
     this.register('ability:task', Ability.extend({ canReposition: true }));
   },
   afterEach() {
@@ -86,4 +107,135 @@ test('it does not send action if clicked and loading', function(assert) {
   this.render(hbs`{{task-card clickedTask=clickedTask task=task}}`);
   page.click();
   assert.ok(true);
+});
+
+test('assignment works if user has ability', function(assert) {
+  assert.expect(2);
+
+  // there is some async behavior here, so we need to explicitly be `done()`
+  let done = assert.async();
+
+  let task = { id: 'task' };
+  let user = { id: 'user', username: 'testuser' };
+
+  let members = [user];
+
+  setProperties(this, { task, members });
+
+  stubService(this, 'current-user', { user });
+
+  stubService(this, 'task-assignment', {
+    assign(sentTask, sentUser) {
+      assert.deepEqual(sentTask, task, 'Correct task was sent.');
+      assert.deepEqual(sentUser, user, 'Correct user was sent.');
+      // this is the final step of the async behavior, so we are `done()` here
+      done();
+      return RSVP.resolve();
+    }
+  });
+
+  this.register('ability:task', Ability.extend({ canAssign: true }));
+
+  renderPage();
+
+  page.taskAssignment.trigger.open();
+  page.taskAssignment.dropdown.options(0).select();
+});
+
+test('unassignment works if user has ability', function(assert) {
+  assert.expect(1);
+
+  // there is some async behavior here, so we need to explicitly be `done()`
+  let done = assert.async();
+
+  let task = { id: 'task' };
+  let user = { id: 'user', username: 'testuser' };
+
+  let members = [user];
+
+  setProperties(this, { task, taskUser: user, members });
+
+  stubService(this, 'task-assignment', {
+    unassign(sentTask) {
+      assert.deepEqual(sentTask, task, 'Correct task was sent.');
+      // this is the final step of the async behavior, so we are `done()` here
+      done();
+      return RSVP.resolve();
+    }
+  });
+
+  this.register('ability:task', Ability.extend({ canAssign: true }));
+
+  renderPage();
+
+  page.taskAssignment.trigger.open();
+  page.taskAssignment.dropdown.options(0).select();
+});
+
+test('assignment dropdown renders when records are loaded', function(assert) {
+  assert.expect(2);
+
+  let task = { id: 'task' };
+  let user1 = { id: 'user1', username: 'testuser1' };
+  let user2 = { id: 'user2', username: 'testuser2' };
+
+  let members = [user1, user2];
+
+  setProperties(this, { task, members });
+
+  stubService(this, 'task-assignment', {
+    isAssignedTo() {
+      return RSVP.resolve(false);
+    }
+  });
+
+  this.register('ability:task', Ability.extend({ canAssign: true }));
+
+  renderPage();
+
+  page.taskAssignment.trigger.open();
+
+  assert.equal(page.taskAssignment.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
+  assert.equal(page.taskAssignment.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
+});
+
+test('assignment dropdown renders when records are still being loaded', function(assert) {
+  assert.expect(2);
+
+  let done = assert.async();
+
+  let task = { id: 'task' };
+  let user1 = { id: 'user1', username: 'testuser1' };
+  let user2 = { id: 'user2', username: 'testuser2' };
+
+  // this function wraps an object into a structure which simulates a DS records
+  // which is in the process of being fetched from the server, meaning that it
+  // will have an id, but all other properties will be delegated to the as of
+  // yet not populated `content` property
+  function proxify(user) {
+    let promise = RSVP.resolve(user);
+    let { id } = user;
+    return PromiseObject.create({ id, promise });
+  }
+
+  let members = [user1, user2].map((user) => proxify(user));
+
+  setProperties(this, { task, members });
+
+  stubService(this, 'task-assignment', {
+    isAssignedTo() {
+      return RSVP.resolve(false);
+    }
+  });
+
+  this.register('ability:task', Ability.extend({ canAssign: true }));
+
+  renderPage();
+
+  RSVP.all(members).then(() => {
+    page.taskAssignment.trigger.open();
+    assert.equal(page.taskAssignment.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
+    assert.equal(page.taskAssignment.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
+    done();
+  });
 });

--- a/tests/pages/components/power-select.js
+++ b/tests/pages/components/power-select.js
@@ -1,0 +1,36 @@
+import { collection } from 'ember-cli-page-object';
+import { clickTrigger, nativeMouseUp } from 'code-corps-ember/tests/helpers/ember-power-select';
+
+// NOTE: The default ember-cli-page-objects do not work properly here
+// Instead, ember-power-select exposes the `clickTrigger` and `nativeMouseUp`
+// helpers which we used to implement this page object.
+//
+// Especially of note is the usage of `nativeMouseUp`.
+// - `clickable`, `click`, or even `nativeMouseDown` do not work.
+// - there is no documentation for this either
+// - the `selectChoose` test helper can only be used in acceptance tests
+// - using `nativeMouseUp` up for this is undocumented, but I started using it after looking at the code at:
+//   https://github.com/cibernox/ember-power-select/blob/master/tests/integration/components/power-select/general-behaviour-test.js#L236
+
+// NOTE: Since the power select is appended to the application root by default,
+// We're also using the `testContainer` feature provided by ember-cli-page-object
+
+export default {
+  trigger: {
+    open: clickTrigger
+  },
+
+  dropdown: {
+    resetScope: true,
+    testContainer: '.ember-power-select-dropdown',
+    options: collection({
+      itemScope: '.ember-power-select-option',
+      item: {
+        select() {
+          nativeMouseUp(this.scope);
+          return this;
+        }
+      }
+    })
+  }
+};

--- a/tests/pages/components/task-card.js
+++ b/tests/pages/components/task-card.js
@@ -1,6 +1,7 @@
 import {
   hasClass
 } from 'ember-cli-page-object';
+import taskAssignment from 'code-corps-ember/tests/pages/components/power-select';
 
 export default {
   scope: '.task-card',
@@ -15,5 +16,7 @@ export default {
   },
   title: {
     scope: '[data-test-selector="task title"]'
-  }
+  },
+
+  taskAssignment
 };


### PR DESCRIPTION
# What's in this PR?

This deals with the sentry issue we've been having and adds test to cover user task assignment in integration.

I'm not 100% positive this will fix the issue, but it should be the case, since I've been able to reproduce it on ocasion in development, but I'm no longer able to after this change.

The best I can figure out was, to populate the assignment dropdown, we were doing a `users.mapBy('content')`. However, in some cases, the `content` property of the `DS.PromiseObject` was `null` (not loaded yet). This happens rarely in development, more often in staging, but almost always on production.

I was implementing integration tests on the task card component and, while trying to implement the power select page object, managed to write a failing test for this without realizing. 

The fix for it was relatively simple - we do not map by content. @JoshSmith do you remember why you were mapping by content in the first place? If a user is a `DS.PromiseObject` then binding `user.username` will render nothing while the user is being loaded, but should switch to rendering `user.content.username` as soon as the loading promise resolves. This is the behaviour I'm observing locally, so there should be no need to map by content at all. Is it not the case on your side, or am I missing something.

Once the fix was applied and the failing case was passing, I wrote more tests to cover cases where we have promises and already loaded objects.

I guess, if we want nicer UX, we could have the list item component also react to `user.isLoading` and show a different state while that is happening. I believe power-select actually supports something like that in some way.

## References
Fixes #1076
