### PR TITLE
chore(package): update ember-auto-focus to version 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "coveralls": "^2.11.14",
     "ember-ajax": "^2.4.1",
-    "ember-auto-focus": "1.0.6",
+    "ember-auto-focus": "1.0.8",
     "ember-autoresize": "0.5.22",
     "ember-can": "^0.8.4",
     "ember-cli": "2.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2244,12 +2244,12 @@ ember-ajax@^2.4.1:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-auto-focus@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ember-auto-focus/-/ember-auto-focus-1.0.6.tgz#722df8405702af0643f19280697f974a9700a9c4"
+ember-auto-focus@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/ember-auto-focus/-/ember-auto-focus-1.0.8.tgz#40ad38b2da84411339727bad9b9e0b1e5278b11a"
   dependencies:
-    ember-cli-babel "5.2.4"
-    ember-cli-htmlbars "1.2.0"
+    ember-cli-babel "6.1.0"
+    ember-cli-htmlbars "1.3.0"
 
 ember-autoresize@0.5.22:
   version "0.5.22"
@@ -2299,17 +2299,7 @@ ember-cli-babel@5.1.10:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@5.2.4, ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7, ember-cli-babel@^5.1.9, ember-cli-babel@^5.2.1:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
-  dependencies:
-    broccoli-babel-transpiler "^5.6.2"
-    broccoli-funnel "^1.0.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^1.0.2"
-    resolve "^1.1.2"
-
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-alpha.8, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.5, ember-cli-babel@^6.0.0-beta.9:
+ember-cli-babel@6.1.0, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-alpha.8, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.5, ember-cli-babel@^6.0.0-beta.9:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.1.0.tgz#d9c83a7d0c67cc8a3ccb9bd082971c3593e54fad"
   dependencies:
@@ -2323,6 +2313,16 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-alpha.8, ember-cli-babel@^6.0.0-b
     broccoli-source "^1.1.0"
     clone "^2.0.0"
     ember-cli-version-checker "^1.2.0"
+
+ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7, ember-cli-babel@^5.1.9, ember-cli-babel@^5.2.1:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
+  dependencies:
+    broccoli-babel-transpiler "^5.6.2"
+    broccoli-funnel "^1.0.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^1.0.2"
+    resolve "^1.1.2"
 
 ember-cli-babel@^6.0.0-beta.7:
   version "6.0.0-beta.9"
@@ -2569,9 +2569,19 @@ ember-cli-htmlbars-inline-precompile@^0.3.6:
     ember-cli-htmlbars "^1.0.0"
     hash-for-dep "^1.0.2"
 
-ember-cli-htmlbars@*, ember-cli-htmlbars@1.2.0, ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.1, ember-cli-htmlbars@^1.0.10, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.0.8, ember-cli-htmlbars@^1.1.0, ember-cli-htmlbars@^1.1.1:
+ember-cli-htmlbars@*, ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.1, ember-cli-htmlbars@^1.0.10, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.0.8, ember-cli-htmlbars@^1.1.0, ember-cli-htmlbars@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.2.0.tgz#327e1a5dda1c85c6fcf8be888f7894b32c3f393b"
+  dependencies:
+    broccoli-persistent-filter "^1.0.3"
+    ember-cli-version-checker "^1.0.2"
+    hash-for-dep "^1.0.2"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^2.0.0"
+
+ember-cli-htmlbars@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.0.tgz#e090f011239153bf45dab29625f94a46fce205af"
   dependencies:
     broccoli-persistent-filter "^1.0.3"
     ember-cli-version-checker "^1.0.2"


### PR DESCRIPTION
Closes #1281

<details>
<summary>Commits</summary>
<p>The new version differs by 2 commits0.</p>
<ul>
<li><a href="https://urls.greenkeeper.io/amk221/ember-auto-focus/commit/a3eedbf722b71bb55beacd9a048ea8e67a123905"><code>a3eedbf</code></a> <code>Released 1.0.8</code></li>
<li><a href="https://urls.greenkeeper.io/amk221/ember-auto-focus/commit/1c53be38a428e5c2758d30b74b1d4f439eb6f80c"><code>1c53be3</code></a> <code>remove use of getAttr</code></li>
</ul>
<p>false</p>
<p>See the <a href="https://urls.greenkeeper.io/amk221/ember-auto-focus/compare/a466984b113b4a9e5ea2249002d436531ba97f36...a3eedbf722b71bb55beacd9a048ea8e67a123905">full diff</a></p>
</details>