### PR TITLE
Addresses 249

### DIFF
--- a/app/components/member-list-item.js
+++ b/app/components/member-list-item.js
@@ -3,12 +3,15 @@ import Ember from 'ember';
 const {
   Component,
   get,
-  inject: { service }
+  inject: { service },
+  set
 } = Ember;
 
 export default Component.extend({
   classNames: ['member-list-item'],
   tagName: 'li',
+  showApprove: false,
+  showDeny: false,
 
   flashMessages: service(),
 
@@ -21,11 +24,17 @@ export default Component.extend({
     },
 
     deny(membership) {
-      if (confirm('Are you sure want to deny their membership?')) {
-        return membership.destroyRecord().then(() => {
-          this._flashSuccess('Membership denied');
-        });
-      }
+      return membership.destroyRecord().then(() => {
+        this._flashSuccess('Membership denied');
+      });
+    },
+
+    showApprove() {
+      set(this, 'showApprove', true);
+    },
+
+    showDeny() {
+      set(this, 'showDeny', true);
     }
   },
 

--- a/app/components/modal-confirm.js
+++ b/app/components/modal-confirm.js
@@ -1,0 +1,94 @@
+import Ember from 'ember';
+import { task } from 'ember-concurrency';
+
+const {
+  Component,
+  get,
+  set
+} = Ember;
+/**
+  `modal-confirm` Replaces javascript confirm with a modal built with ember-modal-dialog
+
+  ## default usage
+
+  ```handlebars
+  {{modal-confirm dialogText='Confirm Text' okAction=(action 'deny' membership) showDialog=showConfirm}}
+  ```
+  ### Testing
+
+  For integration tests you need the modal-dialog service to set a container even when using it as a child component
+
+  ```javascript
+  let modalDialogService = this.container.lookup('service:modal-dialog');
+  modalDialogService.destinationElementId = 'modal-container';
+
+  this.render(hbs```<`div id='modal-container'`>` `<`/div`>`{{member-list-item membership=membership user=user}}``);
+  ```
+
+  For acceptance tests using a page object you need to specify a container of **body** since is uses ember-wormhole and its container is outside of
+  ember-view
+
+  ```javascript
+  modal: {
+    testContainer: 'body',
+    confirmOk: clickable('button#ok')
+  }
+  ```
+  ```javascript
+  page.modal.confirmOk();
+  ```
+
+  @module Components
+  @extends Ember.component
+  @class modal-confirm
+ */
+export default Component.extend({
+  /**
+    Text for Cancel Button on dialog
+    @property cancelText
+    @type String
+    @default 'Cancel'
+  */
+  cancelText: 'Cancel',
+  /**
+    Text for Ok button on dialog
+
+    @property okText
+    @type String
+    @default 'Ok'
+  */
+  okText: 'Ok',
+  /**
+    @property showDialog
+    @type Boolean
+    @default false
+  */
+  showDialog: false,
+
+  actions: {
+    /**
+      Closes dialog
+      @method closeDialog
+    */
+    closeDialog() {
+      get(this, '_hideDialog').perform();
+    },
+
+    /**
+      Fires okAction closure action if one exists
+      and closes the dialog
+
+      @method okAction
+    */
+    okAction() {
+      if (this.attrs.okAction) {
+        get(this, 'okAction')();
+      }
+      this.send('closeDialog');
+    }
+  },
+
+  _hideDialog: task(function* () {
+    yield set(this, 'showDialog', false);
+  })
+});

--- a/app/components/modal-dialog.js
+++ b/app/components/modal-dialog.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
+import { EKMixin as EmberKeyboardMixin, keyDown } from 'ember-keyboard';
+
+const { on, set } = Ember;
+
+export default ModalDialog.extend(EmberKeyboardMixin, {
+  init() {
+    this._super(...arguments);
+
+    set(this, 'keyboardActivated', true);
+  },
+
+  closeOnEsc: on(keyDown('Escape'), function() {
+    this.sendAction('close');
+  })
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -17,6 +17,17 @@
 // http://neat.bourbon.io/
 @import "neat";
 
+//ember-modal-dialog
+//The ember-modal-dialog addon provides components to implement modal dialogs throughout an Ember application using a simple, consistent pattern.
+//https://github.com/yapplabs/ember-modal-dialog
+@import "ember-modal-dialog/ember-modal-structure";
+@import "ember-modal-dialog/ember-modal-appearance";
+
+.ember-modal-dialog {
+  border-radius: 4px;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.15);
+}
+
 //
 // HELPERS
 //
@@ -27,6 +38,8 @@
 
 @import "base/base";
 @import "base/helpers";
+
+
 
 //
 //
@@ -65,6 +78,7 @@
 @import "components/image-drop";
 @import "components/loading-bar";
 @import "components/member-list-item";
+@import "components/modal-confirm";
 @import "components/pager-control";
 @import "components/progress-bar";
 @import "components/settings-menu";

--- a/app/styles/components/modal-confirm.scss
+++ b/app/styles/components/modal-confirm.scss
@@ -1,0 +1,15 @@
+.modal-confirm {
+  @include span-columns(6);
+
+}
+a#cancel.modal-confirm-cancel {
+  color: $red;
+  text-decoration: none;
+  transition: color ease 0.3s;
+
+  &:hover {
+    color: $hidden-link-color;
+    cursor: pointer;
+  }
+}
+

--- a/app/templates/components/member-list-item.hbs
+++ b/app/templates/components/member-list-item.hbs
@@ -29,7 +29,9 @@
 
 <div class="project-member__actions">
   {{#if (eq membership.role 'pending')}}
-    <button class="default small" {{action "approve" membership}}>Approve</button>
-    <button class="danger small" {{action "deny" membership}}>Deny</button>
+    <button class="default small" {{action "showApprove"}}>Approve</button>
+    <button class="danger small" {{action "showDeny"}}>Deny</button>
+    {{modal-confirm dialogText='Are you sure you want to approve their membership?' okAction=(action 'approve' membership) showDialog=showApprove}}
+    {{modal-confirm dialogText='Are you sure you want to deny their membership?' okAction=(action 'deny' membership) showDialog=showDeny}}
   {{/if}}
 </div>

--- a/app/templates/components/modal-confirm.hbs
+++ b/app/templates/components/modal-confirm.hbs
@@ -1,0 +1,13 @@
+{{#if showDialog}}
+<div class="modal-confirm">
+  {{#modal-dialog clickOutsideToClose=true close="closeDialog" translucentOverlay=true}}
+    <div class="dialog-text">
+      <p>{{dialogText}}</p>
+    </div>
+    <div class="actions">
+      <button id="ok" class="default small" {{action "okAction" }}>{{okText}}</button>
+      <a href id="cancel" class="modal-confirm-cancel" {{action "closeDialog" }}>{{cancelText}}</a>
+    </div>
+  {{/modal-dialog}}
+</div>
+{{/if}}

--- a/tests/acceptance/contributors-test.js
+++ b/tests/acceptance/contributors-test.js
@@ -97,7 +97,8 @@ test('Lists multiple contributors if they exists.', function(assert) {
     assert.equal(page.admins.members().count, 1, 'Admins has 1 member listed');
     assert.equal(page.others.members().count, 1, 'Others has 1 member listed');
 
-    page.pendingContributors.members(0).approveMembership();
+    page.pendingContributors.members(0).approveButton.click();
+    page.pendingContributors.members(0).modal.confirmButton.click();
   });
 
   andThen(function() {
@@ -105,10 +106,8 @@ test('Lists multiple contributors if they exists.', function(assert) {
     assert.equal(page.pendingContributors.members().count, 1, 'Pending contributors has 1 member listed');
     assert.equal(page.others.members().count, 2, 'Others has 2 members listed');
 
-    window.confirm = function() {
-      return true;
-    };
-    page.pendingContributors.members(0).denyMembership();
+    page.pendingContributors.members(0).denyButton.click();
+    page.pendingContributors.members(0).modal.confirmButton.click();
   });
 
   andThen(function() {

--- a/tests/helpers/flash-message.js
+++ b/tests/helpers/flash-message.js
@@ -18,7 +18,6 @@ export function getFlashMessageAt(index, context) {
 function getTestContainer(context) {
   if (context.application) { // acceptance test
     return context.application.__container__;
-
   } else { // integration/unit test
     return getOwner(context);
   }

--- a/tests/integration/components/member-list-item-test.js
+++ b/tests/integration/components/member-list-item-test.js
@@ -110,6 +110,7 @@ test('it sends the approve action when clicking approve', function(assert) {
   page.render(hbs`{{member-list-item membership=membership user=user}}`);
 
   page.approveButton.click();
+  page.modal.confirmButton.click();
 
   assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
 
@@ -121,11 +122,11 @@ test('it sends the approve action when clicking approve', function(assert) {
 });
 
 test('it sends the deny action when clicking deny', function(assert) {
-  assert.expect(4);
 
-  window.confirm = function() {
-    return true;
-  };
+  let modalDialogService = this.container.lookup('service:modal-dialog');
+  modalDialogService.destinationElementId = 'modal-container';
+
+  assert.expect(4);
 
   let membership = Object.create({
     role: 'pending',
@@ -138,9 +139,9 @@ test('it sends the deny action when clicking deny', function(assert) {
   set(this, 'membership', membership);
   set(this, 'user', user);
 
-  page.render(hbs`{{member-list-item membership=membership user=user}}`);
-
+  page.render(hbs`<div id='modal-container'></div>{{member-list-item membership=membership user=user}}`);
   page.denyButton.click();
+  page.modal.confirmButton.click();
 
   assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
 

--- a/tests/integration/components/modal-confirm-test.js
+++ b/tests/integration/components/modal-confirm-test.js
@@ -1,0 +1,74 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import page from '../../pages/components/modal-confirm';
+
+moduleForComponent('modal-confirm', 'Integration | Component | modal confirm', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('Render with defaults', function(assert) {
+  assert.expect(3);
+
+  let modalDialogService = this.container.lookup('service:modal-dialog');
+  modalDialogService.destinationElementId = 'modal-container';
+
+  page.render(hbs`<div id='modal-container'></div>{{modal-confirm showDialog=true}}`);
+  assert.equal(page.dialogText, '');
+  assert.equal(page.okText, 'Ok');
+  assert.equal(page.cancelText, 'Cancel');
+});
+
+test('Render with "cancelText", "dialogText", and "okText" options', function(assert) {
+  assert.expect(3);
+
+  let modalDialogService = this.container.lookup('service:modal-dialog');
+  modalDialogService.destinationElementId = 'modal-container';
+
+  page.render(hbs`<div id='modal-container'></div>{{modal-confirm cancelText='Dismiss' dialogText='Are you sure?' okText='Confirm' showDialog=true}}`);
+  assert.equal(page.dialogText, 'Are you sure?');
+  assert.equal(page.okText, 'Confirm');
+  assert.equal(page.cancelText, 'Dismiss');
+});
+
+test('test that dialog disappears when clicking "Cancel"', function(assert) {
+  assert.expect(1);
+
+  let modalDialogService = this.container.lookup('service:modal-dialog');
+  modalDialogService.destinationElementId = 'modal-container';
+
+  page.render(hbs`<div id='modal-container'></div>{{modal-confirm cancelText='Dismiss' dialogText='Are you sure?' okText='Confirm' showDialog=true}}`);
+  page.cancel();
+  assert.ok(page.dialogTextIsHidden, '');
+});
+
+test('test that dialog disappears when clicking "OK", test closure action when clicking "OK"', function(assert) {
+  assert.expect(3);
+
+  let modalDialogService = this.container.lookup('service:modal-dialog');
+  modalDialogService.destinationElementId = 'modal-container';
+
+  this.set('confirmActionArg', true);
+  this.set('showDialog', true);
+
+  this.set('confirmAction', (confirm) => {
+    this.set('confirmValue', confirm);
+  });
+
+  page.render(hbs`<div id='modal-container'></div>{{modal-confirm okAction=(action confirmAction confirmActionArg) showDialog=showDialog}}`);
+  page.ok();
+  assert.equal(this.get('confirmValue'), true);
+  assert.ok(page.dialogTextIsHidden);
+
+  this.set('showDialog', true);
+
+  page.render(hbs`<div id='modal-container'></div>{{modal-confirm showDialog=showDialog}}`);
+  page.ok();
+  assert.ok(page.dialogTextIsHidden);
+});
+

--- a/tests/pages/components/member-list-item.js
+++ b/tests/pages/components/member-list-item.js
@@ -28,6 +28,17 @@ export default {
     url: attribute('src')
   },
 
+  modal: {
+    resetScope: true,
+    testContainer: '.ember-modal-dialog',
+    confirmButton: {
+      scope: 'button.default',
+      click: clickable(),
+      isVisible: isVisible(),
+      text: text()
+    }
+  },
+
   name: {
     scope: '.project-member__name',
     name: {

--- a/tests/pages/components/modal-confirm.js
+++ b/tests/pages/components/modal-confirm.js
@@ -1,0 +1,16 @@
+import {
+  clickable,
+  create,
+  isHidden,
+  text
+} from 'ember-cli-page-object';
+
+export default create({
+  cancel: clickable('a#cancel'),
+  cancelText: text('a#cancel'),
+  dialogText: text('p', { scope: '.dialog-text' }),
+  dialogTextIsHidden: isHidden('p', { scope: '.dialog-text' }),
+  ok: clickable('button#ok'),
+  okText: text('button#ok'),
+  testContainer: 'body'
+});

--- a/tests/pages/contributors.js
+++ b/tests/pages/contributors.js
@@ -1,22 +1,19 @@
 import {
+  collection,
   create,
   visitable,
-  collection,
   isVisible,
-  text,
-  clickable
+  text
 } from 'ember-cli-page-object';
+import memberListItem from './components/member-list-item';
 
 function buildContributorsDefinitionForIndex(index) {
   return {
     scope: `.contributors-list:eq(${index})`,
     emptyMessageVisible: isVisible('.contributors-list--empty'),
     members: collection({
-      itemScope: '.member-list-item',
-      item: {
-        approveMembership: clickable('button.default'),
-        denyMembership: clickable('button.danger')
-      }
+      itemScope: 'li',
+      item: memberListItem
     })
   };
 }
@@ -28,7 +25,6 @@ export default create({
   owners: buildContributorsDefinitionForIndex(1),
   admins: buildContributorsDefinitionForIndex(2),
   others: buildContributorsDefinitionForIndex(3),
-
   projectMenu: {
     scope: '.project__menu',
     contributors: {


### PR DESCRIPTION
- Replaces confirm with `modal-confirm` component that uses
  ember-modal-dialog

# What's in this PR?

List the changes you made and your reasons for them.

Make sure any changes to code include changes to documentation.

## References
Fixes #249 
