### PR TITLE
chore(package): update ember-click-outside to version 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-click-outside": "0.1.6",
+    "ember-click-outside": "0.1.9",
     "ember-composable-helpers": "2.0.0",
     "ember-concurrency": "^0.8.1",
     "ember-data": "^2.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,6 +511,12 @@ babel-plugin-dead-code-elimination@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
 
+babel-plugin-debug-macros@^0.1.6:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.7.tgz#69f5a3dc7d72f781354f18c611a3b007bb223511"
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -2303,7 +2309,22 @@ ember-cli-babel@5.2.4, ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cl
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0-alpha.8, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9:
+ember-cli-babel@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.1.0.tgz#d9c83a7d0c67cc8a3ccb9bd082971c3593e54fad"
+  dependencies:
+    amd-name-resolver "0.0.6"
+    babel-plugin-debug-macros "^0.1.6"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.2.0"
+    broccoli-babel-transpiler "^6.0.0"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^1.2.0"
+
+ember-cli-babel@^6.0.0-alpha.8, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.5, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9:
   version "6.0.0-beta.9"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.0.0-beta.9.tgz#b597d52f12d4429cd5716b55f749ebf6144b7b16"
   dependencies:
@@ -2911,11 +2932,11 @@ ember-cli@2.12.1:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
-ember-click-outside@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ember-click-outside/-/ember-click-outside-0.1.6.tgz#b56f14277351cccd84edaa78bcd399d71393871a"
+ember-click-outside@0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/ember-click-outside/-/ember-click-outside-0.1.9.tgz#a8bf22739814ae44785919faa62102cf7d70a123"
   dependencies:
-    ember-cli-babel "^5.1.7"
+    ember-cli-babel "^6.0.0"
     ember-cli-htmlbars "*"
 
 ember-composable-helpers@2.0.0:


### PR DESCRIPTION
Closes #1287

<details>
<summary>Commits</summary>
<p>The new version differs by 3 commits0.</p>
<ul>
<li><a href="https://urls.greenkeeper.io/zeppelin/ember-click-outside/commit/158d0b25142e25c78614efb59c4f1fecdeecc1ff"><code>158d0b2</code></a> <code>Released v0.1.9</code></li>
<li><a href="https://urls.greenkeeper.io/zeppelin/ember-click-outside/commit/af86be19fc230734012021761b19adb225a0aa13"><code>af86be1</code></a> <code>Merge pull request #13 from mirego/feature/set-cursor-pointer-to-body-when-inserting-click-outside-component</code></li>
<li><a href="https://urls.greenkeeper.io/zeppelin/ember-click-outside/commit/9c5e8f18553f3513c631c41100c693c75f6f3e34"><code>9c5e8f1</code></a> <code>Set “cursor: pointer” on body when inserting click-outside component</code></li>
</ul>
<p>false</p>
<p>See the <a href="https://urls.greenkeeper.io/zeppelin/ember-click-outside/compare/61335eaebd716bf8617964738aa14f7d93f7c07c...158d0b25142e25c78614efb59c4f1fecdeecc1ff">full diff</a></p>
</details>