### PR TITLE
Add tracking for core actions

### DIFF
--- a/app/components/github-connect.js
+++ b/app/components/github-connect.js
@@ -1,12 +1,7 @@
-import Ember from 'ember';
 import ENV from 'code-corps-ember/config/environment';
-
-const {
-  Component,
-  get,
-  inject: { service },
-  set
-} = Ember;
+import Component from '@ember/component';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 const baseUrl = 'https://github.com/login/oauth/authorize';
 
@@ -31,16 +26,24 @@ export default Component.extend({
   attributeBindings: ['url:href'],
 
   githubState: service(),
+  metrics: service(),
 
   clientId: `${ENV.github.clientId}`,
   redirectUri: `${ENV.github.redirectUri}`,
   scope: `${ENV.github.scope}`,
   state: null,
+  url: null,
 
   init() {
     this._super(...arguments);
     this._initState();
     this._initUrl();
+  },
+
+  click() {
+    get(this, 'metrics').trackEvent({
+      event: 'Clicked Connect with GitHub'
+    });
   },
 
   _initState() {

--- a/app/components/github/install-link.js
+++ b/app/components/github/install-link.js
@@ -1,0 +1,29 @@
+import ENV from 'code-corps-ember/config/environment';
+import Component from '@ember/component';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+  githubAppUrl: ENV.github.appUrl,
+
+  metrics: service(),
+
+  organization: null,
+  project: null,
+
+  actions: {
+    trackClick() {
+      let organizationId = get(this, 'organization.id');
+      let organizationName = get(this, 'organization.name');
+      let projectId = get(this, 'project.id');
+      let projectTitle = get(this, 'project.title');
+      get(this, 'metrics').trackEvent({
+        event: 'Clicked Install GitHub Application',
+        organization: organizationName,
+        organization_id: organizationId,
+        project: projectTitle,
+        project_id: projectId
+      });
+    }
+  }
+});

--- a/app/components/github/issue-link.js
+++ b/app/components/github/issue-link.js
@@ -1,11 +1,21 @@
-import Ember from 'ember';
-
-const {
-  Component
-} = Ember;
+import Component from '@ember/component';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
   classNames: ['github__issue-link'],
 
-  size: 'large'
+  metrics: service(),
+
+  githubIssue: null,
+  githubRepo: null,
+  size: 'large',
+
+  actions: {
+    trackClick() {
+      get(this, 'metrics').trackEvent({
+        event: 'Clicked GitHub Link for Task'
+      });
+    }
+  }
 });

--- a/app/controllers/project/settings/integrations.js
+++ b/app/controllers/project/settings/integrations.js
@@ -1,17 +1,9 @@
-import Ember from 'ember';
-import ENV from 'code-corps-ember/config/environment';
-
-const {
-  Controller,
-  computed: { alias, mapBy },
-  computed,
-  get,
-  getProperties,
-  inject: { service }
-} = Ember;
+import Controller from '@ember/controller';
+import { computed, get, getProperties } from '@ember/object';
+import { alias, mapBy } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  githubAppUrl: ENV.github.appUrl,
   store: service(),
 
   organization: alias('project.organization'),

--- a/app/controllers/project/tasks/index.js
+++ b/app/controllers/project/tasks/index.js
@@ -1,17 +1,13 @@
-import Ember from 'ember';
-
-const {
-  computed: { sort },
-  Controller,
-  get,
-  inject: { service },
-  RSVP,
-  setProperties
-} = Ember;
+import Controller from '@ember/controller';
+import { get, setProperties } from '@ember/object';
+import { sort } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import RSVP from 'rsvp';
 
 export default Controller.extend({
   taskListsSorting: ['order:asc'],
 
+  metrics: service(),
   store: service(),
 
   dragulaconfig: {
@@ -46,6 +42,20 @@ export default Controller.extend({
       } else {
         this._moveTaskMaybeBelowTask(taskList, task, position, droppedTaskEl);
       }
+    },
+
+    trackClickNewTask(project) {
+      let organizationId = get(project, 'organization.id');
+      let organizationName = get(project, 'organization.name');
+      let projectId = get(project, 'id');
+      let projectTitle = get(project, 'title');
+      get(this, 'metrics').trackEvent({
+        event: 'Clicked New Task',
+        organization: organizationName,
+        organization_id: organizationId,
+        project: projectTitle,
+        project_id: projectId
+      });
     }
   },
 

--- a/app/routes/project/tasks/index.js
+++ b/app/routes/project/tasks/index.js
@@ -1,13 +1,10 @@
-import Ember from 'ember';
-
-const {
-  get,
-  inject: { service },
-  Route,
-  RSVP
-} = Ember;
+import { get } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import RSVP from 'rsvp';
 
 export default Route.extend({
+  metrics: service(),
   projectTaskBoard: service(),
 
   async model() {
@@ -41,6 +38,24 @@ export default Route.extend({
       let organizationSlug = get(project, 'organization.slug');
       let projectSlug = get(project, 'slug');
       let taskNumber = get(task, 'number');
+
+      let organizationId = get(project, 'organization.id');
+      let organizationName = get(project, 'organization.name');
+      let projectId = get(project, 'id');
+      let projectTitle = get(project, 'title');
+      let taskId = get(task, 'id');
+      let taskTitle = get(task, 'title');
+
+      get(this, 'metrics').trackEvent({
+        event: 'Clicked on Task Card in List',
+        organization: organizationName,
+        organization_id: organizationId,
+        project: projectTitle,
+        project_id: projectId,
+        task: taskTitle,
+        task_id: taskId
+      });
+
       this.transitionTo('project.tasks.task', organizationSlug, projectSlug, taskNumber);
     }
   }

--- a/app/templates/components/github/install-link.hbs
+++ b/app/templates/components/github/install-link.hbs
@@ -1,0 +1,1 @@
+<a data-test-installation-link href={{githubAppUrl}} {{action "trackClick" preventDefault=false}} class="button button__github button__github--light default" target="_blank"><span></span>Install on GitHub</a>

--- a/app/templates/components/github/issue-link.hbs
+++ b/app/templates/components/github/issue-link.hbs
@@ -1,5 +1,5 @@
 {{#if (and githubIssue.isLoaded githubRepo.isLoaded)}}
-  <a data-test-issue-url href={{githubIssue.htmlUrl}}>
+  <a data-test-issue-url href={{githubIssue.htmlUrl}} {{action "trackClick" preventDefault=false}}>
     {{#if (eq size "large")}}
       {{svg/sprite-icon icon="github-48"}} <span class="github__issue-link__repo-name" data-test-repo-name>{{githubRepo.name}}</span> <span class="github__issue-link__issue-number" data-test-issue-number>#{{githubIssue.number}}</span>
     {{else if (eq size "small")}}

--- a/app/templates/project/settings/integrations.hbs
+++ b/app/templates/project/settings/integrations.hbs
@@ -65,7 +65,10 @@
               The button will open a new tab, so come back here and refresh the page when you're done.
             </p>
             <p>
-              <a href={{githubAppUrl}} data-test-installation-link class="button button__github button__github--light default" target="_blank"><span></span>Install on GitHub</a>
+              {{github/install-link
+                organization=project.organization
+                project=project
+              }}
             </p>
             {{else}}
               <p>

--- a/app/templates/project/tasks/index.hbs
+++ b/app/templates/project/tasks/index.hbs
@@ -1,6 +1,6 @@
 <div class="tasks-menu">
   <div class="left">
-    {{link-to 'New task' 'project.tasks.new' tagName='button' class="default small new-task"}}
+    {{link-to 'New task' 'project.tasks.new' invokeAction=(action 'trackClickNewTask' project) tagName='button' class="default small new-task"}}
   </div>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-i18n": "^5.0.2",
     "ember-keyboard": "^2.1.9",
+    "ember-link-action": "^0.0.36",
     "ember-load": "^0.0.12",
     "ember-load-initializers": "^1.0.0",
     "ember-metrics": "code-corps/ember-metrics#add-context-to-segment-adapter",

--- a/tests/acceptance/project-settings-integrations-test.js
+++ b/tests/acceptance/project-settings-integrations-test.js
@@ -35,7 +35,7 @@ test('it renders link to github app installation page if user is connected to Gi
 
   andThen(() => {
     assert.notOk(projectIntegrationsPage.integrationsLink.isVisible, 'The link to user profile integrations does not render');
-    assert.ok(projectIntegrationsPage.installationLink.isVisible, 'The link to GitHub app installation renders');
+    assert.ok(projectIntegrationsPage.installLink.isVisible, 'The link to GitHub app installation renders');
   });
 });
 
@@ -54,7 +54,7 @@ test('it renders link to user integrations page if user is not connected to GitH
 
   andThen(() => {
     assert.ok(projectIntegrationsPage.integrationsLink.isVisible, 'The link to user profile integrations renders');
-    assert.notOk(projectIntegrationsPage.installationLink.isVisible, 'The link to GitHub app installation does not render');
+    assert.notOk(projectIntegrationsPage.installLink.isVisible, 'The link to GitHub app installation does not render');
   });
 });
 

--- a/tests/integration/components/github-connect-test.js
+++ b/tests/integration/components/github-connect-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 import PageObject from 'ember-cli-page-object';
 import component from 'code-corps-ember/tests/pages/components/github-connect';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
@@ -32,4 +33,18 @@ test('binds href correctly', function(assert) {
   let session = this.container.lookup('service:session');
   let { githubState } = get(session, 'data');
   assert.equal(page.href, `${baseUrl}?scope=3098379083&client_id=ace&state=${githubState}&redirect_uri=ace.com`);
+});
+
+test('tracks click event', function(assert) {
+  assert.expect(1);
+  let mockMetrics = {
+    trackEvent(properties) {
+      let event = get(properties, 'event');
+      assert.equal(event, 'Clicked Connect with GitHub');
+    }
+  };
+  stubService(this, 'metrics', mockMetrics);
+
+  page.render(hbs`{{github-connect}}`);
+  page.click();
 });

--- a/tests/integration/components/github/install-link-test.js
+++ b/tests/integration/components/github/install-link-test.js
@@ -1,0 +1,54 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { set } from '@ember/object';
+import component from 'code-corps-ember/tests/pages/components/github/install-link';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
+import PageObject from 'ember-cli-page-object';
+
+let page = PageObject.create(component);
+
+function renderPage() {
+  page.render(hbs`
+    {{github/install-link
+      organization=organization
+      project=project
+    }}
+  `);
+}
+
+moduleForComponent('github/install-link', 'Integration | Component | github/install link', {
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
+});
+
+test('it tracks clicking the link', function(assert) {
+  assert.expect(1);
+
+  let organization = { id: 1, name: 'Code Corps' };
+  let project = { id: 1, title: 'Code Corps' };
+
+  let mockMetrics = {
+    trackEvent(data) {
+      assert.deepEqual(data, {
+        event: 'Clicked Install GitHub Application',
+        organization: organization.name,
+        organization_id: organization.id,
+        project: project.title,
+        project_id: project.id
+      }, 'Event tracking was called with proper attributes.');
+    }
+  };
+  stubService(this, 'metrics', mockMetrics);
+
+  set(this, 'organization', organization);
+  set(this, 'project', project);
+
+  renderPage();
+
+  page.click();
+});

--- a/tests/integration/components/github/issue-link-test.js
+++ b/tests/integration/components/github/issue-link-test.js
@@ -1,15 +1,12 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
+import { get, set } from '@ember/object';
+import { run } from '@ember/runloop';
 import component from 'code-corps-ember/tests/pages/components/github/issue-link';
+import stubService from 'code-corps-ember/tests/helpers/stub-service';
 import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(component);
-
-const {
-  run,
-  set
-} = Ember;
 
 function renderPage() {
   page.render(hbs`
@@ -100,4 +97,23 @@ test('it renders with loading when small', function(assert) {
   renderPage();
 
   assert.ok(page.loadingSmall.isVisible, 'The small loading state renders.');
+});
+
+test('it tracks clicking the link', function(assert) {
+  assert.expect(1);
+
+  let mockMetrics = {
+    trackEvent(properties) {
+      let event = get(properties, 'event');
+      assert.equal(event, 'Clicked GitHub Link for Task');
+    }
+  };
+  stubService(this, 'metrics', mockMetrics);
+
+  set(this, 'githubIssue', githubIssue);
+  set(this, 'githubRepo', githubRepo);
+
+  renderPage();
+
+  page.url.click();
 });

--- a/tests/pages/components/github/install-link.js
+++ b/tests/pages/components/github/install-link.js
@@ -1,0 +1,3 @@
+export default {
+  scope: '[data-test-installation-link]'
+};

--- a/tests/pages/project/settings/integrations.js
+++ b/tests/pages/project/settings/integrations.js
@@ -1,5 +1,6 @@
 import { collection, create, visitable } from 'ember-cli-page-object';
 import connectedInstallation from 'code-corps-ember/tests/pages/components/github/connected-installation';
+import installLink from 'code-corps-ember/tests/pages/components/github/install-link';
 import unconnectedInstallation from 'code-corps-ember/tests/pages/components/github/unconnected-installation';
 
 export default create({
@@ -9,9 +10,7 @@ export default create({
     scope: '[data-test-integrations-link]'
   },
 
-  installationLink: {
-    scope: '[data-test-installation-link]'
-  },
+  installLink,
 
   connectedInstallations: collection({
     itemScope: '.github-app-installation.connected',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3452,6 +3452,12 @@ ember-keyboard@^2.1.9:
   dependencies:
     ember-cli-babel "^6.3.0"
 
+ember-link-action@^0.0.36:
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/ember-link-action/-/ember-link-action-0.0.36.tgz#e30d143a979592196f3f6400dfee12c51e4aa684"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"


### PR DESCRIPTION
# What's in this PR?

Work in progress. So far:

- [x] Clicked New Task
- [x] Clicked on Task Card in List
- [ ] Clicked Assign Task on Task Card (track organization, project, task)
- [x] Clicked GitHub Link on Task Card (track organization, project, task)
- [x] Clicked Install GitHub Application (track organization and project)
- [x] Clicked Connect with GitHub

## References
Progress on #1439 