### PR TITLE
Removes ignoreError since Sentry now ignores `TransitionAborted` erro…

### DIFF
--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -16,18 +16,6 @@ export default RavenLogger.extend({
     return this._super(...arguments);
   },
 
-  ignoreError(error) {
-    // Ember 2.X seems to not catch `TransitionAborted` errors caused by
-    // regular redirects. We don't want these errors to show up in Sentry
-    // so we have to filter them ourselves.
-    //
-    // Once this issue https://github.com/emberjs/ember.js/issues/12505 is
-    // resolved we can remove this code.
-    //
-    // Last checked 9/28/2016
-    return error.name === 'TransitionAborted';
-  },
-
   callRaven(/* methodName, ...optional */) {
     return this._super(...arguments);
   }


### PR DESCRIPTION
# What's in this PR?

Removes ignoreError in Raven

Make sure any changes to code include changes to documentation.

## References
Fixes #1185

Progress on: #
