### PR TITLE
Update skills list to not be hidden by default

### DIFF
--- a/app/components/related-skills.js
+++ b/app/components/related-skills.js
@@ -27,22 +27,22 @@ export default Component.extend({
   isClickable: false,
 
   /**
-   * Returns whether or not the overflowing skills on the project card should be
-   * displayed.
+   * Returns whether or not the overflowing skills on the project card
+   * should be displayed.
    *
    * @property overflowHidden
    * @type Boolean
-   * @default true
+   * @default false
    */
-  overflowHidden: true,
+  overflowHidden: false,
 
   /**
-    Returns whether or not the toggle for showing overflowing skills should be
-    visible or not.
-
-    @property showToggle
-    @type Boolean
-    @default false
+   * Returns whether or not the toggle for showing overflowing skills
+   * should be visible or not.
+   *
+   * @property showToggle
+   * @type Boolean
+   * @default false
    */
   showToggle: false,
 

--- a/app/templates/components/project-card.hbs
+++ b/app/templates/components/project-card.hbs
@@ -34,6 +34,6 @@
       {{/if}}
     {{/if}}
   </p>
-  {{related-skills class="project-card__skills" skills=projectSkills}}
+  {{related-skills class="project-card__skills" overflowHidden=true skills=projectSkills}}
   {{project-card-members members=projectUsers}}
 </div>

--- a/tests/integration/components/related-skills-test.js
+++ b/tests/integration/components/related-skills-test.js
@@ -43,8 +43,8 @@ test('it shows no expander for few skills', function(assert) {
   assert.equal(page.skillListItems.listItems().count, 1, 'Correct number of skills is rendered.');
 });
 
-test('it shows expander and toggles for lots of skills', function(assert) {
-  assert.expect(5);
+test('it does not show expander if overflowHidden is not set', function(assert) {
+  assert.expect(1);
 
   let skills = [];
   for (let i = 1; i <= 100; i++) {
@@ -55,6 +55,22 @@ test('it shows expander and toggles for lots of skills', function(assert) {
 
   this.set('skills', skills);
   renderPage();
+
+  assert.notOk(page.overflow.hidden, 'Overflow is not hidden.');
+});
+
+test('it shows expander and toggles for lots of skills when the component is modified to do so', function(assert) {
+  assert.expect(5);
+
+  let skills = [];
+  for (let i = 1; i <= 100; i++) {
+    skills.pushObject({
+      title: `Skill ${i}`
+    });
+  }
+
+  this.set('skills', skills);
+  page.render(hbs`{{related-skills overflowHidden=true skills=skills}}`);
 
   assert.ok(page.overflow.hidden, 'Overflow is hidden.');
   assert.ok(page.expander.visible, 'Expander button is visible.');


### PR DESCRIPTION
# What's in this PR?

Skills lists are hiding the overflow by default, but this is not the behavior we should expect.