### PR TITLE
Improve .panel and .image-drop on mobile

### DIFF
--- a/app/styles/components/image-drop.scss
+++ b/app/styles/components/image-drop.scss
@@ -36,9 +36,13 @@
 
   &.is-large {
     $size: 200px;
-    $border-radius: $size / 2;
     height: $size;
     width: $size;
+
+    @include media($sm-screen) {
+      height: 100px;
+      width: 100px;
+    }
   }
 
   .hover {

--- a/app/styles/layout/_panel.scss
+++ b/app/styles/layout/_panel.scss
@@ -26,6 +26,11 @@
     float: left;
     width: 25%;
 
+    @include media($sm-screen) {
+      margin-bottom: 1em;
+      width: 100%;
+    }
+
     h3 {
       align-items: center;
       display: flex;
@@ -52,6 +57,11 @@
     float: left;
     margin-left: 8.33333%;
     width: 66.66667%;
+
+    @include media($sm-screen) {
+      margin-left: 0;
+      width: 100%;
+    }
 
     p {
       &:first-child {


### PR DESCRIPTION
# What's in this PR?

Small CSS fixes for `.panel` and `.image-drop` on mobile views.