### PR TITLE
Add head template to fix ember-cli-meta-tags

### DIFF
--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,2 @@
+<title>{{model.title}}</title>
+{{head-tags headTags=model.headTags}}


### PR DESCRIPTION
# What's in this PR?

This is a simple add to fix the way we were using `ember-cli-meta-tags`. This is needed since we're using `ember-page-title`, as well.