### PR TITLE
Add component to display username

### DIFF
--- a/app/components/user/display-username.js
+++ b/app/components/user/display-username.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+const {
+  Component,
+  computed,
+  computed: { alias },
+  get
+} = Ember;
+
+export default Component.extend({
+  tagName: 'span',
+  classNames: ['user__display-username'],
+
+  user: null,
+
+  githubUsername: alias('user.githubUsername'),
+  username: alias('user.username'),
+
+  githubUserUrl: computed('githubUsername', function() {
+    return `https://www.github.com/${get(this, 'githubUsername')}`;
+  })
+});

--- a/app/templates/components/comment-item.hbs
+++ b/app/templates/components/comment-item.hbs
@@ -27,7 +27,7 @@
   </div>
 {{else}}
   <div class="comment-info">
-    {{#link-to 'slugged-route' comment.user.username class="username"}}{{comment.user.username}}{{/link-to}} commented {{moment-from-now comment.insertedAt}}
+    {{user/display-username user=comment.user}} commented {{moment-from-now comment.insertedAt}}
     {{#if canEdit}}
       <a class="edit" {{action 'edit'}}>edit</a>
     {{/if}}

--- a/app/templates/components/task-details.hbs
+++ b/app/templates/components/task-details.hbs
@@ -16,7 +16,7 @@
       </div>
     {{else}}
       <div class="comment-info">
-        {{#link-to 'slugged-route' task.user.username class="username"}}{{task.user.username}}{{/link-to}} posted {{moment-from-now task.insertedAt}}
+        {{user/display-username user=task.user}} posted {{moment-from-now task.insertedAt}}
         {{#if canEdit}}
           <a class="edit" {{action 'editTaskBody'}}>edit</a>
         {{/if}}

--- a/app/templates/components/user/display-username.hbs
+++ b/app/templates/components/user/display-username.hbs
@@ -1,0 +1,5 @@
+{{#if username}}
+  {{#link-to data-test-username 'slugged-route' username class="username"}}{{username}}{{/link-to}}
+{{else if githubUsername}}
+  GitHub user <a data-test-github-username href={{githubUserUrl}} class="username">{{githubUsername}}</a>
+{{/if}}

--- a/tests/integration/components/comment-item-test.js
+++ b/tests/integration/components/comment-item-test.js
@@ -38,7 +38,7 @@ test('it renders all required comment elements properly', function(assert) {
   renderPage();
 
   assert.equal(page.commentBody.text, '', 'The body is not initially rendered, since the comment has not loaded');
-  assert.equal(page.username, '', 'The username of the comment author is not rendered, since the comment is not loaded yet');
+  assert.notOk(page.username.isVisible, 'The username of the comment author is not rendered, since the comment is not loaded yet');
   assert.notOk(page.codeThemeSelectorVisible, 'The code theme selector is hidden, since the comment is not loaded yet.');
 
   // this will trigger some promise resolving, so we wrap it in a loop
@@ -52,7 +52,7 @@ test('it renders all required comment elements properly', function(assert) {
   });
 
   assert.equal(page.commentBody.text, 'A comment', 'The body is now rendered.');
-  assert.equal(page.username, 'tester', 'The username of the comment author is now rendered.');
+  assert.equal(page.username.text, 'tester', 'The username of the comment author is now rendered.');
   assert.ok(page.codeThemeSelectorVisible, 'The code theme selector is visible, since the comment is marked as containing code.');
 });
 
@@ -90,4 +90,3 @@ test('it switches between editing and viewing mode', function(assert) {
 
   assert.notOk(page.editor.isVisible, 'Component switched back to view mode.');
 });
-

--- a/tests/integration/components/user/display-username-test.js
+++ b/tests/integration/components/user/display-username-test.js
@@ -1,0 +1,68 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import PageObject from 'ember-cli-page-object';
+import component from 'code-corps-ember/tests/pages/components/user/display-username';
+
+let page = PageObject.create(component);
+
+moduleForComponent('user/display-username', 'Integration | Component | user/display username', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it renders only the username if present', function(assert) {
+  assert.expect(3);
+
+  let user = {
+    githubUsername: null,
+    username: 'test-user'
+  };
+
+  this.set('user', user);
+
+  page.render(hbs`{{user/display-username user=user}}`);
+
+  assert.ok(page.username.isVisible);
+  assert.notOk(page.githubUsername.isVisible);
+  assert.equal(page.username.text.trim(), 'test-user');
+});
+
+test('it renders only the username regardless of whether both are present', function(assert) {
+  assert.expect(3);
+
+  let user = {
+    githubUsername: 'github-test-user',
+    username: 'test-user'
+  };
+
+  this.set('user', user);
+
+  page.render(hbs`{{user/display-username user=user}}`);
+
+  assert.ok(page.username.isVisible);
+  assert.notOk(page.githubUsername.isVisible);
+  assert.equal(page.username.text.trim(), 'test-user');
+});
+
+test('it renders only the github username if only it is present', function(assert) {
+  assert.expect(4);
+
+  let user = {
+    githubUsername: 'github-test-user',
+    username: null
+  };
+
+  this.set('user', user);
+
+  page.render(hbs`{{user/display-username user=user}}`);
+
+  assert.notOk(page.username.isVisible);
+  assert.ok(page.githubUsername.isVisible);
+  assert.equal(page.githubUsername.text.trim(), 'github-test-user');
+  assert.equal(page.text.trim(), 'GitHub user github-test-user');
+});

--- a/tests/pages/components/comment-item.js
+++ b/tests/pages/components/comment-item.js
@@ -2,8 +2,7 @@ import {
   clickable,
   collection,
   fillable,
-  isVisible,
-  text
+  isVisible
 } from 'ember-cli-page-object';
 
 export default {
@@ -39,5 +38,7 @@ export default {
     itemScope: '.error'
   }),
 
-  username: text('.username')
+  username: {
+    scope: '[data-test-username]'
+  }
 };

--- a/tests/pages/components/user/display-username.js
+++ b/tests/pages/components/user/display-username.js
@@ -1,0 +1,11 @@
+export default {
+  scope: '.user__display-username',
+
+  githubUsername: {
+    scope: '[data-test-github-username]'
+  },
+
+  username: {
+    scope: '[data-test-username]'
+  }
+};


### PR DESCRIPTION
# What's in this PR?

This adds a `{{user/display-username}}` component. This is used only in places where you could potentially have a username displayed for a user that does not have a Code Corps username (e.g. if they were created from GitHub).