### PR TITLE
volunteer-headshot falls back to username

### DIFF
--- a/app/components/volunteer-headshot.js
+++ b/app/components/volunteer-headshot.js
@@ -50,25 +50,20 @@ export default Component.extend({
   }),
 
   /**
-    Returns the volunteer's name. If the `name` property is not defined, it
-    computes a name from the volunteer's `firstName` & `lastName`. If neither
-    are defined it returns the volunteer's username.
-
-    @property volunteerName
-    @type String
+   * Returns the volunteer's name. If the `name` property is not defined,
+   * it returns the volunteer's username.
+   *
+   * @property volunteerName
+   * @type String
    */
-  volunteerName: computed('volunteer.{name,firstName,lastName}', function() {
+  volunteerName: computed('volunteer.{name,username}', function() {
     let name = get(this, 'volunteer.name');
-    let firstName = get(this, 'volunteer.firstName');
-    let lastName = get(this, 'volunteer.lastName');
-    let userName = get(this, 'volunteer.userName');
+    let username = get(this, 'volunteer.username');
 
     if (isPresent(name)) {
       return name;
-    } else if (isPresent(firstName) && isPresent(lastName)) {
-      return `${firstName} ${lastName}`;
     } else {
-      return userName;
+      return username;
     }
   })
 });

--- a/tests/integration/components/volunteer-headshot-test.js
+++ b/tests/integration/components/volunteer-headshot-test.js
@@ -32,15 +32,12 @@ test('it renders the volunteer\'s name', function(assert) {
   assert.equal(page.name, this.get('user.name'));
 });
 
-test('it computes the name if it is not present', function(assert) {
-  let firstName = 'Split';
-  let lastName = 'Name';
+test('it computes username if name is not present', function(assert) {
+  let username = 'Ace';
 
   this.set('user.name', null);
-  this.set('user.firstName', firstName);
-  this.set('user.lastName', lastName);
-
-  assert.equal(page.name, `${firstName} ${lastName}`);
+  this.set('user.username', username);
+  assert.equal(page.name, `${username}`);
 });
 
 test('it randomly selects one of the available roles', function(assert) {


### PR DESCRIPTION
# What's in this PR?

Fixed bug by adding cache breaking key userName. So if volunteer doesn't have a name or first or last name is should fall back to there username.

## References
Fixes #1220 

