### PR TITLE
Reload tasks when visiting tasks/index

### DIFF
--- a/app/routes/project/tasks/index.js
+++ b/app/routes/project/tasks/index.js
@@ -12,9 +12,10 @@ export default Route.extend({
 
   async model() {
     let project = this.modelFor('project');
-    let memberPromises = await get(project, 'projectUsers').then((projectUsers) => {
-      return projectUsers.map((projectUser) => get(projectUser, 'user'));
-    });
+    let projectUsers = await get(project, 'projectUsers');
+    let memberPromises = projectUsers.mapBy('user');
+    let taskLists = get(project, 'taskLists');
+    taskLists.forEach((taskList) => get(taskList, 'tasks').reload());
     return RSVP.hash({ project, members: RSVP.all(memberPromises) });
   },
 


### PR DESCRIPTION
# What's in this PR?

Hacky fix but makes it so task data reloads when the task board is navigated away from and back to.

## References
Fixes #1418 