### PR TITLE
Add meta to head in html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -8,6 +8,23 @@
     <link rel="icon" href="https://d3pgew4wbk2vb1.cloudfront.net/icons/favicon.png">
     <link rel="icon" href="https://d3pgew4wbk2vb1.cloudfront.net/icons/favicon-32.png" sizes="32x32">
 
+    <title>Code Corps | Build a better future.</title>
+    <meta property="description" content="Contribute to software projects for social good. Give your time or money to help build software to better the arts, education, government, science, and more."></meta>
+    <meta property="og:description" content="Contribute to software projects for social good. Give your time or money to help build software to better the arts, education, government, science, and more."></meta>
+    <meta property="og:image" content="https://d3pgew4wbk2vb1.cloudfront.net/images/universal-card.png"></meta>
+    <meta property="og:site_name" content="Code Corps"></meta>
+    <meta property="og:title" content="Code Corps | Build a better future."></meta>
+    <meta property="og:type" content="website"></meta>
+    <meta property="og:url" content="http://www.codecorps.org"></meta>
+    <meta name="twitter:card" content="summary_large_image"></meta>
+    <meta name="twitter:creator" content="@thecodecorps"></meta>
+    <meta name="twitter:creator:id" content="4608917052"></meta>
+    <meta name="twitter:description" content="Contribute to software projects for social good. Give your time or money to help build software to better the arts, education, government, science, and more."></meta>
+    <meta name="twitter:image" content="https://d3pgew4wbk2vb1.cloudfront.net/images/universal-card.png"></meta>
+    <meta name="twitter:site" content="@thecodecorps"></meta>
+    <meta name="twitter:site:id" content="4608917052"></meta>
+    <meta name="twitter:title" content="Code Corps | Build a better future."></meta>
+
     {{content-for "head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">


### PR DESCRIPTION
# What's in this PR?

Until we use Fastboot, etc, this is the best way to get our metadata for social sharing.

We need to remove this when fastboot comes along.