### PR TITLE
Fix run loop issues for role item and user dropdown integration tests

### DIFF
--- a/app/components/role-item.js
+++ b/app/components/role-item.js
@@ -5,7 +5,9 @@ const {
   computed,
   computed: { notEmpty },
   get,
-  inject: { service }
+  getProperties,
+  inject: { service },
+  set
 } = Ember;
 
 export default Component.extend({
@@ -19,31 +21,30 @@ export default Component.extend({
   selected: notEmpty('userRole'),
 
   userRole: computed('role', 'userRoles.userRoles', function() {
-    let role = this.get('role');
-    let userRoles = this.get('userRoles');
+    let { role, userRoles } = getProperties(this, 'role', 'userRoles');
     return userRoles.findUserRole(role);
   }),
 
   actions: {
     addRole(role) {
-      this.set('isLoading', true);
+      set(this, 'isLoading', true);
       let userRoles = this.get('userRoles');
       return userRoles.addRole(role).catch(() => {
         let message = `An error occurred trying to add ${role.get('name')}.`;
         this._flashError(message);
       }).finally(() => {
-        this.set('isLoading', false);
+        set(this, 'isLoading', false);
       });
     },
 
     removeRole(role) {
-      this.set('isLoading', true);
+      set(this, 'isLoading', true);
       let userRoles = this.get('userRoles');
       return userRoles.removeRole(role).catch(() => {
         let message = `An error occurred trying to remove ${role.get('name')}.`;
         this._flashError(message);
       }).finally(() => {
-        this.set('isLoading', false);
+        set(this, 'isLoading', false);
       });
     }
   },

--- a/tests/integration/components/user-dropdown-test.js
+++ b/tests/integration/components/user-dropdown-test.js
@@ -4,7 +4,8 @@ import Ember from 'ember';
 
 const {
   computed,
-  Object
+  Object,
+  run
 } = Ember;
 
 moduleForComponent('user-dropdown', 'Integration | Component | user dropdown', {
@@ -41,5 +42,5 @@ test('it triggers the hide action when clicked', function(assert) {
     assert.ok(true, 'It triggers the hide action when clicked');
   });
   this.render(hbs`{{user-dropdown user=user action='hide'}}`);
-  this.$('.dropdown-menu').click();
+  run(() => this.$('.dropdown-menu').click());
 });

--- a/tests/pages/components/role-item.js
+++ b/tests/pages/components/role-item.js
@@ -1,0 +1,17 @@
+import { hasClass, notHasClass } from 'ember-cli-page-object';
+
+export default {
+  scope: '.role-item',
+
+  isSelected: hasClass('selected'),
+  isUnselected: notHasClass('selected'),
+
+  button: {
+    scope: 'button'
+  },
+
+  icon: {
+    scope: 'span',
+    isLoading: hasClass('button-spinner')
+  }
+};


### PR DESCRIPTION
# What's in this PR?

Working on merging PRs like #1245, I realized the tests in development are failing with run loop issues. This small but long to figure out PR resolves those issues. Why they did not appear on our CI, I'm not sure.

The PR also introduces a page object for the role item test and slightly rewrites the code so it's less reliant on promises and run loop operations.

