### PR TITLE
Updated hello/start pages continue button from footer to under name f…

### DIFF
--- a/app/templates/start/hello.hbs
+++ b/app/templates/start/hello.hbs
@@ -26,6 +26,7 @@
           {{/auto-focus}}
           {{input type="text" name="lastName" value=model.lastName placeholder="Last name" enter='attemptToContinue' }}
         </div>
+        <button class="{{if usersNameIsEmpty "clear" "default"}} right" disabled={{or usersNameIsEmpty uploadingImage}} {{action 'continue'}}>Continue</button>
       </div>
     </div>
   </div>
@@ -34,7 +35,4 @@
 
 </div>
 
-<div class="start__footer">
-  <p>Nice to finally meet you.</p>
-  <button class="{{if usersNameIsEmpty "clear" "default"}}" disabled={{or usersNameIsEmpty uploadingImage}} {{action 'continue'}}>Let's go!</button>
-</div>
+<div class="start__footer"></div>

--- a/tests/acceptance/onboarding-test.js
+++ b/tests/acceptance/onboarding-test.js
@@ -46,22 +46,22 @@ test('A user can onboard as expected', function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/start/interests');
-    assert.ok(onboardingPage.startButton.isDisabled, 'start button is disabled');
+    assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
     onboardingPage.clickCategoryItem();
   });
 
   andThen(() => {
-    assert.notOk(onboardingPage.startButton.isDisabled, 'start button is enabled');
+    assert.notOk(onboardingPage.startFooterButton.isDisabled, 'start button is enabled');
     onboardingPage.clickCategoryItem();
   });
 
   andThen(() => {
-    assert.ok(onboardingPage.startButton.isDisabled, 'start button is disabled');
+    assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
     onboardingPage.clickCategoryItem();
   });
 
   andThen(() => {
-    onboardingPage.startButton.click();
+    onboardingPage.startFooterButton.click();
   });
 
   andThen(() => {
@@ -79,22 +79,22 @@ test('A user can onboard as expected', function(assert) {
     assert.ok(onboardingPage.roleColumns(2).hasClass('expertise__column--support'));
     assert.equal(onboardingPage.roleColumns(2).roles(0).button.text, 'Donations');
 
-    assert.ok(onboardingPage.startButton.isDisabled, 'start button is disabled');
+    assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
     onboardingPage.roleColumns(0).roles(0).button.click();
   });
 
   andThen(() => {
-    assert.notOk(onboardingPage.startButton.isDisabled, 'start button is enabled');
+    assert.notOk(onboardingPage.startFooterButton.isDisabled, 'start button is enabled');
     onboardingPage.roleColumns(0).roles(0).button.click();
   });
 
   andThen(() => {
-    assert.ok(onboardingPage.startButton.isDisabled, 'start button is disabled');
+    assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
     onboardingPage.roleColumns(0).roles(0).button.click();
   });
 
   andThen(() => {
-    onboardingPage.startButton.click();
+    onboardingPage.startFooterButton.click();
   });
 
   andThen(() => {
@@ -125,7 +125,7 @@ test('A user can onboard as expected', function(assert) {
   });
 
   andThen(() => {
-    onboardingPage.startButton.click();
+    onboardingPage.startFooterButton.click();
   });
 
   andThen(() => {
@@ -189,7 +189,7 @@ test('A user can submit name by hitting enter key on firstName input field', fun
 
   andThen(() => {
     assert.equal(currentURL(), '/start/interests');
-    assert.ok(onboardingPage.startButton.isDisabled, 'start button is disabled');
+    assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
   });
 });
 
@@ -213,7 +213,7 @@ test('A user can submit name by hitting enter key on lastName input field', func
 
   andThen(() => {
     assert.equal(currentURL(), '/start/interests');
-    assert.ok(onboardingPage.startButton.isDisabled, 'start button is disabled');
+    assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
   });
 });
 

--- a/tests/pages/onboarding.js
+++ b/tests/pages/onboarding.js
@@ -32,6 +32,11 @@ export default create({
   },
 
   startButton: {
+    scope: '.hello__column--name-input button',
+    isDisabled: attribute('disabled')
+  },
+
+  startFooterButton: {
     scope: '.start__footer button',
     isDisabled: attribute('disabled')
   },


### PR DESCRIPTION
Updated hello/start pages continue button from footer to under name field. Added page object for new button and updated acceptance test

# What's in this PR?
- updated start/hello template to move button under name fields.
- added class "right" to pull right.
- Changed text to "continue" as in the mockup
- removed button from start-footer div. However it still has the border styling so it's still used

### Updated onboarding tests: 
1. Changed startFooter button to scope inside `.hello_column--name-input- button` Added another object called startFooterButton to replace original startFooter Object. Not sure if I should add another className or just use this class?
2. Updated onboarding acceptance test to use startFooterButton. 

Make sure any changes to code include changes to documentation.

## References
Fixes #1323
