### PR TITLE
Add project card donation progress component

### DIFF
--- a/app/components/project-card/donation-progress.js
+++ b/app/components/project-card/donation-progress.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+
+const {
+  Component,
+  computed
+} = Ember;
+
+/**
+ * Displays progress towards the current donation goal
+ *
+ * Needs to be provided a donation goal and the current amount donated towards that goal.
+ *
+ * ## default usage
+ *
+ * {{project-card/donation-progress
+ *   donationGoal=donationGoal
+ *   amountDonated=amountDonated
+ * }}
+ *
+ * @class project-card/donation-progress
+ * @module  Component
+ * @extends Ember.Component
+ */
+export default Component.extend({
+  classNames: ['project-card__donation-progress'],
+
+  /**
+   * The amount donated towards this donation goal
+   * @property {Number} amountDonated
+   */
+  amountDonated: 0,
+
+  /**
+   * The total amount needed to donate towards the current donation goal.
+   * Aliased from the donation goal assigned in the template.
+   *
+   * @property {Number} amountNeeded
+   */
+  amountNeeded: computed.alias('donationGoal.amount'),
+
+  /**
+   * The description this donation goal
+   * @property {String} description
+   */
+  description: computed.alias('donationGoal.description'),
+
+  /**
+   * A computed field. Uses fields `amountDonated` and `amountNeeded` to
+   * compute a percentage.
+   *
+   * @return {String} The computed percentage, rounded to two decimals.
+   */
+  percentage: computed('amountDonated', 'amountNeeded', function() {
+    let { amountDonated, amountNeeded } = this.getProperties('amountDonated', 'amountNeeded');
+    let percentage = amountDonated / amountNeeded * 100;
+    return percentage.toFixed(2);
+  })
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -131,6 +131,7 @@
 //
 @import "components/project-card-members";
 @import "components/project-card";
+@import "components/project-card/donation-progress";
 @import "components/project-header";
 @import "components/project-item";
 @import "components/project-join-modal";

--- a/app/styles/components/project-card/donation-progress.scss
+++ b/app/styles/components/project-card/donation-progress.scss
@@ -1,0 +1,35 @@
+.project-card__donation-progress {
+  .progress-bar-container {
+    height: 8px;
+    margin: 1.5rem 0 0 0;
+  }
+
+  &__details {
+    display: flex;
+    justify-content: space-between;
+    margin: 1rem 0 0 0;
+
+    &__amount, &__percentage {
+      text-align: center;
+
+      &__label {
+        color: $text--light;
+        font-size: $body-font-size-small;
+      }
+
+      &__value {
+        font-size: $body-font-size-normal;
+        font-weight: 600;
+        line-height: 1rem;
+      }
+
+      &:first-child {
+        text-align: left;
+      }
+
+      &:last-child {
+        text-align: right;
+      }
+    }
+  }
+}

--- a/app/templates/components/project-card.hbs
+++ b/app/templates/components/project-card.hbs
@@ -36,4 +36,10 @@
   </p>
   {{related-skills class="project-card__skills" overflowHidden=true skills=projectSkills}}
   {{project-card-members members=projectUsers}}
+  {{#if project.donationsActive}}
+    {{project-card/donation-progress
+      amountDonated=project.totalMonthlyDonated
+      donationGoal=project.currentDonationGoal
+    }}
+  {{/if}}
 </div>

--- a/app/templates/components/project-card/donation-progress.hbs
+++ b/app/templates/components/project-card/donation-progress.hbs
@@ -1,0 +1,11 @@
+{{progress-bar-container percentage=percentage}}
+<div class="project-card__donation-progress__details">
+  <div class="project-card__donation-progress__details__percentage">
+    <div class="project-card__donation-progress__details__percentage__value">{{format-percentage percentage trimZero=true}}</div>
+    <div class="project-card__donation-progress__details__percentage__label">of {{format-currency donationGoal.amount trimZero=true}} goal</div>
+  </div>
+  <div class="project-card__donation-progress__details__amount">
+    <div class="project-card__donation-progress__details__amount__value">{{format-currency amountDonated trimZero=true}}</div>
+    <div class="project-card__donation-progress__details__amount__label">given each month</div>
+  </div>
+</div>

--- a/tests/integration/components/project-card/donation-progress-test.js
+++ b/tests/integration/components/project-card/donation-progress-test.js
@@ -1,0 +1,47 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+import PageObject from 'ember-cli-page-object';
+import component from '../../../pages/components/project-card/donation-progress';
+
+let page = PageObject.create(component);
+
+moduleForComponent('project-card/donation-progress', 'Integration | Component | project card/donation progress', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders proper information', function(assert) {
+  assert.expect(4);
+
+  let mockGoal = { amount: 1000 };
+
+  this.set('donationGoal', mockGoal);
+
+  page.render(hbs`{{project-card/donation-progress donationGoal=donationGoal amountDonated=500}}`);
+
+  assert.equal(page.amountValue, '$500', 'Correct amount value is rendered');
+  assert.equal(page.percentageLabel, 'of $1,000 goal', 'Correct percentage label is rendered');
+  assert.equal(page.percentageValue, '50%', 'Correct percentage value is rendered');
+  assert.ok(page.progressBar.isVisible, 'Progress bar component is rendered');
+});
+
+test('it renders decimal values if there are any', function(assert) {
+  assert.expect(4);
+
+  let mockGoal = { amount: 1000, description: 'Lorem ipsum' };
+
+  this.set('donationGoal', mockGoal);
+
+  page.render(hbs`{{project-card/donation-progress donationGoal=donationGoal amountDonated=505.50}}`);
+
+  assert.equal(page.amountValue, '$505.50', 'Correct amount is rendered');
+  assert.equal(page.percentageLabel, 'of $1,000 goal', 'Correct percentage label is rendered');
+  assert.equal(page.percentageValue, '50.5%', 'Correct percentage is rendered');
+  assert.ok(page.progressBar.isVisible, 'Progress bar component is rendered');
+});

--- a/tests/pages/components/project-card/donation-progress.js
+++ b/tests/pages/components/project-card/donation-progress.js
@@ -1,0 +1,11 @@
+import { text } from 'ember-cli-page-object';
+import progressBar from 'code-corps-ember/tests/pages/components/progress-bar';
+
+export default {
+  scope: '.project-card__donation-progress',
+
+  amountValue: text('.project-card__donation-progress__details__amount__value'),
+  percentageLabel: text('.project-card__donation-progress__details__percentage__label'),
+  percentageValue: text('.project-card__donation-progress__details__percentage__value'),
+  progressBar
+};


### PR DESCRIPTION
# What's in this PR?

Simply adds a donation progress component to the `project-card`. It's very similar to the other one, but think it deserves to split off on its own as it may be used differently going forward. Not yet a good candidate to be DRY-ed up.