### PR TITLE
Implement csf protection

### DIFF
--- a/app/components/github-connect.js
+++ b/app/components/github-connect.js
@@ -2,8 +2,11 @@ import Ember from 'ember';
 
 const {
   Component,
+  get,
+  inject: { service },
   set
 } = Ember;
+
 const baseUrl = 'https://github.com/login/oauth/authorize';
 
 /**
@@ -26,6 +29,8 @@ export default Component.extend({
   classNames: ['button', 'default'],
   attributeBindings: ['url:href'],
 
+  githubState: service(),
+
   clientId: null,
   scope: null,
   state: null,
@@ -33,8 +38,19 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let { clientId, scope, state, redirectUri } = this.getProperties('clientId', 'scope', 'state', 'redirectUri');
+    this._initState();
+    this._initUrl();
+  },
+
+  _initState() {
+    let githubState = get(this, 'githubState').generate();
+    set(this, 'state', githubState);
+  },
+
+  _initUrl() {
+    let { clientId, scope, state, redirectUri }
+      = this.getProperties('clientId', 'scope', 'state', 'redirectUri');
+
     set(this, 'url', `${baseUrl}?scope=${scope}&client_id=${clientId}&state=${state}&redirect_uri=${redirectUri}`);
   }
-
 });

--- a/tests/integration/components/github-connect-test.js
+++ b/tests/integration/components/github-connect-test.js
@@ -3,27 +3,33 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import PageObject from 'ember-cli-page-object';
 import component from 'code-corps-ember/tests/pages/components/github-connect';
+import setupSession from 'ember-simple-auth/initializers/setup-session';
+import setupSessionService from 'ember-simple-auth/initializers/setup-session-service';
 
-const { set } = Ember;
+const { get, set } = Ember;
 const baseUrl = 'https://github.com/login/oauth/authorize';
+
 let page = PageObject.create(component);
 
 moduleForComponent('github-connect', 'Integration | Component | github connect', {
   integration: true,
   beforeEach() {
     page.setContext(this);
+    setupSession(this.registry);
+    setupSessionService(this.registry);
   },
   afterEach() {
     page.removeContext();
   }
 });
 
-test('check if properties are bound correctly', function(assert) {
+test('binds href correctly', function(assert) {
   set(this, 'scope', '3098379083');
   set(this, 'clientId', 'ace');
-  set(this, 'state', 'ace123');
   set(this, 'redirectUri', 'ace.com');
   page.render(hbs`{{github-connect scope=scope clientId=clientId state=state redirectUri=redirectUri}}`);
-  assert.equal(page.button.href, `${baseUrl}?scope=3098379083&client_id=ace&state=ace123&redirect_uri=ace.com`);
-});
 
+  let session = this.container.lookup('service:session');
+  let { githubState } = get(session, 'data');
+  assert.equal(page.button.href, `${baseUrl}?scope=3098379083&client_id=ace&state=${githubState}&redirect_uri=ace.com`);
+});

--- a/tests/unit/routes/github-test.js
+++ b/tests/unit/routes/github-test.js
@@ -5,6 +5,7 @@ moduleFor('route:github', 'Unit | Route | github', {
     'service:ajax',
     'service:current-user',
     'service:flash-messages',
+    'service:github-state',
     'service:metrics',
     'service:session'
   ]


### PR DESCRIPTION
# What's in this PR?

This PR builds on top of #1282 to fix #1266 

It makes use of the service provided by #1282 to first generate and store a state value to send to github connect, followed by validating that value when the user comes back from github.

Right now, the PR is submitted against #1282 instead of develop, so the changes are clearer to see, but we should switch the base to develop when #1282 is merged.
