### PR TITLE
Remove github pull request link and rely only on issue

### DIFF
--- a/app/templates/components/task-card.hbs
+++ b/app/templates/components/task-card.hbs
@@ -25,13 +25,6 @@
           size="small"
         }}
       {{/if}}
-      {{#if task.githubPullRequest}}
-        {{github/issue-link
-          githubIssue=task.githubPullRequest
-          githubRepo=task.githubRepo
-          size="small"
-        }}
-      {{/if}}
     </span>
   </p>
   <p class="task-card__assignee">


### PR DESCRIPTION
# What's in this PR?

Removes an unnecessary reliance on the pull request. This will work for _all_ issues, regardless of whether it's a pull request.