### PR TITLE
Code corps ember#1180/markdown areas do not style ul and li tags

### DIFF
--- a/app/styles/components/project-long-description.scss
+++ b/app/styles/components/project-long-description.scss
@@ -54,3 +54,14 @@
     margin: 10px 0;
   }
 }
+
+.long-description {
+
+  &, &-editor {
+
+    li {
+      list-style-type: disc;
+      margin-left: 20px;
+    }
+  }
+}

--- a/tests/integration/components/project-long-description-test.js
+++ b/tests/integration/components/project-long-description-test.js
@@ -31,6 +31,12 @@ let projectWithDescription = Object.create({
   projectUsers: [{ user: owner, role: 'owner' }]
 });
 
+let projectWithListedDescription = Object.create({
+  longDescriptionBody: 'Todo list: <ul><li>list item 1</li></ul>',
+  longDescriptionMarkdown: 'Todo list: \n *   list item 1',
+  projectUsers: [{ user: owner, role: 'owner' }]
+});
+
 let blankProject = Object.create({
   longDescriptionBody: null,
   longDescriptionMarkdown: null,
@@ -127,4 +133,14 @@ test('it is possible to edit a description', function(assert) {
   page.edit.click();
   assert.ok(page.editorWithPreview.isVisible, 'The editor is shown, since we are in edit mode');
   page.save.click();
+});
+
+test('it renders list items in the description with bullet points', function(assert) {
+  assert.expect(2);
+
+  set(this, 'project', projectWithListedDescription);
+  page.render(hbs`{{project-long-description project=project}}`);
+
+  assert.equal(page.longDescription.list.listItem.text, 'list item 1', 'the description text shows the list');
+  assert.equal(this.$('li').css('listStyleType'), 'disc', 'list in description text is displayed with bullet points');
 });

--- a/tests/pages/components/project-long-description.js
+++ b/tests/pages/components/project-long-description.js
@@ -35,6 +35,16 @@ export default {
       text: text()
     },
 
+    list: {
+      scope: 'ul',
+      text: text(),
+
+      listItem: {
+        scope: 'li',
+        text: text()
+      }
+    },
+
     text: text()
   },
 


### PR DESCRIPTION
# What's in this PR?
This PR adds missing bullet points to list items which are displayed in the long project description view (either default view or editor view).

![screenshot from 2017-04-17 21-55-54](https://cloud.githubusercontent.com/assets/8811742/25103794/156099e4-23be-11e7-8c9d-11fe9c4adef0.png)

![screenshot from 2017-04-17 22-29-12](https://cloud.githubusercontent.com/assets/8811742/25103813/1a5e2650-23be-11e7-992f-d024d6f6e857.png)

## References
Fixes code-corps/code-corps-ember#1180
