### PR TITLE
Hide task assignment dropdown if user has no ability to assign

### DIFF
--- a/app/components/task-card.js
+++ b/app/components/task-card.js
@@ -29,6 +29,7 @@ export default Component.extend({
   bound: false,
   shouldShowUsers: false,
 
+  // auto-assigns 'task' property from component as ability 'model'
   ability: EmberCan.computed.ability('task'),
   canAssign: alias('ability.canAssign'),
   canEdit: alias('ability.canEdit'),

--- a/app/styles/layout/_select-inline.scss
+++ b/app/styles/layout/_select-inline.scss
@@ -45,8 +45,9 @@ $list-height: 220px;
 }
 
 .select-inline {
-  display: flex;
   align-items: center;
+  display: flex;
+  font-size: $body-font-size-small;
 
   .ember-power-select-trigger {
     align-items: left;
@@ -56,7 +57,6 @@ $list-height: 220px;
     color: $gray;
     cursor: pointer;
     display: flex;
-    font-size: $body-font-size-small;
     justify-content: left;
     position: relative;
 

--- a/app/templates/components/task-card.hbs
+++ b/app/templates/components/task-card.hbs
@@ -16,29 +16,33 @@
   <p class="task-card__meta">
     <span class="task-card__time" data-test-selector="task time">{{moment-from-now task.insertedAt}}</span>
   </p>
-  {{#power-select
-    beforeOptionsComponent=(component "power-select/before-options" selectRemoteController=selectRemoteController)
-    buildSelection=(action "buildSelection")
-    class="select-inline"
-    disabled=userSelectDisabled
-    dropdownClass="select-inline-dropdown"
-    loadingMessage=""
-    matchTriggerWidth=false
-    onchange=(action "changeUser")
-    options=userOptions
-    placeholderComponent=(component "task-card/user/unselected-item" click=(action "stopClickPropagation") task=task)
-    registerAPI=(action (mut selectRemoteController))
-    search=(action "searchUsers")
-    selected=selectedOption
-    selectedItemComponent=(component "task-card/user/selected-item" click=(action "stopClickPropagation"))
-    tagName="div"
-    as |user select|
-  }}
-    {{select-inline-dropdown/list-item
-      iconUrl=user.photoThumbUrl
-      lastSearchedText=select.lastSearchedText
-      primaryText=user.username
-      secondaryText=user.name
+  {{#if canAssign}}
+    {{#power-select
+      beforeOptionsComponent=(component "power-select/before-options" selectRemoteController=selectRemoteController)
+      buildSelection=(action "buildSelection")
+      class="select-inline"
+      disabled=userSelectDisabled
+      dropdownClass="select-inline-dropdown"
+      loadingMessage=""
+      matchTriggerWidth=false
+      onchange=(action "changeUser")
+      options=userOptions
+      placeholderComponent=(component "task-card/user/unselected-item" click=(action "stopClickPropagation") task=task)
+      registerAPI=(action (mut selectRemoteController))
+      search=(action "searchUsers")
+      selected=selectedOption
+      selectedItemComponent=(component "task-card/user/selected-item" click=(action "stopClickPropagation"))
+      tagName="div"
+      as |user select|
     }}
-  {{/power-select}}
+      {{select-inline-dropdown/list-item
+        iconUrl=user.photoThumbUrl
+        lastSearchedText=select.lastSearchedText
+        primaryText=user.username
+        secondaryText=user.name
+      }}
+    {{/power-select}}
+  {{else if taskUser}}
+    {{task-card/user/selected-item select=(hash selected = selectedOption)}}
+  {{/if}}
 {{/if}}

--- a/tests/integration/components/task-card-test.js
+++ b/tests/integration/components/task-card-test.js
@@ -167,7 +167,7 @@ test('unassignment works if user has ability', function(assert) {
   page.taskAssignment.dropdown.options(0).select();
 });
 
-test('assignment dropdown renders', function(assert) {
+test('assignment dropdown renders if user has ability', function(assert) {
   assert.expect(2);
 
   let task = { id: 'task' };
@@ -224,4 +224,33 @@ test('assignment dropdown renders when records are still being loaded', function
     assert.equal(page.taskAssignment.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
     done();
   });
+});
+
+test('assignment dropdown does not render if user has no ability', function(assert) {
+  assert.expect(3);
+
+  let task = { id: 'task' };
+  let user1 = { id: 'user1', username: 'testuser1' };
+  let user2 = {
+    id: 'user2',
+    username: 'testuser2',
+    photoThumbUrl: 'test.png'
+  };
+  let members = [user1, user2];
+
+  setProperties(this, { task, members, taskUser: user2 });
+
+  stubService(this, 'task-assignment', {
+    isAssignedTo() {
+      return RSVP.resolve(false);
+    }
+  });
+
+  this.register('ability:task', Ability.extend({ canAssign: false }));
+
+  renderPage();
+
+  assert.notOk(page.taskAssignment.triggerRenders, 'Dropdown trigger for assignment does not render.');
+  assert.equal(page.assignedUser.text, 'testuser2');
+  assert.equal(page.assignedUser.icon.url, 'test.png');
 });

--- a/tests/pages/components/power-select.js
+++ b/tests/pages/components/power-select.js
@@ -1,4 +1,4 @@
-import { collection } from 'ember-cli-page-object';
+import { collection, isVisible } from 'ember-cli-page-object';
 import { clickTrigger, nativeMouseUp } from 'code-corps-ember/tests/helpers/ember-power-select';
 
 // NOTE: The default ember-cli-page-objects do not work properly here
@@ -16,23 +16,6 @@ import { clickTrigger, nativeMouseUp } from 'code-corps-ember/tests/helpers/embe
 // We're also using the `testContainer` feature provided by ember-cli-page-object
 
 export default {
-  trigger: {
-    scope: '.ember-power-select-trigger',
-    open: clickTrigger,
-    unassigned: {
-      isDescriptor: true,
-      get() {
-        return this.text === 'No one yet';
-      }
-    },
-    assigned: {
-      isDescriptor: true,
-      get() {
-        return !this.unassigned;
-      }
-    }
-  },
-
   dropdown: {
     resetScope: true,
     testContainer: '.ember-power-select-dropdown',
@@ -45,5 +28,24 @@ export default {
         }
       }
     })
-  }
+  },
+
+  trigger: {
+    scope: '.ember-power-select-trigger',
+    assigned: {
+      isDescriptor: true,
+      get() {
+        return !this.unassigned;
+      }
+    },
+    open: clickTrigger,
+    unassigned: {
+      isDescriptor: true,
+      get() {
+        return this.text === 'No one yet';
+      }
+    }
+  },
+
+  triggerRenders: isVisible('.ember-power-select-trigger')
 };

--- a/tests/pages/components/task-card.js
+++ b/tests/pages/components/task-card.js
@@ -1,10 +1,19 @@
 import {
+  attribute,
   hasClass
 } from 'ember-cli-page-object';
 import taskAssignment from 'code-corps-ember/tests/pages/components/power-select';
 
 export default {
   scope: '.task-card',
+
+  assignedUser: {
+    scope: '.select-inline__selected-item',
+    icon: {
+      scope: 'img',
+      url: attribute('src')
+    }
+  },
 
   canReposition: hasClass('task-card--can-reposition'),
 


### PR DESCRIPTION
# What's in this PR?

Closes #1081 

We already had the ability as a component property, so all it took was to update the template and add a test.

From now on, 

- if user has the ability to assign (author, or at least project contributor), the dropdown will render
- if user has no ability, the assigned user will render if there is one, otherwise, nothing will render

## References
Fixes #1081
