### PR TITLE
Fix alignment of ember-power-select-option icon in Firefox

### DIFF
--- a/app/styles/layout/_select-inline.scss
+++ b/app/styles/layout/_select-inline.scss
@@ -201,6 +201,7 @@ $list-height: 220px;
     &:before {
       content: "";
       height: 10px;
+      left: 10px; // fix for firefox inline
       margin: 5px 7px 0 0;
       position: absolute;
       width: $icon-width;


### PR DESCRIPTION
# What's in this PR?

Fix alignment of ember-power-select-option icon in Firefox

## References
Fixes #1116 
