### PR TITLE
Switch project owners to projectUser records

### DIFF
--- a/app/abilities/project.js
+++ b/app/abilities/project.js
@@ -3,9 +3,10 @@ import { Ability } from 'ember-can';
 
 const {
   computed,
-  computed: { alias },
+  computed: { alias, equal },
   get,
-  inject: { service }
+  inject: { service },
+  isEmpty
 } = Ember;
 
 /**
@@ -24,11 +25,25 @@ export default Ability.extend({
    * Returns true if the user is the owner of the project.
    * @type {Boolean}
    */
-  canManage: alias('isOwner'),
+  canManage: alias('userIsOwner'),
 
-  isOwner: computed('project.owner.id', 'currentUser.user.id', function() {
-    return get(this, 'project.owner.id') === get(this, 'currentUser.user.id');
+  // TODO: Similar code is defined in
+  // - `components/project-details.js`
+  // - `abilities/task.js`
+  projectMembership: computed('project.projectUsers', 'currentUser.user.id', function() {
+    let currentUserId = get(this, 'currentUser.user.id');
+
+    if (isEmpty(currentUserId)) {
+      return false;
+    } else {
+      return get(this, 'project.projectUsers').find((item) => {
+        return get(item, 'user.id') === currentUserId;
+      });
+    }
   }),
+
+  userRole: alias('projectMembership.role'),
+  userIsOwner: equal('userRole', 'owner'),
 
   project: alias('model')
 });

--- a/app/abilities/task.js
+++ b/app/abilities/task.js
@@ -25,7 +25,9 @@ export default Ability.extend({
     }
   }),
 
-  // TODO: Similar code is defined in `components/project-details.js`
+  // TODO: Similar code is defined in
+  // - `components/project-details.js`
+  // - `abilities/project.js`
   projectMembership: computed('task.project.projectUsers', 'currentUser.user.id', function() {
     let currentUserId = get(this, 'currentUser.user.id');
 
@@ -38,13 +40,10 @@ export default Ability.extend({
     }
   }),
 
-  userIsOwner: computed('currentUser.user.id', 'task.project.owner.id', function() {
-    return get(this, 'currentUser.user.id') === get(this, 'task.project.owner.id');
-  }),
-
   userRole: alias('projectMembership.role'),
   userIsContributor: equal('userRole', 'contributor'),
   userIsAdmin: equal('userRole', 'admin'),
+  userIsOwner: equal('userRole', 'owner'),
 
   //
   // Abilities

--- a/app/components/project-details.js
+++ b/app/components/project-details.js
@@ -52,7 +52,9 @@ export default Component.extend({
    */
   user: alias('currentUser.user'),
 
-  // TODO: Similar code is defined in `abilities/task.js`
+  // TODO: Similar code is defined in
+  // - `abilities/project.js`
+  // - `abilities/task.js`
   currentProjectMembership: computed('project.projectUsers', 'currentUser.user.id', function() {
     let projectUsers = get(this, 'project.projectUsers');
     let currentUserId = get(this, 'currentUser.user.id');

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -25,7 +25,6 @@ export default Model.extend({
 
   donationGoals: hasMany('donation-goal', { async: true }),
   organization: belongsTo('organization', { async: true }),
-  owner: belongsTo('user', { async: true }),
   taskLists: hasMany('task-list', { async: true }),
   tasks: hasMany('tasks', { async: true }),
   projectCategories: hasMany('project-category', { async: true }),

--- a/app/routes/project/settings.js
+++ b/app/routes/project/settings.js
@@ -4,8 +4,8 @@ import { CanMixin } from 'ember-can';
 
 const {
   get,
-  Route,
-  inject: { service }
+  inject: { service },
+  Route
 } = Ember;
 
 export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
@@ -34,8 +34,14 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
 
   _ensureUserHasCredentials() {
     let project = this.modelFor('project');
-    if (this.cannot('manage project', project)) {
-      return this.transitionTo('project');
-    }
+    // TODO: As things grow, this will be problematic. We need to wait to load
+    // all membership records here. Solutions are
+    // 1. Sideload membership records
+    // 2. Have the server compute an ability table for the current user
+    return get(project, 'projectUsers').then(() => {
+      if (this.cannot('manage project', project)) {
+        return this.transitionTo('project');
+      }
+    });
   }
 });

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -20,11 +20,6 @@ export default Factory.extend({
 
   // ensures associations exist if they haven't been provided
   afterCreate(project, server) {
-    if (!project.owner) {
-      project.owner = server.create('user');
-      project.save();
-    }
-
     if (!project.organization) {
       project.organization = server.create('organization');
       project.save();

--- a/mirage/models/project.js
+++ b/mirage/models/project.js
@@ -3,7 +3,6 @@ import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   donationGoals: hasMany(),
   organization: belongsTo(),
-  owner: belongsTo('user'),
   projectCategories: hasMany(),
   projectSkills: hasMany(),
   projectUsers: hasMany(),

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -183,7 +183,6 @@ export default function(server) {
   let project = server.create('project', {
     description: 'Help build and fund public software projects for social good.',
     organization,
-    owner,
     slug: 'code-corps',
     title: 'Code Corps',
     website: 'https://www.codecorps.org'

--- a/tests/acceptance/contributors-test.js
+++ b/tests/acceptance/contributors-test.js
@@ -18,11 +18,7 @@ moduleForAcceptance('Acceptance: Contributors');
 test('Requires user to be project owner to visit.', function(assert) {
   assert.expect(1);
 
-  let project = server.create('project');
-
-  let user = server.create('user');
-
-  server.create('projectUser', { user, project, role: 'contributor' });
+  let { project, user } = server.create('project-user', { role: 'contributor' });
 
   let contributorURLParts = buildURLParts(project.organization.slug, project.slug);
 
@@ -39,10 +35,7 @@ test('Requires user to be project owner to visit.', function(assert) {
 test('Lists owner when owner is the only member.', function(assert) {
   assert.expect(9);
 
-  let project = server.create('project');
-  let user = project.createOwner();
-
-  server.create('projectUser', { user, project, role: 'owner' });
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   let contributorURLParts = buildURLParts(project.organization.slug, project.slug);
 
@@ -68,13 +61,11 @@ test('Lists owner when owner is the only member.', function(assert) {
 test('Lists multiple contributors if they exists.', function(assert) {
   assert.expect(16);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
-  server.create('projectUser', { user, project, role: 'owner' });
-  server.create('projectUser', { project, role: 'admin' });
-  server.create('projectUser', { project, role: 'contributor' });
-  server.createList('projectUser', 2, { project, role: 'pending' });
+  server.create('project-user', { project, role: 'admin' });
+  server.create('project-user', { project, role: 'contributor' });
+  server.createList('project-user', 2, { project, role: 'pending' });
 
   let contributorURLParts = buildURLParts(project.organization.slug, project.slug);
 

--- a/tests/acceptance/project-about-test.js
+++ b/tests/acceptance/project-about-test.js
@@ -7,15 +7,13 @@ moduleForAcceptance('Acceptance | Project - About');
 
 test('When unauthenticated, and project has no long description, it shows proper UI', function(assert) {
   assert.expect(2);
-  let organization = server.create('organization');
   let project = server.create('project', {
     longDescriptionBody: null,
-    longDescriptionMarkdown: null,
-    organization
+    longDescriptionMarkdown: null
   });
 
   projectAboutPage.visit({
-    organization: organization.slug,
+    organization: project.organization.slug,
     project: project.slug
   });
 
@@ -28,15 +26,13 @@ test('When unauthenticated, and project has no long description, it shows proper
 test('When unauthenticated, and project has long description, it shows the project long description', function(assert) {
   assert.expect(2);
 
-  let organization = server.create('organization');
   let project = server.create('project', {
     longDescriptionBody: 'A body',
-    longDescriptionMarkdown: 'A body',
-    organization
+    longDescriptionMarkdown: 'A body'
   });
 
   projectAboutPage.visit({
-    organization: organization.slug,
+    organization: project.organization.slug,
     project: project.slug
   });
 
@@ -46,23 +42,20 @@ test('When unauthenticated, and project has long description, it shows the proje
   });
 });
 
-test('When authenticate as owner, and project has no long description, it allows setting it', function(assert) {
+test('When authenticated as owner, and project has no long description, it allows setting it', function(assert) {
   assert.expect(4);
-
-  let organization = server.create('organization');
 
   let project = server.create('project', {
     longDescriptionBody: null,
-    longDescriptionMarkdown: null,
-    organization
+    longDescriptionMarkdown: null
   });
 
-  let user = project.createOwner();
+  let { user } = server.create('project-user', { project, role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
   projectAboutPage.visit({
-    organization: organization.slug,
+    organization: project.organization.slug,
     project: project.slug
   });
 
@@ -82,20 +75,17 @@ test('When authenticate as owner, and project has no long description, it allows
 test('When authenticated as owner, and project has long description, it allows editing it', function(assert) {
   assert.expect(4);
 
-  let organization = server.create('organization');
-
   let project = server.create('project', {
     longDescriptionBody: 'A body',
-    longDescriptionMarkdown: 'A body',
-    organization
+    longDescriptionMarkdown: 'A body'
   });
 
-  let user = project.createOwner();
+  let { user } = server.create('project-user', { project, role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
   projectAboutPage.visit({
-    organization: organization.slug,
+    organization: project.organization.slug,
     project: project.slug
   });
 
@@ -116,17 +106,13 @@ test('Does not show donation progress sidebar if donations are not active', func
   assert.expect(1);
 
   let user = server.create('user');
-  let organization = server.create('organization');
 
-  let project = server.create('project', {
-    donationsActive: false,
-    organization
-  });
+  let project = server.create('project', { donationsActive: false });
 
   authenticateSession(this.application, { user_id: user.id });
 
   projectAboutPage.visit({
-    organization: organization.slug,
+    organization: project.organization.slug,
     project: project.slug
   });
 
@@ -139,19 +125,17 @@ test('Allows donating to a project from the sidebar', function(assert) {
   assert.expect(2);
 
   let user = server.create('user');
-  let organization = server.create('organization');
 
   let project = server.create('project', {
     donationsActive: true,
     longDescriptionBody: 'A body',
-    longDescriptionMarkdown: 'A body',
-    organization
+    longDescriptionMarkdown: 'A body'
   });
 
   authenticateSession(this.application, { user_id: user.id });
 
   projectAboutPage.visit({
-    organization: organization.slug,
+    organization: project.organization.slug,
     project: project.slug
   });
 
@@ -163,7 +147,7 @@ test('Allows donating to a project from the sidebar', function(assert) {
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.donate', 'App transitioned to the donate route.');
-    let expectedURL = `/${organization.slug}/${project.slug}/donate?amount=15`;
+    let expectedURL = `/${project.organization.slug}/${project.slug}/donate?amount=15`;
     assert.equal(currentURL(), expectedURL, 'URL contains amount as query parameter.');
   });
 });

--- a/tests/acceptance/project-donation-goals-test.js
+++ b/tests/acceptance/project-donation-goals-test.js
@@ -22,12 +22,11 @@ test('it redirects to project list page if user is not allowed to manage project
   assert.expect(1);
 
   let project = server.create('project');
-  let { organization } = project;
   let user = server.create('user');
 
   authenticateSession(this.application, { user_id: user.id });
 
-  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.index', 'User was redirected to project list route');
@@ -37,8 +36,8 @@ test('it redirects to project list page if user is not allowed to manage project
 test('it renders existing donation goals', function(assert) {
   assert.expect(1);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
+
   server.createList('donation-goal', 3, { project });
 
   authenticateSession(this.application, { user_id: user.id });
@@ -53,8 +52,7 @@ test('it renders existing donation goals', function(assert) {
 test('it sets up a new unsaved donation goal if there are no donation goals, which can be added', function(assert) {
   assert.expect(4);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
@@ -80,8 +78,7 @@ test('it sets up a new unsaved donation goal if there are no donation goals, whi
 test('it is possible to add a donation goal when donation goals already exists', function(assert) {
   assert.expect(3);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
   server.createList('donation-goal', 1, { project });
 
   authenticateSession(this.application, { user_id: user.id });
@@ -108,8 +105,7 @@ test('it is possible to add a donation goal when donation goals already exists',
 test('it allows editing of existing donation goals', function(assert) {
   assert.expect(3);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
   server.createList('donation-goal', 1, { project });
 
   authenticateSession(this.application, { user_id: user.id });
@@ -136,8 +132,7 @@ test('it allows editing of existing donation goals', function(assert) {
 test('cancelling edit of an unsaved new goal removes that goal from the list', function(assert) {
   assert.expect(1);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
   server.createList('donation-goal', 1, { project });
 
   authenticateSession(this.application, { user_id: user.id });
@@ -159,8 +154,7 @@ test('cancelling edit of an unsaved new goal removes that goal from the list', f
 test('cancelling edit of an unsaved existing goal keeps that goal in the list', function(assert) {
   assert.expect(1);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
   server.createList('donation-goal', 1, { project });
 
   authenticateSession(this.application, { user_id: user.id });
@@ -182,8 +176,7 @@ test('cancelling edit of an unsaved existing goal keeps that goal in the list', 
 test('it allows activating donations for the project', function(assert) {
   assert.expect(2);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
   project.attrs.canActivateDonations = true;
   project.save();
 
@@ -205,18 +198,14 @@ test('it allows activating donations for the project', function(assert) {
 test('it shows donation progress if donations are active', function(assert) {
   assert.expect(1);
 
-  let organization = server.create('organization');
-  let project = server.create('project', {
-    donationsActive: true,
-    organization
-  });
-  let user = project.createOwner();
+  let project = server.create('project', { donationsActive: true });
+  let { user } = server.create('project-user', { project, role: 'owner' });
 
   server.createList('donation-goal', 1, { project });
 
   authenticateSession(this.application, { user_id: user.id });
 
-  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
     assert.ok(projectSettingsDonationsPage.donationProgress.isVisible, 'It shows donation progress.');
@@ -226,16 +215,12 @@ test('it shows donation progress if donations are active', function(assert) {
 test('it does not show donation progress if donations are not active', function(assert) {
   assert.expect(1);
 
-  let organization = server.create('organization');
-  let project = server.create('project', {
-    donationsActive: false,
-    organization
-  });
-  let user = project.createOwner();
+  let project = server.create('project', { donationsActive: false });
+  let { user } = server.create('project-user', { project, role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
-  projectSettingsDonationsPage.visit({ organization: organization.slug, project: project.slug });
+  projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
     assert.notOk(projectSettingsDonationsPage.donationProgress.isVisible, 'It does not show donation progress.');
@@ -245,8 +230,7 @@ test('it does not show donation progress if donations are not active', function(
 test('it renders validation errors', function(assert) {
   assert.expect(3);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
@@ -288,8 +272,7 @@ test('it renders validation errors', function(assert) {
 test('it renders other errors', function(assert) {
   assert.expect(1);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 

--- a/tests/acceptance/project-payments-test.js
+++ b/tests/acceptance/project-payments-test.js
@@ -36,8 +36,7 @@ test('it redirects to project list page if user is not allowed to setup the acco
 test('The full setup works properly', function(assert) {
   assert.expect(12);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 

--- a/tests/acceptance/project-settings-test.js
+++ b/tests/acceptance/project-settings-test.js
@@ -23,8 +23,7 @@ test('it requires authentication', function(assert) {
 test('it allows editing of project profile for owners', function(assert) {
   assert.expect(5);
 
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
@@ -65,8 +64,7 @@ test("it allows editing of project's image for owners", function(assert) {
   let done = assert.async();
 
   let droppedImageString = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 
@@ -92,8 +90,7 @@ test("it allows editing of project's skills for owners", function(assert) {
   let done = assert.async();
 
   server.create('skill', { title: 'Ruby' });
-  let project = server.create('project');
-  let user = project.createOwner();
+  let { project, user } = server.create('project-user', { role: 'owner' });
 
   authenticateSession(this.application, { user_id: user.id });
 

--- a/tests/integration/components/project-long-description-test.js
+++ b/tests/integration/components/project-long-description-test.js
@@ -28,13 +28,13 @@ let owner = Object.create({ id: 'owner' });
 let projectWithDescription = Object.create({
   longDescriptionBody: 'A <strong>body</strong>',
   longDescriptionMarkdown: 'A **body**',
-  owner
+  projectUsers: [{ user: owner, role: 'owner' }]
 });
 
 let blankProject = Object.create({
   longDescriptionBody: null,
   longDescriptionMarkdown: null,
-  owner
+  projectUsers: [{ user: owner, role: 'owner' }]
 });
 
 test('it renders properly when decription is blank and the user cannot add to it', function(assert) {

--- a/tests/unit/abilities/project-test.js
+++ b/tests/unit/abilities/project-test.js
@@ -10,7 +10,9 @@ const {
 
 let owner = Object.create({ id: 'owner' });
 let other = Object.create({ id: 'other' });
-let project = Object.create({ owner });
+let project = Object.create({
+  projectUsers: [{ user: owner, role: 'owner' }]
+});
 
 moduleFor('ability:project', 'Unit | Ability | project', {
   needs: ['service:current-user']

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -18,8 +18,7 @@ moduleForModel('project', 'Unit | Model | project', {
     'model:stripe-connect-account',
     'model:stripe-connect-plan',
     'model:task',
-    'model:task-list',
-    'model:user'
+    'model:task-list'
   ]
 });
 
@@ -36,7 +35,6 @@ testForAttributes('project', [
 ]);
 
 testForBelongsTo('project', 'organization');
-testForBelongsTo('project', 'owner');
 testForBelongsTo('project', 'stripeConnectPlan');
 
 testForHasMany('project', 'donationGoals');


### PR DESCRIPTION
# What's in this PR?

Removes `project.owner` concept and replaces it with a `projectUser` record with `role: 'owner'`

## References
Fixes #1142
Related to: https://github.com/code-corps/code-corps-api/pull/751

