### PR TITLE
Add ability to quick-add project skills to new task

### DIFF
--- a/app/components/project-skill-item.js
+++ b/app/components/project-skill-item.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+const {
+  Component,
+  getProperties
+} = Ember;
+
+export default Component.extend({
+  classNames: ['skill', 'has-spinner', 'default', 'small'],
+  tagName: 'button',
+
+  click() {
+    let { skill, onClicked } = getProperties(this, 'skill', 'onClicked');
+    onClicked(skill);
+  }
+});

--- a/app/components/project-skills-list.js
+++ b/app/components/project-skills-list.js
@@ -1,0 +1,66 @@
+import Ember from 'ember';
+
+const {
+  computed,
+  computed: { mapBy },
+  Component,
+  get,
+  getProperties
+} = Ember;
+
+export default Component.extend({
+  classNames: ['project-skills-list'],
+
+  /**
+   * Component will render the assigned header if property is set to true
+   * @property showHeader
+   */
+  showHeader: false,
+
+  /**
+   * Header the component will render if `showHeader` is set to true
+   *
+   * @property header
+   */
+  header: '',
+
+  /**
+   * The project to render the skills for
+   *
+   * @property project
+   */
+  project: null,
+
+  /**
+   * Skills not to render on the list
+   *
+   * @property excludedSkills
+   */
+  excludedSkills: [],
+
+  /**
+   * Computed property
+   * Skill records tied to the project via the projectSkills relationship
+   * @property projectSkills
+   */
+  projectSkills: mapBy('project.projectSkills', 'skill'),
+
+  /**
+   * Computed property
+   * Skills which will be rendered in the list.
+   * The project's skills, minus any skills set not to be rendered via
+   * the `excludedSkills` property
+   *
+   * @property skills
+   */
+  skills: computed('projectSkills.@each', 'excludedSkills.@each', function() {
+    // NOTE: In a perfect case, we would use `Ember.computed.setDif`
+    // However, project.projectSkills.@each.skill is fetched assinchronously, so
+    // each item in `projectSkills` is a `DS.PromiseObject` instead of a
+    // `DS.Model`, so we have to compare by id instead.
+    let { projectSkills, excludedSkills } = getProperties(this, 'projectSkills', 'excludedSkills');
+    return projectSkills.filter((skill) => {
+      return !excludedSkills || !excludedSkills.isAny('id', get(skill, 'id'));
+    });
+  })
+});

--- a/app/controllers/project/tasks/new.js
+++ b/app/controllers/project/tasks/new.js
@@ -40,8 +40,11 @@ export default Controller.extend({
 
     toggleSkill(skill) {
       let unsavedTaskSkills = get(this, 'unsavedTaskSkills');
-      if (unsavedTaskSkills.includes(skill)) {
-        unsavedTaskSkills.removeObject(skill);
+      let id = get(skill, 'id');
+
+      let unsavedSkill = unsavedTaskSkills.findBy('id', id);
+      if (unsavedSkill) {
+        unsavedTaskSkills.removeObject(unsavedSkill);
       } else {
         unsavedTaskSkills.pushObject(skill);
       }

--- a/app/styles/_buttons.scss
+++ b/app/styles/_buttons.scss
@@ -53,16 +53,6 @@
     @include focus($default-color);
   }
 
-  &.small {
-    font-size: $body-font-size-small;
-    padding: 6px 14px;
-
-    &.skill {
-      padding: 6px 9px;
-      font-size: $body-font-size-normal;
-    }
-  }
-
   &.large {
     font-size: $body-font-size-large;
     padding: 15px 40px;
@@ -88,6 +78,16 @@
 
     &.skill {
       padding: 11px 14px;
+    }
+  }
+
+  &.small {
+    font-size: $body-font-size-small;
+    padding: 6px 14px;
+
+    &.skill {
+      padding: 6px 9px;
+      font-size: $body-font-size-normal;
     }
   }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -172,6 +172,9 @@
 @import "components/user-projects-list";
 @import "components/user-sidebar";
 
+// used from task/new.hbs
+@import "components/project-skills-list";
+
 //
 // TEMPLATES
 //

--- a/app/styles/components/project-skills-list.scss
+++ b/app/styles/components/project-skills-list.scss
@@ -1,0 +1,38 @@
+.project-skills-list {
+  $color: $gray--dark;
+
+  &__header {
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    margin-bottom: 1em;
+
+    span {
+      display: inline-block;
+      vertical-align: baseline;
+      zoom: 1;
+      *display: inline;
+      *vertical-align: auto;
+      position: relative;
+      padding: 0 1em;
+      color: $color;
+
+      &:before, &:after {
+        content: '';
+        display: block;
+        width: 1000px;
+        position: absolute;
+        top: 0.73em;
+        border-top: 1px solid $color;
+      }
+
+      &:before { right: 100%; }
+      &:after { left: 100%; }
+    }
+  }
+
+  &__fallback {
+    color: $color;
+  }
+}

--- a/app/templates/components/project-skill-item.hbs
+++ b/app/templates/components/project-skill-item.hbs
@@ -1,0 +1,5 @@
+{{#if skill.isLoading}}
+  <span class="button-spinner"></span>
+{{else}}
+  {{skill.title}}
+{{/if}}

--- a/app/templates/components/project-skills-list.hbs
+++ b/app/templates/components/project-skills-list.hbs
@@ -1,0 +1,12 @@
+{{#if showHeader}}
+  <div class="project-skills-list__header">
+    <span>{{header}}</span>
+  </div>
+{{/if}}
+{{#each skills as |skill|}}
+  {{project-skill-item skill=skill onClicked=onSkillClicked}}
+{{else}}
+  <div class="project-skills-list__fallback">
+    There are no more project skills to be added.
+  </div>
+{{/each}}

--- a/app/templates/project/tasks/new.hbs
+++ b/app/templates/project/tasks/new.hbs
@@ -31,6 +31,13 @@
           skillsList=unsavedTaskSkills
         }}
       </div>
+      {{project-skills-list
+        onSkillClicked=(action 'toggleSkill')
+        project=task.project
+        excludedSkills=unsavedTaskSkills
+        showHeader=true
+        header="Or click to add skills below"
+      }}
     </div>
   </div>
 </div>

--- a/tests/integration/components/project-skill-item-test.js
+++ b/tests/integration/components/project-skill-item-test.js
@@ -1,0 +1,58 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import PageObject from 'ember-cli-page-object';
+import component from 'code-corps-ember/tests/pages/components/project-skill-item';
+
+let page = PageObject.create(component);
+
+const {
+  set
+} = Ember;
+
+function setHandler(context, clickHandler = () => {}) {
+  set(context, 'clickHandler', clickHandler);
+}
+
+function renderPage() {
+  page.render(hbs`{{project-skill-item skill=skill onClicked=clickHandler}}`);
+}
+
+moduleForComponent('project-skill-item', 'Integration | Component | project skill item', {
+  integration: true,
+  beforeEach() {
+    setHandler(this);
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders loading spinnner if skill is loading', function(assert) {
+  assert.expect(2);
+  set(this, 'skill', { isLoading: true, title: 'Test' });
+  renderPage();
+  assert.ok(page.isLoading, 'Component is rendered as loading');
+  assert.equal(page.text, '', 'Title is not rendered');
+});
+
+test('it renders skill title if skill is loaded', function(assert) {
+  assert.expect(1);
+  set(this, 'skill', { title: 'Test' });
+  renderPage();
+  assert.equal(page.text, 'Test', 'Title is rendered');
+});
+
+test('it calls action on click', function(assert) {
+  assert.expect(1);
+  let mockSkill = { id: 'skill', title: 'Skill' };
+  set(this, 'skill', mockSkill);
+
+  setHandler(this, (skill) => {
+    assert.deepEqual(skill, mockSkill, 'The sent skill matches the assigned skill.');
+  });
+
+  renderPage();
+  page.click();
+});

--- a/tests/integration/components/project-skills-list-test.js
+++ b/tests/integration/components/project-skills-list-test.js
@@ -1,0 +1,112 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import PageObject from 'ember-cli-page-object';
+import component from 'code-corps-ember/tests/pages/components/project-skills-list';
+
+let page = PageObject.create(component);
+
+const {
+  set, setProperties
+} = Ember;
+
+function setHandler(context, clickHandler = () => {}) {
+  set(context, 'clickHandler', clickHandler);
+}
+
+function renderPage() {
+  page.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
+}
+
+let ruby = { title: 'Ruby', id: 1 };
+let css = { title: 'CSS', id: 2 };
+
+let project = {
+  projectSkills: [
+    { skill: ruby },
+    { skill: css }
+  ]
+};
+
+moduleForComponent('project-skills-list', 'Integration | Component | project skills list', {
+  integration: true,
+  beforeEach() {
+    setHandler(this);
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders header if set that way', function(assert) {
+  assert.expect(1);
+
+  setProperties(this, { showHeader: true, header: 'Test' });
+  renderPage();
+
+  assert.equal(page.header.text, 'Test');
+});
+
+test('it hides header by default', function(assert) {
+  assert.expect(1);
+
+  set(this, 'header', 'Test');
+  renderPage();
+
+  assert.notOk(page.headerIsVisible, 'Header is not rendered');
+});
+
+test('it renders a list of project skills', function(assert) {
+  assert.expect(3);
+
+  set(this, 'project', project);
+
+  renderPage();
+
+  assert.equal(page.skills().count, 2, 'Correct number of skills is rendered.');
+  assert.equal(page.skills(0).text, 'Ruby', 'Skill is rendered correctly.');
+  assert.equal(page.skills(1).text, 'CSS', 'Skill is rendered correctly.');
+});
+
+test('it is able to filter out skills if exclusion list is provided', function(assert) {
+  assert.expect(2);
+
+  set(this, 'project', project);
+  set(this, 'excludedSkills', [css]);
+
+  renderPage();
+
+  assert.equal(page.skills().count, 1, 'Correct number of skills is rendered.');
+  assert.equal(page.skills(0).text, 'Ruby', 'Skill is rendered correctly.');
+});
+
+test('it renders fallback if there are no skills to render', function(assert) {
+  assert.expect(1);
+
+  renderPage();
+
+  assert.ok(page.fallbackIsVisible, 'Fallback is rendered.');
+});
+
+test('it calls proper function when clicking a skill', function(assert) {
+  assert.expect(1);
+
+  set(this, 'project', project);
+
+  setHandler(this, (skill) => {
+    assert.deepEqual(skill, css, 'Correct skill was sent on click.');
+  });
+
+  renderPage();
+
+  page.skills(1).click();
+});

--- a/tests/pages/components/project-skill-item.js
+++ b/tests/pages/components/project-skill-item.js
@@ -1,0 +1,6 @@
+import { isVisible } from 'ember-cli-page-object';
+
+export default {
+  scope: '.skill',
+  isLoading: isVisible('span')
+};

--- a/tests/pages/components/project-skills-list.js
+++ b/tests/pages/components/project-skills-list.js
@@ -1,0 +1,23 @@
+import { collection, isVisible } from 'ember-cli-page-object';
+import projectSkillItem from 'code-corps-ember/tests/pages/components/project-skill-item';
+
+export default {
+  scope: '.project-skills-list',
+
+  header: {
+    scope: '.project-skills-list__header'
+  },
+
+  headerIsVisible: isVisible('.project-skills-list__header'),
+
+  fallback: {
+    scope: '.project-skills-list__falback'
+  },
+
+  fallbackIsVisible: isVisible('.project-skills-list__fallback'),
+
+  skills: collection({
+    itemScope: '.skill',
+    item: projectSkillItem
+  })
+};

--- a/tests/pages/project/tasks/new.js
+++ b/tests/pages/project/tasks/new.js
@@ -8,6 +8,7 @@ import {
 } from 'ember-cli-page-object';
 
 import projectMenu from 'code-corps-ember/tests/pages/components/project-menu';
+import projectSkillsList from 'code-corps-ember/tests/pages/components/project-skills-list';
 import skillsTypeahead from 'code-corps-ember/tests/pages/components/skills-typeahead';
 
 export default create({
@@ -22,6 +23,7 @@ export default create({
   taskMarkdown: fillable('[name=markdown]'),
 
   projectMenu,
+  projectSkillsList,
 
   previewBody: {
     scope: '.body-preview'


### PR DESCRIPTION
# What's in this PR?

A new set of components which lists project skills in the new tasks sidebar. Clicking these assigns them as task skills to the new task.

## References
Fixes #1052