### PR TITLE
Create GitHub connect button component #1263

### DIFF
--- a/app/components/github-connect.js
+++ b/app/components/github-connect.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+
+const {
+  Component,
+  set
+} = Ember;
+const baseUrl = 'https://github.com/login/oauth/authorize';
+
+/**
+  The github-connect component is used to to connect to github
+
+  ## default usage
+
+  ```handlebars
+    {{github-connect clientId=clientId scope=scope state=state redirectUri=redirectUri}}
+  ```
+
+  @module Component
+  @class github-connect
+  @extends Ember.Component
+  @public
+ */
+
+export default Component.extend({
+  tagName: 'a',
+  classNames: ['button', 'default'],
+  attributeBindings: ['url:href'],
+
+  clientId: null,
+  scope: null,
+  state: null,
+  redirectUri: null,
+
+  init() {
+    this._super(...arguments);
+    let { clientId, scope, state, redirectUri } = this.getProperties('clientId', 'scope', 'state', 'redirectUri');
+    set(this, 'url', `${baseUrl}?scope=${scope}&client_id=${clientId}&state=${state}&redirect_uri=${redirectUri}`);
+  }
+
+});

--- a/app/templates/components/github-connect.hbs
+++ b/app/templates/components/github-connect.hbs
@@ -1,0 +1,1 @@
+GitHub Connect

--- a/tests/integration/components/github-connect-test.js
+++ b/tests/integration/components/github-connect-test.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+import component from 'code-corps-ember/tests/pages/components/github-connect';
+
+const { set } = Ember;
+const baseUrl = 'https://github.com/login/oauth/authorize';
+let page = PageObject.create(component);
+
+moduleForComponent('github-connect', 'Integration | Component | github connect', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('check if properties are bound correctly', function(assert) {
+  set(this, 'scope', '3098379083');
+  set(this, 'clientId', 'ace');
+  set(this, 'state', 'ace123');
+  set(this, 'redirectUri', 'ace.com');
+  page.render(hbs`{{github-connect scope=scope clientId=clientId state=state redirectUri=redirectUri}}`);
+  assert.equal(page.button.href, `${baseUrl}?scope=3098379083&client_id=ace&state=ace123&redirect_uri=ace.com`);
+});
+

--- a/tests/pages/components/github-connect.js
+++ b/tests/pages/components/github-connect.js
@@ -1,0 +1,10 @@
+import {
+  attribute
+} from 'ember-cli-page-object';
+
+export default {
+  button: {
+    scope: '.default',
+    href: attribute('href')
+  }
+};


### PR DESCRIPTION
# What's in this PR?

- Github connect button

- button url takes in `scope`, `state`, `cliendId`, `redirectUri`

- component is a anchor tag styled like a button

## References
Fixes #1263 

Progress on: #
