### PR TITLE
1083 fix unassign issue

### DIFF
--- a/app/components/organization-profile.js
+++ b/app/components/organization-profile.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const {
   Component,
-  computed: { mapBy },
+  computed: { alias, mapBy },
   inject: { service }
 } = Ember;
 
@@ -11,7 +11,8 @@ export default Component.extend({
 
   credentials: service(),
 
-  organizationMembers: mapBy('organization.organizationMemberships', 'member'),
+  members: mapBy('organization.organizationMemberships', 'member'),
+  membersCount: alias('members.length'),
 
   didReceiveAttrs() {
     this._super(...arguments);

--- a/app/components/project-card-members.js
+++ b/app/components/project-card-members.js
@@ -40,10 +40,10 @@ export default Component.extend({
   /**
     Total number of members of a project.
 
-    @property totalMembersCount
+    @property membersCount
     @type Number
   */
-  totalMembersCount: alias('members.length'),
+  membersCount: alias('members.length'),
 
   /**
     Total number of members not shown on the project card.
@@ -51,8 +51,8 @@ export default Component.extend({
     @property hiddenMembersCount
     @type Number
   */
-  hiddenMembersCount: computed('totalMembersCount', function() {
-    return this.get('totalMembersCount') -  VISIBLE_MEMBERS_COUNT;
+  hiddenMembersCount: computed('membersCount', function() {
+    return this.get('membersCount') -  VISIBLE_MEMBERS_COUNT;
   }),
 
   /**

--- a/app/controllers/project/index.js
+++ b/app/controllers/project/index.js
@@ -3,19 +3,22 @@ import Ember from 'ember';
 const {
   Controller,
   computed: { alias, mapBy },
+  get,
   inject: { service }
 } = Ember;
 
 export default Controller.extend({
-  store: service(),
   currentUser: service(),
+  store: service(),
 
-  user: alias('currentUser.user'),
+  members: mapBy('project.organization.organizationMemberships', 'member'),
+  membersCount: alias('members.length'),
   projectSkills: mapBy('project.projectSkills', 'skill'),
+  user: alias('currentUser.user'),
 
   actions: {
     saveSubscription(amount) {
-      let project = this.get('project');
+      let project = get(this, 'project');
       let queryParams = { amount };
       this.transitionToRoute('project.donate', project, { queryParams });
     }

--- a/app/controllers/project/tasks/index.js
+++ b/app/controllers/project/tasks/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 const {
-  computed: { alias, sort },
+  computed: { sort },
   Controller,
   get,
   inject: { service },
@@ -27,9 +27,7 @@ export default Controller.extend({
     enabledEvents: ['drag', 'drop']
   },
 
-  members: alias('project.organization.organizationMembers'),
   orderedTaskLists: sort('project.taskLists', 'taskListsSorting'),
-  project: alias('model'),
 
   actions: {
     onDrop(droppedTaskEl, listDropTargetEl, source, siblingTaskEl) {

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -24,6 +24,5 @@ export default Model.extend({
   hasPendingMembers: gt('pendingMembersCount', 0),
   organizationMembers: mapBy('organizationMemberships', 'member'),
   pendingMembersCount: alias('pendingMemberships.length'),
-  pendingMemberships: filterBy('organizationMemberships', 'isPending'),
-  totalMembersCount: alias('organizationMembers.length')
+  pendingMemberships: filterBy('organizationMemberships', 'isPending')
 });

--- a/app/routes/project/tasks/index.js
+++ b/app/routes/project/tasks/index.js
@@ -3,14 +3,21 @@ import Ember from 'ember';
 const {
   get,
   inject: { service },
-  Route
+  Route,
+  RSVP
  } = Ember;
 
 export default Route.extend({
   projectTaskBoard: service(),
 
   model() {
-    return this.modelFor('project');
+    let project = this.modelFor('project');
+    let members = RSVP.all(get(project, 'organization.organizationMemberships').mapBy('member'));
+    return RSVP.hash({ project, members });
+  },
+
+  setupController(controller, models) {
+    controller.setProperties(models);
   },
 
   actions: {

--- a/app/services/task-assignment.js
+++ b/app/services/task-assignment.js
@@ -10,35 +10,70 @@ const {
 export default Service.extend({
   store: service(),
 
+  /**
+    Assign a task to a user.
+
+    If there's already a user task for the task passed in, it updates th
+    existing record. Otherwise, it createes a new record.
+
+    @method assign
+    @param {DS.Model} task
+    @param {DS.Model} user
+    @return {DS.Model} userTask
+  */
   async assign(task, user) {
     let userTask = await get(task, 'userTask');
+    // If there's already a userTask, update, otherwise create a new one
     return userTask ? this._update(userTask, user) : this._create(user, task);
   },
 
+  /**
+    Check if a task is assigned to a user.
+
+    @method isAssignedTo
+    @param {DS.Model} task
+    @param {DS.Model} user
+    @return {Boolean}
+  */
   async isAssignedTo(task, user) {
     return await get(task, 'userTask.user.id') === get(user, 'id');
   },
 
+  /**
+    Unassign a task.
+
+    For the given task, unassign it from whomever it's assigned to. This simply
+    destroys the userTask record for that task.
+
+    @method assign
+    @param {DS.Model} task
+    @return {DS.Model} userTask
+  */
   async unassign(task) {
     let userTask = await get(task, 'userTask');
 
     if (userTask) {
-      return this._destroy(userTask);
+      return userTask.destroyRecord();
     }
   },
 
   _create(user, task) {
     let store = get(this, 'store');
-    return store.createRecord('user-task', { user, task })
-                .save();
-  },
-
-  _destroy(userTask) {
-    return userTask.destroyRecord();
+    let userTask = store.createRecord('user-task', { user, task });
+    return userTask.save().catch(() => {
+      userTask.unloadRecord();
+    });
   },
 
   _update(userTask, user) {
+    // rollbackAttributes does not roll back relationships,
+    // so we need to reset if it fails
+    let oldUser = get(userTask, 'user');
     set(userTask, 'user', user);
-    return userTask.save();
+    return userTask.save().catch(() => {
+      set(userTask, 'user', oldUser);
+      // so it's not dirty anymore
+      userTask.rollbackAttributes();
+    });
   }
 });

--- a/app/templates/components/organization-profile.hbs
+++ b/app/templates/components/organization-profile.hbs
@@ -11,7 +11,7 @@
 
   <div class="organization-sidebar">
     <div class="organization-sidebar__section">
-      {{organization-members count=organization.totalMembersCount members=organizationMembers}}
+      {{organization-members count=membersCount members=members}}
     </div>
   </div>
 </div>

--- a/app/templates/project/index.hbs
+++ b/app/templates/project/index.hbs
@@ -29,7 +29,7 @@
       {{/if}}
 
       <section class="project-sidebar__section">
-        {{organization-members count=project.organization.totalMembersCount members=project.organization.organizationMembers}}
+        {{organization-members count=membersCount members=members}}
       </section>
 
       <section class="project-sidebar__section">

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -691,6 +691,15 @@ export default function() {
   // DELETE /user-skills/:id
   this.delete('/user-skills/:id');
 
+  /**
+  * User tasks
+  */
+  this.get('/user-tasks', { coalesce: true });
+  this.patch('/user-tasks/:id');
+  this.post('/user-tasks');
+  this.get('/user-tasks/:id');
+  this.delete('/user-tasks/:id');
+
   // Create a passthrough for ember-cli-code-coverage
   // https://github.com/kategengler/ember-cli-code-coverage
   this.passthrough('/write-coverage');

--- a/mirage/models/task.js
+++ b/mirage/models/task.js
@@ -6,5 +6,6 @@ export default Model.extend({
   taskList: belongsTo(),
   taskUserMentions: hasMany(),
   project: belongsTo(),
-  user: belongsTo()
+  user: belongsTo(),
+  userTask: belongsTo()
 });

--- a/mirage/models/user-task.js
+++ b/mirage/models/user-task.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  task: belongsTo(),
+  user: belongsTo()
+});

--- a/tests/acceptance/task-list-test.js
+++ b/tests/acceptance/task-list-test.js
@@ -1,0 +1,82 @@
+import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
+import { test } from 'qunit';
+import createProjectWithSluggedRoute from 'code-corps-ember/tests/helpers/mirage/create-project-with-slugged-route';
+import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
+import page from '../pages/project/tasks/index';
+
+moduleForAcceptance('Acceptance | Task List');
+
+function createContributor(organization) {
+  return createMemberWithRole(organization, 'contributor');
+}
+
+function createMemberWithRole(organization, role) {
+  let member = server.create('user');
+  server.create('organizationMembership', { member, organization, role });
+  return member;
+}
+
+test('member can assign/reassign/unassign tasks to user', function(assert) {
+  assert.expect(7);
+
+  let project = createProjectWithSluggedRoute();
+
+  let { organization } = project;
+  let currentUser = createContributor(organization);
+  let taskList = server.create('task-list', { project });
+  server.create('task', { project, taskList });
+
+  let otherUsers = server.createList('user', 5);
+  otherUsers.forEach((member) => {
+    server.create('organizationMembership', { member, organization, role: 'contributor' });
+  });
+
+  authenticateSession(this.application, { user_id: currentUser.id });
+
+  page.visit({
+    organization: organization.slug,
+    project: project.slug
+  });
+
+  let taskCard;
+
+  andThen(() => {
+    taskCard = page.taskBoard.taskLists(0).taskCards(0);
+    assert.ok(taskCard.taskAssignment.trigger.unassigned, 'Task is rendered unassigned.');
+    taskCard.taskAssignment.trigger.open();
+  });
+
+  andThen(() => {
+    taskCard.taskAssignment.dropdown.options(0).select();
+  });
+
+  andThen(() => {
+    // assert assignment went through
+    assert.ok(taskCard.taskAssignment.trigger.assigned, 'Task is rendered assigned.');
+    let userTask = server.schema.userTasks.first();
+    assert.equal(userTask.user.username, taskCard.taskAssignment.trigger.text, 'Assigned user is rendered.');
+    taskCard.taskAssignment.trigger.open();
+  });
+
+  andThen(() => {
+    taskCard.taskAssignment.dropdown.options(1).select();
+  });
+
+  andThen(() => {
+    // assert reassignment went through
+    assert.ok(taskCard.taskAssignment.trigger.assigned, 'Task is rendered assigned.');
+    let userTask = server.schema.userTasks.first();
+    assert.equal(userTask.user.username, taskCard.taskAssignment.trigger.text, 'Assigned user is rendered.');
+    taskCard.taskAssignment.trigger.open();
+  });
+
+  andThen(() => {
+    taskCard.taskAssignment.dropdown.options(1).select();
+  });
+
+  andThen(() => {
+    // assert unassignment went through
+    assert.equal(server.schema.userTasks.all().models.length, 0, 'The record was destroyed.');
+    assert.ok(taskCard.taskAssignment.trigger.unassigned, 'Task is rendered unassigned.');
+  });
+});

--- a/tests/integration/components/task-card-test.js
+++ b/tests/integration/components/task-card-test.js
@@ -4,12 +4,12 @@ import PageObject from 'ember-cli-page-object';
 import taskCardComponent from 'code-corps-ember/tests/pages/components/task-card';
 import moment from 'moment';
 import { Ability } from 'ember-can';
-import Ember from 'ember';
 import DS from 'ember-data';
+import Ember from 'ember';
 import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
-const { RSVP, set, setProperties } = Ember;
 const { PromiseObject } = DS;
+const { RSVP, set, setProperties } = Ember;
 
 let page = PageObject.create(taskCardComponent);
 
@@ -48,7 +48,7 @@ test('it renders all the required elements', function(assert) {
     title: 'Clean the house'
   };
 
-  this.set('task', task);
+  set(this, 'task', task);
   this.render(hbs`{{task-card task=task}}`);
 
   assert.equal(page.number.text, '#1', 'The number renders');
@@ -82,10 +82,10 @@ test('it sends action if clicked and not loading', function(assert) {
     number: 1
   };
 
-  this.set('clickedTask', function(clickedTask) {
+  set(this, 'clickedTask', function(clickedTask) {
     assert.deepEqual(clickedTask, task);
   });
-  this.set('task', task);
+  set(this, 'task', task);
 
   this.render(hbs`{{task-card clickedTask=clickedTask task=task}}`);
   page.click();
@@ -99,10 +99,10 @@ test('it does not send action if clicked and loading', function(assert) {
     number: 1
   };
 
-  this.set('clickedTask', function() {
+  set(this, 'clickedTask', function() {
     assert.notOk();
   });
-  this.set('task', task);
+  set(this, 'task', task);
 
   this.render(hbs`{{task-card clickedTask=clickedTask task=task}}`);
   page.click();
@@ -110,14 +110,11 @@ test('it does not send action if clicked and loading', function(assert) {
 });
 
 test('assignment works if user has ability', function(assert) {
-  assert.expect(2);
-
-  // there is some async behavior here, so we need to explicitly be `done()`
   let done = assert.async();
+  assert.expect(2);
 
   let task = { id: 'task' };
   let user = { id: 'user', username: 'testuser' };
-
   let members = [user];
 
   setProperties(this, { task, members });
@@ -143,17 +140,15 @@ test('assignment works if user has ability', function(assert) {
 });
 
 test('unassignment works if user has ability', function(assert) {
-  assert.expect(1);
-
-  // there is some async behavior here, so we need to explicitly be `done()`
   let done = assert.async();
+  assert.expect(1);
 
   let task = { id: 'task' };
   let user = { id: 'user', username: 'testuser' };
-
   let members = [user];
+  let taskUser = user;
 
-  setProperties(this, { task, taskUser: user, members });
+  setProperties(this, { task, members, taskUser });
 
   stubService(this, 'task-assignment', {
     unassign(sentTask) {
@@ -172,13 +167,12 @@ test('unassignment works if user has ability', function(assert) {
   page.taskAssignment.dropdown.options(0).select();
 });
 
-test('assignment dropdown renders when records are loaded', function(assert) {
+test('assignment dropdown renders', function(assert) {
   assert.expect(2);
 
   let task = { id: 'task' };
   let user1 = { id: 'user1', username: 'testuser1' };
   let user2 = { id: 'user2', username: 'testuser2' };
-
   let members = [user1, user2];
 
   setProperties(this, { task, members });
@@ -194,15 +188,13 @@ test('assignment dropdown renders when records are loaded', function(assert) {
   renderPage();
 
   page.taskAssignment.trigger.open();
-
   assert.equal(page.taskAssignment.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
   assert.equal(page.taskAssignment.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
 });
 
 test('assignment dropdown renders when records are still being loaded', function(assert) {
-  assert.expect(2);
-
   let done = assert.async();
+  assert.expect(2);
 
   let task = { id: 'task' };
   let user1 = { id: 'user1', username: 'testuser1' };
@@ -221,12 +213,6 @@ test('assignment dropdown renders when records are still being loaded', function
   let members = [user1, user2].map((user) => proxify(user));
 
   setProperties(this, { task, members });
-
-  stubService(this, 'task-assignment', {
-    isAssignedTo() {
-      return RSVP.resolve(false);
-    }
-  });
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 

--- a/tests/pages/components/power-select.js
+++ b/tests/pages/components/power-select.js
@@ -17,7 +17,20 @@ import { clickTrigger, nativeMouseUp } from 'code-corps-ember/tests/helpers/embe
 
 export default {
   trigger: {
-    open: clickTrigger
+    scope: '.ember-power-select-trigger',
+    open: clickTrigger,
+    unassigned: {
+      isDescriptor: true,
+      get() {
+        return this.text === 'No one yet';
+      }
+    },
+    assigned: {
+      isDescriptor: true,
+      get() {
+        return !this.unassigned;
+      }
+    }
   },
 
   dropdown: {

--- a/tests/unit/services/task-assignment-test.js
+++ b/tests/unit/services/task-assignment-test.js
@@ -104,3 +104,49 @@ test('it unassigns a task from the user using unassign', function(assert) {
     done();
   });
 });
+
+test('it calls unloadRecord if assign fails', function(assert) {
+  let done = assert.async();
+  let service = this.subject();
+
+  let rejectingStore = Object.create({
+    createRecord() {
+      return Object.create({
+        save() {
+          return RSVP.reject();
+        },
+        unloadRecord() {
+          assert.ok(true);
+          done();
+        }
+      });
+    }
+  });
+
+  set(service, 'store', rejectingStore);
+
+  service.assign(Object.create(), Object.create());
+});
+
+test('it calls rollbackAttributes if assign fails', function(assert) {
+  let done = assert.async();
+  let service = this.subject();
+
+  let assignedTask = Object.create({
+    id: 'task-1',
+    userTask: Object.create({
+      rollbackAttributes() {
+        assert.ok(true);
+        done();
+      },
+      save() {
+        return RSVP.reject();
+      },
+      user: {
+        id: 'user-1'
+      }
+    })
+  });
+
+  service.assign(assignedTask, user2);
+});


### PR DESCRIPTION
# What's in this PR?

This is initial work on fixing #1090

I discovered the issue while adding acceptance tests to task assignment.

Turns out, I caused the bug by removing the `mapBy('content')` within the `userOptions` method. This caused the `ember-power-select-is-equal` helper to internally fail, since it was comparing a `DS.Model` with a `DS.PromiseObject`.

This likely breaks a couple of tests, but with the computed change introduced in #1082, the sentry bug where the task list page failed to render due to fetching on id on a null object should no longer be a problem.

That being said, with the feature enabled again, it does seem like it's a bit buggy and sluggish, so maybe we should consider using another approach altogether. For example, a separate option to clear assignment might work, or we could map the options into a simpler object.

## References
Fixes #1090 