### PR TITLE
Replaces email in footer with Help Center link

### DIFF
--- a/app/templates/components/site-footer.hbs
+++ b/app/templates/components/site-footer.hbs
@@ -19,7 +19,7 @@
       <h4>Help</h4>
       <ul class="footer-links">
         <li>
-          <a href="mailto:team@codecorps.org">team@codecorps.org</a>
+          <a href="https://help.codecorps.org">Help Center</a>
         </li>
         <li>
           {{#scroll-top}}

--- a/tests/integration/components/site-footer-test.js
+++ b/tests/integration/components/site-footer-test.js
@@ -28,8 +28,8 @@ test('it renders all elements', function(assert) {
   assert.equal(page.columns(0).rows(0).text, 'About us');
   assert.equal(page.columns(0).rows(1).text, 'Team');
 
-  assert.equal(page.columns(1).rows(0).text, 'team@codecorps.org');
-  assert.equal(page.columns(1).rows(0).link.href, 'mailto:team@codecorps.org');
+  assert.equal(page.columns(1).rows(0).text, 'Help Center');
+  assert.equal(page.columns(1).rows(0).link.href, 'https://help.codecorps.org');
   assert.equal(page.columns(1).rows(1).text, 'Terms of Use');
   assert.equal(page.columns(1).rows(2).text, 'Privacy Policy');
 


### PR DESCRIPTION
# What's in this PR?

Replaced email in footer with link to help center.

## References
Fixes #1141 