### PR TITLE
Add keyboard shortcuts for assigning

### DIFF
--- a/app/templates/components/task-card.hbs
+++ b/app/templates/components/task-card.hbs
@@ -36,6 +36,7 @@
     </span>
   </p>
   {{task-assignment
+    canTriggerAssignment=hovering
     deferredRendering=(not hasHovered)
     onclose=(action assignmentClosed)
     onopen=(action assignmentOpened)

--- a/tests/acceptance/task-list-test.js
+++ b/tests/acceptance/task-list-test.js
@@ -48,11 +48,8 @@ test('member can assign/reassign/unassign tasks to user', function(assert) {
   andThen(() => {
     taskCard = page.taskBoard.taskLists(0).taskCards(0);
     assert.ok(taskCard.taskAssignment.select.trigger.unassigned, 'Task is rendered unassigned.');
-    taskCard.taskAssignment.select.trigger.open();
-  });
-
-  andThen(() => {
-    taskCard.taskAssignment.select.dropdown.options(0).select();
+    taskCard.mouseenter();
+    taskCard.triggerKeyDown('Space');
   });
 
   andThen(() => {
@@ -60,7 +57,8 @@ test('member can assign/reassign/unassign tasks to user', function(assert) {
     assert.ok(taskCard.taskAssignment.select.trigger.assigned, 'Task is rendered assigned.');
     let userTask = server.schema.userTasks.first();
     assert.equal(userTask.user.photoThumbUrl, taskCard.taskAssignment.assignedUser.icon.url, 'Assigned user is rendered.');
-    taskCard.taskAssignment.select.trigger.open();
+    taskCard.mouseenter();
+    taskCard.triggerKeyDown('KeyA');
   });
 
   andThen(() => {

--- a/tests/pages/components/task-assignment.js
+++ b/tests/pages/components/task-assignment.js
@@ -2,6 +2,7 @@ import {
   attribute
 } from 'ember-cli-page-object';
 import select from 'code-corps-ember/tests/pages/components/power-select';
+import { triggerKeyDown } from 'ember-keyboard';
 
 export default {
   scope: '.task-assignment',
@@ -15,6 +16,8 @@ export default {
   },
 
   select,
+
+  triggerKeyDown,
 
   unselectedItem: {
     scope: '.select-inline__unselected-item'


### PR DESCRIPTION
# What's in this PR?

- Press <kbd>A</kbd> to open the task assignment dropdown when hovering the task card
- Press <kbd>Space</kbd> to self-assign/unassign when hovering the task card