### PR TITLE
Add github-service with getRepositories, getIssues(project)

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -8,9 +8,10 @@ const { computed } = Ember;
 export default Model.extend({
   biography: attr(),
   cloudinaryPublicId: attr(),
-  insertedAt: attr('date'),
   email: attr(),
   firstName: attr(),
+  githubAuthToken: attr(),
+  insertedAt: attr('date'),
   lastName: attr(),
   name: attr(),
   password: attr(),

--- a/app/services/github-service.js
+++ b/app/services/github-service.js
@@ -1,0 +1,136 @@
+import AjaxService from 'ember-ajax/services/ajax';
+import Ember from 'ember';
+
+const {
+  computed,
+  computed: { alias },
+  get,
+  inject: { service }
+} = Ember;
+
+/**
+ * A Github API client service, used to communicate with the github API and
+ * interpret the returned data.
+ *
+ * @class GithubService
+ * @module code-corps-ember/services/github-service
+ * @extends EmberAjax.AjaxService
+ * @uses CurrentUserService
+ * @public
+ */
+export default AjaxService.extend({
+  currentUser: service(),
+  host: 'https://api.github.com/',
+
+  authToken: alias('currentUser.user.githubAuthToken'),
+
+  headers: computed('authToken', {
+    get() {
+      let authToken = get(this, 'authToken');
+      return { 'Authorization': `token ${authToken}` };
+    }
+  }),
+
+  /**
+   * Retrieves a list of repositories for a user.
+   *
+   * Requires user to be connected to github, meaning the current user must have
+   * a `githubAuthToken`.
+   *
+   * @method getRepositories
+   * @return {Array}
+   * @public
+   */
+  getRepositories() {
+    return this.request('/user/repos')
+               .then((data) => this._mapRepositories(data));
+  },
+
+  /**
+   * Maps a repository list payload retrieved from github.
+   *
+   * @method _mapRepositories
+   * @param {Array} githubData payload to map
+   * @return {Array} The mapped payload
+   * @private
+   */
+  _mapRepositories(githubData) {
+    return githubData.map((githubRepo) => this._mapRepository(githubRepo));
+  },
+
+  /**
+   * Maps a single github repository item retrieved from github.
+   *
+   * @method _mapRepository
+   * @param {Object} githubData The object containing data for a single repo.
+   * @return {Object} The mapped repo object.
+   * @private
+   */
+  _mapRepository({ id, name }) {
+    return { githubId: id, repositoryName: name };
+  },
+
+  /**
+   * Retrieves a list of github issues for a project.
+   *
+   * The project must be connected to github.
+   *
+   * NOTE: In the current implementation, where a project connected to github
+   * will simply have a github id, which is the id of a connected github
+   * repository, we make use of an undocumented github API endpoint to retrive
+   * a single repository: `GET /repositories/:id`.
+   *
+   * The documented endpoint to retrieve a repository is `GET /:owner/:repo`.
+   *
+   * We are forced to use this undocumented endpoint because the id is the only
+   * thing we store, and the only way to retrieve issues is via the endpoint
+   * `GET /:owner/:repo/issues`.
+   *
+   * @method getIssues
+   * @param {DS.Model} project - The project to get a list of github issues for.
+   * @return {Array}
+   * @public
+   */
+  getIssues(project) {
+    let repoGithubId = get(project, 'githubId');
+    return this.request(`/repositories/${repoGithubId}`)
+               .then((repo) => this._getIssuesForRepo(repo))
+               .then((issues) => this._mapIssues(issues));
+  },
+
+  /**
+   * Retrieves a list of issues for a github repository.
+   *
+   * @method _getIssuesForRepo
+   * @param {Object} githubRepo Data for a github repo, retrieved from github.
+   * @return {Promise} A promise for an ajax request
+   * @private
+   */
+  _getIssuesForRepo({ owner: { login }, name }) {
+    return this.request(`/${login}/${name}/issues`);
+  },
+
+  /**
+   * Maps an issue list payload retrieved from github.
+   *
+   * @method _mapIssues
+   * @param {Array} githubIssues An array of issues retrieved from github
+   * @return {Array} An array of mapped issues
+   * @private
+   */
+  _mapIssues(issues) {
+    return issues.map((issueData) => this._mapIssue(issueData));
+  },
+
+  /**
+   * Maps an issue payload retrieved from github
+   *
+   * @method _mapIssue
+   * @param {Object} githubIsue An issue retrieved from github
+   * @return {Object} A mapped issue
+   * @private
+   */
+  _mapIssue({ id, title }) {
+    return { githubId: id, issueName: title };
+  }
+});

--- a/tests/integration/services/github-service-test.js
+++ b/tests/integration/services/github-service-test.js
@@ -1,0 +1,120 @@
+import { moduleFor, test } from 'ember-qunit';
+import { startMirage } from 'code-corps-ember/initializers/ember-cli-mirage';
+
+const githubRepo = {
+  id: 1296269,
+  owner: {
+    login: 'octocat',
+    id: 1,
+    avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+    type: 'User',
+    site_admin: false
+  },
+  name: 'Hello-World',
+  full_name: 'octocat/Hello-World',
+  description: 'This your first repo!',
+  private: false,
+  fork: false,
+  language: null,
+  forks_count: 9,
+  stargazers_count: 80,
+  watchers_count: 80,
+  size: 108,
+  permissions: {
+    admin: false,
+    push: false,
+    pull: true
+  }
+};
+
+const githubRepoData = [githubRepo];
+
+const githubIssue = {
+  id: 1,
+  url: 'https://api.github.com/repos/octocat/Hello-World/issues/1347',
+  repository_url: 'https://api.github.com/repos/octocat/Hello-World',
+  number: 1347,
+  state: 'open',
+  title: 'Found a bug',
+  body: "I'm having a problem with this."
+};
+
+const githubIssueData = [githubIssue];
+
+const project = Object.create({ githubId: githubRepo.id });
+
+moduleFor('service:github-service', 'Integration | Service | github service', {
+  integration: true,
+  beforeEach() {
+    this.server = new startMirage();
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('getRepositories returns a properly mapped list of github repositories', function(assert) {
+  assert.expect(1);
+
+  let service = this.subject();
+
+  this.server.get('https://api.github.com/user/repos', function() {
+    return githubRepoData;
+  });
+
+  let done = assert.async();
+  service.getRepositories().then(([repo]) => {
+    let expectedRepo = { repositoryName: githubRepo.name, githubId: githubRepo.id };
+    assert.deepEqual(repo, expectedRepo, 'Repository was properly mapped.');
+    done();
+  });
+});
+
+test('getRepositories throws error if something goes wrong', function(assert) {
+  assert.expect(1);
+
+  let service = this.subject();
+
+  this.server.get('https://api.github.com/user/repos', {}, 401);
+
+  let done = assert.async();
+  service.getRepositories().catch(() => {
+    assert.ok(true, 'Error was raised.');
+    done();
+  });
+});
+
+test('getIssues returns a properly mapped list of github issues for a repository', function(assert) {
+  assert.expect(1);
+
+  let service = this.subject();
+
+  this.server.get('https://api.github.com/repositories/1296269', githubRepo, 200);
+
+  this.server.get('https://api.github.com/octocat/Hello-World/issues', function() {
+    return githubIssueData;
+  });
+
+  let done = assert.async();
+  service.getIssues(project).then(([issue]) => {
+    let expectedIssue = { issueName: githubIssue.title, githubId: githubIssue.id };
+    assert.deepEqual(issue, expectedIssue, 'Issue was properly mapped.');
+    done();
+  });
+});
+
+test('getRepositories throws error if something goes wrong', function(assert) {
+  assert.expect(1);
+
+  let service = this.subject();
+
+  this.server.get('https://api.github.com/repositories/1296269', githubRepo, 200);
+
+  this.server.get('https://api.github.com/octocat/Hello-World/issues', {}, 401);
+
+  let done = assert.async();
+  service.getIssues(project).catch(() => {
+    assert.ok(true, 'Error was raised.');
+    done();
+  });
+});

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -21,10 +21,10 @@ test('it exists', function(assert) {
 });
 
 testForAttributes('user', [
-  'biography', 'cloudinaryPublicId', 'email', 'firstName', 'insertedAt',
-  'lastName', 'name', 'password', 'photoLargeUrl', 'photoThumbUrl',
-  'signUpContext', 'state', 'stateTransition', 'twitter', 'username',
-  'website'
+  'biography', 'cloudinaryPublicId', 'email', 'firstName', 'githubAuthToken',
+  'lastName', 'insertedAt', 'name', 'password', 'photoLargeUrl',
+  'photoThumbUrl', 'signUpContext', 'state', 'stateTransition', 'twitter',
+  'username', 'website'
 ]);
 
 testForBelongsTo('user', 'stripePlatformCard');


### PR DESCRIPTION
# What's in this PR?

This PR adds a `github-service`, which is a client to be used when communicating with the github API.

The service defines two public methods.

### `getRepositories`

This method uses the `githubAuthToken` for the currently signed in user and makes a request to retrieve a list of repositories for that user. It maps the retrieved data and returns a promise.

### `getIssues(project)`

This method uses the project's `githubId`, which is github repository ID to retrieve a list of issues for that repository. 

Due to the fact that we only have access to the github repository id, we are forced to make use of an undocumented github api endpoint `GET /repositories/:id`, to request a repository first, followed by a request `GET /:owner/:repo/issues`. 

If were to be storing the `owner.login` and `repo.name` values in some association to our project, we would not require the first request and would be able to request issues directly. 

That being said, regardless of how we want to proceed, this service should be a good starting point from which we can build.

## References
Fixes #1275, #1276 