### PR TITLE
Fix keyframes and fix the animated high five component

### DIFF
--- a/app/styles/base/_animations.scss
+++ b/app/styles/base/_animations.scss
@@ -46,55 +46,7 @@
   to   { opacity: 1; }
 }
 
-/* Firefox < 16 */
-@-moz-keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-/* Safari, Chrome and Opera > 12.1 */
-@-webkit-keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-/* Internet Explorer */
-@-ms-keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-/* Opera < 12.1 */
-@-o-keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
 @keyframes fadeInDown {
-  from { opacity: 0; transform: translate3d(0, -100%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Firefox < 16 */
-@-moz-keyframes fadeInDown {
-  from { opacity: 0; transform: translate3d(0, -100%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Safari, Chrome and Opera > 12.1 */
-@-webkit-keyframes fadeInDown {
-  from { opacity: 0; transform: translate3d(0, -100%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Internet Explorer */
-@-ms-keyframes fadeInDown {
-  from { opacity: 0; transform: translate3d(0, -100%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Opera < 12.1 */
-@-o-keyframes fadeInDown {
   from { opacity: 0; transform: translate3d(0, -100%, 0); }
   to { opacity: 1; transform: none; }
 }
@@ -104,55 +56,7 @@
   to { opacity: 1; transform: none; }
 }
 
-/* Firefox < 16 */
-@-moz-keyframes fadeInUp {
-  from { opacity: 0; transform: translate3d(0, 50%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Safari, Chrome and Opera > 12.1 */
-@-webkit-keyframes fadeInUp {
-  from { opacity: 0; transform: translate3d(0, 50%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Internet Explorer */
-@-ms-keyframes fadeInUp {
-  from { opacity: 0; transform: translate3d(0, 50%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
-/* Opera < 12.1 */
-@-o-keyframes fadeInUp {
-  from { opacity: 0; transform: translate3d(0, 50%, 0); }
-  to { opacity: 1; transform: none; }
-}
-
 @keyframes fadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-/* Firefox < 16 */
-@-moz-keyframes fadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-/* Safari, Chrome and Opera > 12.1 */
-@-webkit-keyframes fadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-/* Internet Explorer */
-@-ms-keyframes fadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-/* Opera < 12.1 */
-@-o-keyframes fadeOut {
   from { opacity: 1; }
   to   { opacity: 0; }
 }
@@ -176,30 +80,6 @@
   to   { left: 45%; }
 }
 
-/* Firefox < 16 */
-@-moz-keyframes fly {
-  from { left: -100%; }
-  to   { left: 45%; }
-}
-
-/* Safari, Chrome and Opera > 12.1 */
-@-webkit-keyframes fly {
-  from { left: -100%; }
-  to   { left: 45%; }
-}
-
-/* Internet Explorer */
-@-ms-keyframes fly {
-  from { left: -100%; }
-  to   { left: 45%; }
-}
-
-/* Opera < 12.1 */
-@-o-keyframes fly {
-  from { left: -100%; }
-  to   { left: 45%; }
-}
-
 @mixin translateX($val) {
   -webkit-transform: translateX($val);
   -moz-transform: translateX($val);
@@ -208,34 +88,6 @@
 }
 
 @keyframes moveRight {
-  0% { @include translateX(-100%); }
-  40% { @include translateX(0%); }
-  60% { @include translateX(0%); }
-  100% { @include translateX(100%); }
-}
-
-@-moz-keyframes moveRight {
-  0% { @include translateX(-100%); }
-  40% { @include translateX(0%); }
-  60% { @include translateX(0%); }
-  100% { @include translateX(100%); }
-}
-
-@-o-keyframes moveRight {
-  0% { @include translateX(-100%); }
-  40% { @include translateX(0%); }
-  60% { @include translateX(0%); }
-  100% { @include translateX(100%); }
-}
-
-@-webkit-keyframes moveRight {
-  0% { @include translateX(-100%); }
-  40% { @include translateX(0%); }
-  60% { @include translateX(0%); }
-  100% { @include translateX(100%); }
-}
-
-@-ms-keyframes moveRight {
   0% { @include translateX(-100%); }
   40% { @include translateX(0%); }
   60% { @include translateX(0%); }

--- a/app/styles/components/animated-high-five.scss
+++ b/app/styles/components/animated-high-five.scss
@@ -1,11 +1,11 @@
 @keyframes emptyAnimation {}
 
-@-webkit-keyframes pulsate {
+@keyframes pulsate {
   25% {transform: scale(1.3, 1.3);}
   100% {transform: scale(1.0, 1.0);}
 }
 
-@-webkit-keyframes reset {
+@keyframes reset {
   100% {transform: scale(1.0, 1.0);}
 }
 

--- a/app/styles/templates/index.scss
+++ b/app/styles/templates/index.scss
@@ -126,18 +126,6 @@
   100% { opacity:1; }
 }
 
-@-webkit-keyframes blink {
-  0% { opacity:1; }
-  50% { opacity:0; }
-  100% { opacity:1; }
-}
-
-@-moz-keyframes blink {
-  0% { opacity:1; }
-  50% { opacity:0; }
-  100% { opacity:1; }
-}
-
 .landing-subsection {
   @include span-columns(12);
   margin-top: 40px;


### PR DESCRIPTION
# What's in this PR?

Fixes the `animated-high-five` component by adding unprefixed `@keyframes` and removes prefixed versions everywhere.