### PR TITLE
Add minor design changes to text sizes

### DIFF
--- a/app/styles/_buttons.scss
+++ b/app/styles/_buttons.scss
@@ -54,7 +54,7 @@
   }
 
   &.large {
-    font-size: $body-font-size-large;
+    font-size: $body-font-size-normal;
     padding: 15px 40px;
 
     &.skill {

--- a/app/styles/_inputs.scss
+++ b/app/styles/_inputs.scss
@@ -18,3 +18,11 @@
   background-color: #FFFFFF;
   box-shadow: inset 0 2px 2px rgba(0,0,0,0.075), 0 0 5px rgba(81,167,232,0.5);
 }
+
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  select,
+  textarea,
+  input {
+    font-size: 16px;
+  }
+}

--- a/app/styles/base/_fonts.scss
+++ b/app/styles/base/_fonts.scss
@@ -8,8 +8,6 @@ $body-font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 // Open Sans: light (300), regular (400), italic (400i), semi-bold (600), bold (700)
 //
 
-$body-font-size-x-large: 18px;
-$body-font-size-large: 16px;
 $body-font-size-normal: 14px;
 $body-font-size-small: 12px;
 $body-font-size-tiny: 11px;

--- a/app/styles/components/project-join-modal.scss
+++ b/app/styles/components/project-join-modal.scss
@@ -7,7 +7,7 @@
   }
 
   h1 {
-    font-size: $body-font-size-x-large;
+    font-size: $header-font-size-small;
     margin-bottom: 20px;
     text-align: center;
   }

--- a/app/styles/layout/_forms.scss
+++ b/app/styles/layout/_forms.scss
@@ -148,7 +148,7 @@ form {
 
 .login-form, .signup-form {
   .input-group {
-    margin: 0 0 24px 0;
+    margin: 0 0 1em 0;
   }
 }
 


### PR DESCRIPTION
# What's in this PR?

Some small but important design changes:

- Remove some styles that were barely used and condense them into other styles
- Prevent zoom on inputs when on iOS
- Group inputs closer together (and use `em` for it)