### PR TITLE
Introduce category-item page object

### DIFF
--- a/app/components/category-item.js
+++ b/app/components/category-item.js
@@ -24,7 +24,6 @@ const {
  */
 export default Component.extend({
   classNames: ['category-item'],
-  classNameBindings: ['selected'],
   isLoading: false,
 
   /**
@@ -38,6 +37,21 @@ export default Component.extend({
    * @type Ember.Service
    */
   userCategories: service(),
+
+  /**
+   * Returns the class name for the icon.
+   *
+   * @property iconClass
+   * @type String
+   */
+  iconClass: computed('category.slug', 'selected', function() {
+    let slug = get(this, 'category.slug');
+    if (get(this, 'selected')) {
+      return `category-item__icon--${slug}--selected`;
+    } else {
+      return `category-item__icon--${slug}`;
+    }
+  }),
 
   /**
    * Returns if the category has been selected by the user.

--- a/app/components/demo-category-item.js
+++ b/app/components/demo-category-item.js
@@ -1,7 +1,16 @@
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { Component, computed, get } = Ember;
 
 export default Component.extend({
-  classNames: ['category-item']
+  classNames: ['category-item'],
+
+  iconClass: computed('category.slug', 'selected', function() {
+    let slug = get(this, 'category.slug');
+    if (get(this, 'selected')) {
+      return `category-item__icon--${slug}--selected`;
+    } else {
+      return `category-item__icon--${slug}`;
+    }
+  })
 });

--- a/app/components/demo-projects.js
+++ b/app/components/demo-projects.js
@@ -17,12 +17,16 @@ export default Component.extend({
         {
           name: 'Society',
           selected: false,
-          slug: 'society'
+          slug: 'society',
+          className: 'category-item__icon--small--society',
+          selectedClassName: 'category-item__icon--small--society--selected'
         },
         {
           name: 'Technology',
           selected: true,
-          slug: 'technology'
+          slug: 'technology',
+          className: 'category-item__icon--small--technology',
+          selectedClassName: 'category-item__icon--small--technology--selected'
         }
       ],
       skills: [
@@ -61,17 +65,23 @@ export default Component.extend({
         {
           name: 'Government',
           selected: true,
-          slug: 'government'
+          slug: 'government',
+          className: 'category-item__icon--small--government',
+          selectedClassName: 'category-item__icon--small--government--selected'
         },
         {
           name: 'Politics',
           selected: false,
-          slug: 'politics'
+          slug: 'politics',
+          className: 'category-item__icon--small--politics',
+          selectedClassName: 'category-item__icon--small--politics--selected'
         },
         {
           name: 'Society',
           selected: false,
-          slug: 'society'
+          slug: 'society',
+          className: 'category-item__icon--small--society',
+          selectedClassName: 'category-item__icon--small--society--selected'
         }
       ],
       skills: [

--- a/app/components/project-category-item.js
+++ b/app/components/project-category-item.js
@@ -4,6 +4,7 @@ const {
   Component,
   computed,
   computed: { alias, notEmpty },
+  get,
   inject: { service }
 } = Ember;
 
@@ -23,6 +24,21 @@ const {
 export default Component.extend({
   classNames: ['project-category-item'],
   tagName: ['li'],
+
+  /**
+   * Returns the class name for the icon.
+   *
+   * @property iconClass
+   * @type String
+   */
+  iconClass: computed('category.slug', 'selected', function() {
+    let slug = get(this, 'category.slug');
+    if (get(this, 'selected')) {
+      return `category-item__icon--small--${slug}--selected`;
+    } else {
+      return `category-item__icon--small--${slug}`;
+    }
+  }),
 
   /**
     Returns true if 'userCategory' is not empty

--- a/app/styles/_icons.scss
+++ b/app/styles/_icons.scss
@@ -160,106 +160,110 @@ $security-hover: 35px 35px $interestsURL -70px -210px $interestsx2URL;
 $technology-hover: 35px 35px $interestsURL 0px -245px $interestsx2URL;
 $transportation-hover: 35px 35px $interestsURL -35px -245px $interestsx2URL;
 
-.interest-icon {
-  display: block;
-  height: 35px;
-  width: 35px;
+.category-item {
+  &__icon {
+    &--small {
+      display: block;
+      height: 35px;
+      width: 35px;
 
-  &.arts {
-    @include interestIconSprite($arts);
-    &:hover, &.selected {
-      @include interestIconSprite($arts-hover);
-    }
-  }
+      &--arts {
+        @include interestIconSprite($arts);
+        &--selected {
+          @include interestIconSprite($arts-hover);
+        }
+      }
 
-  &.economy {
-    @include interestIconSprite($economy);
-    &:hover, &.selected {
-      @include interestIconSprite($economy-hover);
-    }
-  }
+      &--economy {
+        @include interestIconSprite($economy);
+        &--selected {
+          @include interestIconSprite($economy-hover);
+        }
+      }
 
-  &.education {
-    @include interestIconSprite($education);
-    &:hover, &.selected {
-      @include interestIconSprite($education-hover);
-    }
-  }
+      &--education {
+        @include interestIconSprite($education);
+        &--selected {
+          @include interestIconSprite($education-hover);
+        }
+      }
 
-  &.environment {
-    @include interestIconSprite($environment);
-    &:hover, &.selected {
-      @include interestIconSprite($environment-hover);
-    }
-  }
+      &--environment {
+        @include interestIconSprite($environment);
+        &--selected {
+          @include interestIconSprite($environment-hover);
+        }
+      }
 
-  &.government {
-    @include interestIconSprite($government);
-    &:hover, &.selected {
-      @include interestIconSprite($government-hover);
-    }
-  }
+      &--government {
+        @include interestIconSprite($government);
+        &--selected {
+          @include interestIconSprite($government-hover);
+        }
+      }
 
-  &.health {
-    @include interestIconSprite($health);
-    &:hover, &.selected {
-      @include interestIconSprite($health-hover);
-    }
-  }
+      &--health {
+        @include interestIconSprite($health);
+        &--selected {
+          @include interestIconSprite($health-hover);
+        }
+      }
 
-  &.justice {
-    @include interestIconSprite($justice);
-    &:hover, &.selected {
-      @include interestIconSprite($justice-hover);
-    }
-  }
+      &--justice {
+        @include interestIconSprite($justice);
+        &--selected {
+          @include interestIconSprite($justice-hover);
+        }
+      }
 
-  &.politics {
-    @include interestIconSprite($politics);
-    &:hover, &.selected {
-      @include interestIconSprite($politics-hover);
-    }
-  }
+      &--politics {
+        @include interestIconSprite($politics);
+        &--selected {
+          @include interestIconSprite($politics-hover);
+        }
+      }
 
-  &.public-safety {
-    @include interestIconSprite($public-safety);
-    &:hover, &.selected {
-      @include interestIconSprite($public-safety-hover);
-    }
-  }
+      &--public-safety {
+        @include interestIconSprite($public-safety);
+        &--selected {
+          @include interestIconSprite($public-safety-hover);
+        }
+      }
 
-  &.science {
-    @include interestIconSprite($science);
-    &:hover, &.selected {
-      @include interestIconSprite($science-hover);
-    }
-  }
+      &--science {
+        @include interestIconSprite($science);
+        &--selected {
+          @include interestIconSprite($science-hover);
+        }
+      }
 
-  &.security {
-    @include interestIconSprite($security);
-    &:hover, &.selected {
-      @include interestIconSprite($security-hover);
-    }
-  }
+      &--security {
+        @include interestIconSprite($security);
+        &--selected {
+          @include interestIconSprite($security-hover);
+        }
+      }
 
-  &.society {
-    @include interestIconSprite($society);
-    &:hover, &.selected {
-      @include interestIconSprite($society-hover);
-    }
-  }
+      &--society {
+        @include interestIconSprite($society);
+        &--selected {
+          @include interestIconSprite($society-hover);
+        }
+      }
 
-  &.technology {
-    @include interestIconSprite($technology);
-    &:hover, &.selected {
-      @include interestIconSprite($technology-hover);
-    }
-  }
+      &--technology {
+        @include interestIconSprite($technology);
+        &--selected {
+          @include interestIconSprite($technology-hover);
+        }
+      }
 
-  &.transportation {
-    @include interestIconSprite($transportation);
-    &:hover, &.selected {
-      @include interestIconSprite($transportation-hover);
+      &--transportation {
+        @include interestIconSprite($transportation);
+        &--selected {
+          @include interestIconSprite($transportation-hover);
+        }
+      }
     }
   }
 }
@@ -315,93 +319,96 @@ $society: 70px 70px $categoriesURL -350px -70px $categoriesx2URL;
 $technology: 70px 70px $categoriesURL 0px -140px $categoriesx2URL;
 $transportation: 70px 70px $categoriesURL -70px -140px $categoriesx2URL;
 
-.category-icon {
-  display: block;
-  height: 70px;
-  margin: 10px auto;
-  width: 70px;
-  &.arts {
-    @include categoryIconSprite($arts);
-    &.selected {
-      @include categoryIconSprite($arts-hover);
+.category-item {
+  &__icon {
+    display: block;
+    height: 70px;
+    margin: 10px auto;
+    width: 70px;
+
+    &--arts {
+      @include categoryIconSprite($arts);
+      &--selected {
+        @include categoryIconSprite($arts-hover);
+      }
     }
-  }
-  &.economy {
-    @include categoryIconSprite($economy);
-    &.selected {
-      @include categoryIconSprite($economy-hover);
+    &--economy {
+      @include categoryIconSprite($economy);
+      &--selected {
+        @include categoryIconSprite($economy-hover);
+      }
     }
-  }
-  &.education {
-    @include categoryIconSprite($education);
-    &.selected {
-      @include categoryIconSprite($education-hover);
+    &--education {
+      @include categoryIconSprite($education);
+      &--selected {
+        @include categoryIconSprite($education-hover);
+      }
     }
-  }
-  &.environment {
-    @include categoryIconSprite($environment);
-    &.selected {
-      @include categoryIconSprite($environment-hover);
+    &--environment {
+      @include categoryIconSprite($environment);
+      &--selected {
+        @include categoryIconSprite($environment-hover);
+      }
     }
-  }
-  &.government {
-    @include categoryIconSprite($government);
-    &.selected {
-      @include categoryIconSprite($government-hover);
+    &--government {
+      @include categoryIconSprite($government);
+      &--selected {
+        @include categoryIconSprite($government-hover);
+      }
     }
-  }
-  &.health {
-    @include categoryIconSprite($health);
-    &.selected {
-      @include categoryIconSprite($health-hover);
+    &--health {
+      @include categoryIconSprite($health);
+      &--selected {
+        @include categoryIconSprite($health-hover);
+      }
     }
-  }
-  &.justice {
-    @include categoryIconSprite($justice);
-    &.selected {
-      @include categoryIconSprite($justice-hover);
+    &--justice {
+      @include categoryIconSprite($justice);
+      &--selected {
+        @include categoryIconSprite($justice-hover);
+      }
     }
-  }
-  &.politics {
-    @include categoryIconSprite($politics);
-    &.selected {
-      @include categoryIconSprite($politics-hover);
+    &--politics {
+      @include categoryIconSprite($politics);
+      &--selected {
+        @include categoryIconSprite($politics-hover);
+      }
     }
-  }
-  &.public-safety {
-    @include categoryIconSprite($public-safety);
-    &.selected {
-      @include categoryIconSprite($public-safety-hover);
+    &--public-safety {
+      @include categoryIconSprite($public-safety);
+      &--selected {
+        @include categoryIconSprite($public-safety-hover);
+      }
     }
-  }
-  &.science {
-    @include categoryIconSprite($science);
-    &.selected {
-      @include categoryIconSprite($science-hover);
+    &--science {
+      @include categoryIconSprite($science);
+      &--selected {
+        @include categoryIconSprite($science-hover);
+      }
     }
-  }
-  &.security {
-    @include categoryIconSprite($security);
-    &.selected {
-      @include categoryIconSprite($security-hover);
+    &--security {
+      @include categoryIconSprite($security);
+      &--selected {
+        @include categoryIconSprite($security-hover);
+      }
     }
-  }
-  &.society {
-    @include categoryIconSprite($society);
-    &.selected {
-      @include categoryIconSprite($society-hover);
+    &--society {
+      @include categoryIconSprite($society);
+      &--selected {
+        @include categoryIconSprite($society-hover);
+      }
     }
-  }
-  &.technology {
-    @include categoryIconSprite($technology);
-    &.selected {
-      @include categoryIconSprite($technology-hover);
+    &--technology {
+      @include categoryIconSprite($technology);
+      &--selected {
+        @include categoryIconSprite($technology-hover);
+      }
     }
-  }
-  &.transportation {
-    @include categoryIconSprite($transportation);
-    &.selected {
-      @include categoryIconSprite($transportation-hover);
+    &--transportation {
+      @include categoryIconSprite($transportation);
+      &--selected {
+        @include categoryIconSprite($transportation-hover);
+      }
     }
   }
 }

--- a/app/styles/components/category-item.scss
+++ b/app/styles/components/category-item.scss
@@ -13,7 +13,7 @@
     font-size: $body-font-size-small;
     margin: 10px 0;
 
-    &.selected {
+    .selected & {
       color: $default-color;
     }
   }

--- a/app/styles/components/related-skills.scss
+++ b/app/styles/components/related-skills.scss
@@ -44,7 +44,7 @@
   }
 
   .skills {
-    $font-size: $body-font-size-tiny;
+    $font-size: $body-font-size-small;
     $line-height: $font-size * 1.6;
     $lines-to-show: 3;
 

--- a/app/styles/templates/index.scss
+++ b/app/styles/templates/index.scss
@@ -1,6 +1,6 @@
 .landing {
   .landing-section {
-    margin-bottom: 80px;
+    margin: 80px 0;
     text-align: center;
   }
 
@@ -15,12 +15,6 @@
     font-family: "HelveticaNeueThin", "HelveticaNeue-Thin", "Helvetica Neue Thin", "HelveticaNeue", "Helvetica Neue", 'TeXGyreHerosRegular', "Arial", sans-serif;
     font-size: $header-font-size-large;
     font-weight: 200;
-    margin: 10px;
-  }
-
-  h4 {
-    font-size: $header-font-size-large;
-    font-weight: 500;
     margin: 10px;
   }
 
@@ -171,6 +165,12 @@
 .landing-subsection-header {
   display: none;
   margin-bottom: 30px;
+
+  h4 {
+    font-size: $header-font-size-large;
+    font-weight: 500;
+    margin: 10px;
+  }
 }
 
 .landing-subsection-content {

--- a/app/templates/components/category-item.hbs
+++ b/app/templates/components/category-item.hbs
@@ -1,4 +1,4 @@
-<div class="category-icon {{category.slug}} {{if selected "selected"}}"></div>
+<div class="category-item__icon {{iconClass}}"></div>
 
 {{#if selected}}
   <button class="default has-spinner" {{action "removeCategory" category}} disabled={{isLoading}}>
@@ -12,4 +12,4 @@
   </button>
 {{/if}}
 
-<p class="{{if selected "selected"}}">{{category.description}}</p>
+<p>{{category.description}}</p>

--- a/app/templates/components/demo-category-item.hbs
+++ b/app/templates/components/demo-category-item.hbs
@@ -1,4 +1,4 @@
-<div class="category-icon {{category.slug}} {{if category.selected "selected"}}"></div>
+<div class="category-item__icon {{iconClass}}"></div>
 
 {{#if category.selected}}
   <button class="default has-spinner" disabled={{category.isLoading}}><span class="{{if category.isLoading "button-spinner" "check-mark"}}"></span>{{category.name}}</button>

--- a/app/templates/components/demo-projects.hbs
+++ b/app/templates/components/demo-projects.hbs
@@ -11,14 +11,14 @@
       <ul class="categories">
         {{#each project.categories as |category|}}
           <li>
-            <a class="interest-icon {{category.slug}} {{if category.selected "selected"}}"></a>
+            <a class="category-item__icon--small {{category.className}} {{if category.selected category.selectedClassName}}"></a>
           </li>
         {{/each}}
       </ul>
       <p class="description">
         {{project.description}}
       </p>
-      <div class="project-card-skills">
+      <div class="project-card__skills related-skills">
         <ul class="skills">
           {{#each project.skills as |skill|}}
             {{skill-list-item skill=skill}}

--- a/app/templates/components/project-category-item.hbs
+++ b/app/templates/components/project-category-item.hbs
@@ -1,6 +1,6 @@
 {{#link-to 'projects-list'
-  class="interest-icon"
-  classNameBindings="category.slug selected"
+  class="category-item__icon--small"
+  classNameBindings="iconClass"
 }}
 {{/link-to}}
 {{#tooltip-on-component

--- a/tests/integration/components/project-category-item-test.js
+++ b/tests/integration/components/project-category-item-test.js
@@ -54,8 +54,8 @@ test('it works for unselected categories', function(assert) {
   this.set('category', category);
   renderPage();
 
-  assert.ok(page.linkIcon.hasClass('technology'), 'Dynamic category class is properly bound.');
-  assert.ok(page.linkIcon.unselected, 'Icon is unselected.');
+  assert.ok(page.linkIcon.classContains('technology'), 'Dynamic category class is properly bound.');
+  assert.notOk(page.linkIcon.classContains('selected'), 'Icon is unselected.');
   assert.ok(page.isTooltipTarget, 'Component works as a tooltip target.');
   assert.equal(page.tooltip.text, 'Technology', 'Dynamic tooltip text is properly bound.');
   assert.ok(page.tooltip.isAriaHidden, 'Aria attribute is bound as hidden by default.');
@@ -80,8 +80,8 @@ test('it works for selected categories', function(assert) {
   this.set('category', category);
   renderPage();
 
-  assert.ok(page.linkIcon.hasClass('society'));
-  assert.ok(page.linkIcon.selected);
+  assert.ok(page.linkIcon.classContains('society'));
+  assert.ok(page.linkIcon.classContains('selected'));
   assert.ok(page.isTooltipTarget);
   assert.equal(page.tooltip.text, 'Society');
   assert.ok(page.tooltip.isAriaHidden);

--- a/tests/pages/components/category-item.js
+++ b/tests/pages/components/category-item.js
@@ -1,0 +1,28 @@
+import { attribute, hasClass, notHasClass } from 'ember-cli-page-object';
+
+export default {
+  scope: '.category-item',
+
+  button: {
+    scope: 'button',
+    spinning: hasClass('button-spinner', 'span'),
+    notSpinning: notHasClass('button-spinner', 'span'),
+    checked: hasClass('check-mark', 'span'),
+    unchecked: hasClass('check-area', 'span')
+  },
+
+  description: {
+    scope: 'p'
+  },
+
+  icon: {
+    scope: '.category-item__icon',
+    cssClass: attribute('class'),
+    classContains(klass) {
+      return this.cssClass.indexOf(klass) > -1;
+    }
+  },
+
+  selected: hasClass('selected'),
+  unselected: notHasClass('selected')
+};

--- a/tests/pages/components/project-category-item.js
+++ b/tests/pages/components/project-category-item.js
@@ -1,4 +1,4 @@
-import { attribute, hasClass, notHasClass, triggerable } from 'ember-cli-page-object';
+import { attribute, hasClass, triggerable } from 'ember-cli-page-object';
 import tooltip from 'code-corps-ember/tests/pages/helpers/tooltip';
 
 export default {
@@ -8,10 +8,8 @@ export default {
 
   linkIcon: {
     scope: 'a',
-    selected: hasClass('selected'),
-    unselected: notHasClass('selected'),
     cssClass: attribute('class'),
-    hasClass(klass) {
+    classContains(klass) {
       return this.cssClass.indexOf(klass) > -1;
     }
   },


### PR DESCRIPTION
# What's in this PR?

This PR introduces the `category-item` page object.

While implementing it, I also simplified the component slightly.

Before this, we were binding the `selected` and `category.slug` properties as css classes on multiple different elements within the component.

With a minor `.scss` rewrite, I was able to make it so we just need a `classsNameBindings` for both at the root level of the component.

I decided to leave the `getFlashMessageX` helpers as is, since they deal with testing the associated service, not the actual UI, so they don't really fit within the page object. Integration tests will not have the flash messages rendered, since the service does that at the application level, meaning we can't ditch them at integration test level.