### PR TITLE
Added link on the header which links to typeform

### DIFF
--- a/app/templates/components/navigation-menu.hbs
+++ b/app/templates/components/navigation-menu.hbs
@@ -3,6 +3,7 @@
     <nav class="header-navigation--left">
       <ul class="header-navigation__options">
         <li>{{#link-to 'projects-list'}}Projects{{/link-to}}</li>
+        <li><a href="https://codecorps.typeform.com/to/rMxOCA">Submit a project</a></li>
         <li><a href="https://blog.codecorps.org">Blog</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
# What's in this PR?

Only a link-to item was added on the header that links to typeform so people are able to find it easily and submit projects. Nothing else was modified or changed.
![screen shot 2017-04-18 at 1 08 34 am](https://cloud.githubusercontent.com/assets/8007671/25115629/a6b8924a-23d5-11e7-8735-1b8fd185c33c.png)

## References
Progress on: https://github.com/code-corps/code-corps-ember/issues/1152
