### PR TITLE
chore(package): update ember-cli-moment-shim to version 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-jwt-decode": "0.0.3",
     "ember-cli-meta-tags": "3.1.0",
     "ember-cli-mirage": "^0.3.1",
-    "ember-cli-moment-shim": "3.1.0",
+    "ember-cli-moment-shim": "3.3.0",
     "ember-cli-neat": "^0.0.6",
     "ember-cli-page-object": "1.9.0",
     "ember-cli-password-strength": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,9 +2757,9 @@ ember-cli-mirage@^0.3.1:
     pretender "^1.4.2"
     route-recognizer "^0.2.3"
 
-ember-cli-moment-shim@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.1.0.tgz#ec6a39a0dcb4badeaf6dcb74a6c05b0bc576f721"
+ember-cli-moment-shim@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.3.0.tgz#420ea29a81d7c03410ee988d0d7e36b49b2b283d"
   dependencies:
     broccoli-funnel "^1.1.0"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
Closes #1306

## Version **3.3.0** of [ember-cli-moment-shim](https://github.com/jasonmit/ember-cli-moment-shim) just got published.

<details>
<summary>Commits</summary>
<p>The new version differs by 3 commits.</p>
<ul>
<li><a href="https://urls.greenkeeper.io/jasonmit/ember-cli-moment-shim/commit/97dbc90173942932625b957b96775bf90bfaf54c"><code>97dbc90</code></a> <code>3.3.0</code></li>
<li><a href="https://urls.greenkeeper.io/jasonmit/ember-cli-moment-shim/commit/2a653bd88386eb5979f87dbe0444e43f2310f0ae"><code>2a653bd</code></a> <code>Removing unused import</code></li>
<li><a href="https://urls.greenkeeper.io/jasonmit/ember-cli-moment-shim/commit/5adc56b892a6b087769d8b21a0bdea73f08937dc"><code>5adc56b</code></a> <code>Revert "Initial commit to support rc changes (#137)"</code></li>
</ul>
<p>See the <a href="https://urls.greenkeeper.io/jasonmit/ember-cli-moment-shim/compare/9993ad4e59019c6b133dfe90d6aedabcc47ad704...97dbc90173942932625b957b96775bf90bfaf54c">full diff</a></p>
</details>