### PR TITLE
Improve performance of task card

### DIFF
--- a/app/components/task-assignment.js
+++ b/app/components/task-assignment.js
@@ -11,6 +11,7 @@ export default Component.extend({
   currentUser: service(),
   taskAssignment: service(),
 
+  deferredRendering: null,
   task: null,
   taskUser: null,
   users: null,

--- a/app/components/task-card.js
+++ b/app/components/task-card.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { mapBy, alias } from '@ember/object/computed';
+import { alias, mapBy } from '@ember/object/computed';
 import { computed, get, getProperties, set } from '@ember/object';
 import { on } from '@ember/object/evented';
 import { inject as service } from '@ember/service';
@@ -20,6 +20,7 @@ export default Component.extend(EmberKeyboardMixin, {
   store: service(),
 
   bound: false,
+  hasHovered: false,
   hovering: false,
   shouldShowUsers: false,
   task: null,
@@ -85,6 +86,7 @@ export default Component.extend(EmberKeyboardMixin, {
   },
 
   mouseEnter() {
+    set(this, 'hasHovered', true);
     set(this, 'hovering', true);
     set(this, 'keyboardActivated', true);
   },

--- a/app/styles/components/task-card.scss
+++ b/app/styles/components/task-card.scss
@@ -20,6 +20,7 @@
   }
 
   &__assignee {
+    display: flex;
     flex-direction: row;
     justify-content: flex-start;
     margin: 0;

--- a/app/styles/layout/_select-inline.scss
+++ b/app/styles/layout/_select-inline.scss
@@ -243,7 +243,7 @@ $list-height: 220px;
       width: $icon-size;
 
       img {
-        border-radius: 10px;
+        border-radius: $icon-border-radius;
         display: inline-block;
         height: $icon-size;
         width: $icon-size;
@@ -253,7 +253,7 @@ $list-height: 220px;
     &__content {
       color: $text--lightest;
       font-size: $body-font-size-tiny;
-      line-height: 18px;
+      line-height: 22px;
       padding-top: 1px;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/app/templates/components/github/pull-request-icon.hbs
+++ b/app/templates/components/github/pull-request-icon.hbs
@@ -1,9 +1,21 @@
 {{#if merged}}
-  {{svg/sprite-icon icon="github-merge-48" style="solid-purple"}}
+  <span class="sprite-icon">
+    <svg class="solid-purple size-16">
+      <use xlink:href="#github-merge-48"></use>
+    </svg>
+  </span>
 {{else if (eq state 'closed')}}
-  {{svg/sprite-icon icon="github-pull-request-48" style="solid-red"}}
+  <span class="sprite-icon">
+    <svg class="solid-red size-16">
+      <use xlink:href="#github-pull-request-48"></use>
+    </svg>
+  </span>
 {{else if (eq state 'open')}}
-  {{svg/sprite-icon icon="github-pull-request-48" style="solid-green"}}
+  <span class="sprite-icon">
+    <svg class="solid-green size-16">
+      <use xlink:href="#github-pull-request-48"></use>
+    </svg>
+  </span>
 {{else}}
   <div data-test-loading class="loading loading--circle-16"></div>
 {{/if}}

--- a/app/templates/components/task-assignment.hbs
+++ b/app/templates/components/task-assignment.hbs
@@ -1,31 +1,52 @@
 <p class="task-card__assignee">
-  {{#if canAssign}}
-    {{#power-select
-      beforeOptionsComponent=(component "power-select/before-task-options" selectRemoteController=selectRemoteController)
-      buildSelection=(action "buildSelection")
-      class="select-inline"
-      disabled=userSelectDisabled
-      dropdownClass="select-inline-dropdown"
-      loadingMessage=""
-      matchTriggerWidth=false
-      onchange=(action "changeUser")
-      options=userOptions
-      placeholderComponent=(component "task-card/user/unselected-item" click=(action "stopClickPropagation") task=task)
-      registerAPI=(action (mut selectRemoteController))
-      search=(action "searchUsers")
-      selected=selectedOption
-      selectedItemComponent=(component "task-card/user/selected-item" click=(action "stopClickPropagation"))
-      tagName="div"
-      as |user select|
-    }}
-      {{select-inline-dropdown/list-item
-        iconUrl=user.photoThumbUrl
-        lastSearchedText=select.lastSearchedText
-        primaryText=user.username
-        secondaryText=user.name
+  {{#if deferredRendering}}
+    {{#if (and canAssign (not taskUser))}}
+      <div class="select-inline select-inline__unselected-item">
+        {{#if task.userTask.isLoading}}
+          <span class="select-inline__loading-item__icon"></span>
+          <span class="select-inline__loading-item__text"></span>
+        {{else}}
+          <span data-test-unselected-icon class="select-inline__unselected-item__icon">
+            <span class="sprite-icon">
+              <svg class="solid-light-gray size-14">
+                <use xlink:href="#user-48"></use>
+              </svg>
+            </span>
+          </span>
+        {{/if}}
+      </div>
+    {{else if taskUser}}
+      {{task-card/user/selected-item select=(hash selected = taskUser)}}
+    {{/if}}
+  {{else}}
+    {{#if canAssign}}
+      {{#power-select
+        beforeOptionsComponent=(component "power-select/before-task-options" selectRemoteController=selectRemoteController)
+        buildSelection=(action "buildSelection")
+        class="select-inline"
+        disabled=userSelectDisabled
+        dropdownClass="select-inline-dropdown"
+        loadingMessage=""
+        matchTriggerWidth=false
+        onchange=(action "changeUser")
+        options=userOptions
+        placeholderComponent=(component "task-card/user/unselected-item" click=(action "stopClickPropagation") task=task)
+        registerAPI=(action (mut selectRemoteController))
+        search=(action "searchUsers")
+        selected=selectedOption
+        selectedItemComponent=(component "task-card/user/selected-item" click=(action "stopClickPropagation"))
+        tagName="div"
+        as |user select|
       }}
-    {{/power-select}}
-  {{else if taskUser}}
-    {{task-card/user/selected-item select=(hash selected = selectedOption)}}
+        {{select-inline-dropdown/list-item
+          iconUrl=user.photoThumbUrl
+          lastSearchedText=select.lastSearchedText
+          primaryText=user.username
+          secondaryText=user.name
+        }}
+      {{/power-select}}
+    {{else if taskUser}}
+      {{task-card/user/selected-item select=(hash selected = selectedOption)}}
+    {{/if}}
   {{/if}}
 </p>

--- a/app/templates/components/task-card.hbs
+++ b/app/templates/components/task-card.hbs
@@ -19,15 +19,24 @@
     <span class="task-card__time" data-test-task-time>{{moment-from-now task.createdAt}}</span>
     <span class="task-card__integrations" data-test-task-integrations>
       {{#if task.githubIssue}}
-        {{github/issue-link
-          githubIssue=task.githubIssue
-          githubRepo=task.githubRepo
-          size="small"
-        }}
+        {{#if hasHovered}}
+          {{github/issue-link
+            githubIssue=task.githubIssue
+            githubRepo=task.githubRepo
+            size="small"
+          }}
+        {{else}}
+          <span class="sprite-icon">
+            <svg class="solid-light-gray size-16">
+              <use xlink:href="#github-48"></use>
+            </svg>
+          </span>
+        {{/if}}
       {{/if}}
     </span>
   </p>
   {{task-assignment
+    deferredRendering=(not hasHovered)
     task=task
     taskUser=taskUser
     users=users

--- a/app/templates/components/task-card/user/unselected-item.hbs
+++ b/app/templates/components/task-card/user/unselected-item.hbs
@@ -3,7 +3,11 @@
   <span class="select-inline__loading-item__text"></span>
 {{else}}
   <span data-test-unselected-icon class="select-inline__unselected-item__icon">
-    {{svg/sprite-icon icon="user-48" size="14" style="solid-light-gray"}}
+    <span class="sprite-icon">
+      <svg class="solid-light-gray size-14">
+        <use xlink:href="#user-48"></use>
+      </svg>
+    </span>
   </span>
   {{#tooltip-on-component
     class='tooltip'

--- a/tests/acceptance/task-list-test.js
+++ b/tests/acceptance/task-list-test.js
@@ -40,6 +40,12 @@ test('member can assign/reassign/unassign tasks to user', function(assert) {
   let taskCard;
 
   andThen(() => {
+    // We need to hover the card to be able to assign the task
+    // NOTE: mouseenter doesn't trigger in the page object
+    find('.task-card:eq(0)').mouseenter();
+  });
+
+  andThen(() => {
     taskCard = page.taskBoard.taskLists(0).taskCards(0);
     assert.ok(taskCard.taskAssignment.select.trigger.unassigned, 'Task is rendered unassigned.');
     taskCard.taskAssignment.select.trigger.open();

--- a/tests/integration/components/task-card-test.js
+++ b/tests/integration/components/task-card-test.js
@@ -99,20 +99,22 @@ test('it cannot reposition if it does not have the ability', function(assert) {
   assert.notOk(page.canReposition, 'Cannot reposition');
 });
 
-test('it renders the GitHub issue link icon if it has an issue', function(assert) {
+test('it renders the GitHub issue link icon if it has an issue and is hovering', function(assert) {
   assert.expect(1);
   let isLoaded = true;
   let task = { githubIssue: { isLoaded }, githubRepo: { isLoaded } };
   set(this, 'task', task);
   renderPage();
+  page.mouseenter();
   assert.ok(page.issueLink.isVisible, 'The GitHub issue link is visible');
 });
 
-test('it does not render the GitHub issue link icon if it does not have an issue', function(assert) {
+test('it does not render the GitHub issue link icon if it does not have an issue and is hovering', function(assert) {
   assert.expect(1);
   let task = { githubIssue: null };
   set(this, 'task', task);
   renderPage();
+  page.mouseenter();
   assert.notOk(page.issueLink.isVisible, 'The GitHub issue link is not visible');
 });
 
@@ -151,7 +153,7 @@ test('it does not send action if clicked and loading', function(assert) {
   assert.ok(true);
 });
 
-test('assignment works if user has ability', function(assert) {
+test('assignment works if user has ability and card is hovered', function(assert) {
   let done = assert.async();
   assert.expect(2);
 
@@ -176,11 +178,12 @@ test('assignment works if user has ability', function(assert) {
 
   renderPage();
 
+  page.mouseenter();
   page.taskAssignment.select.trigger.open();
   page.taskAssignment.select.dropdown.options(0).select();
 });
 
-test('unassignment works if user has ability', function(assert) {
+test('unassignment works if user has ability and card is hovered', function(assert) {
   let done = assert.async();
   assert.expect(1);
 
@@ -204,11 +207,12 @@ test('unassignment works if user has ability', function(assert) {
 
   renderPage();
 
+  page.mouseenter();
   page.taskAssignment.select.trigger.open();
   page.taskAssignment.select.dropdown.options(0).select();
 });
 
-test('assignment dropdown renders if user has ability', function(assert) {
+test('assignment dropdown renders if user has ability and card is hovered', function(assert) {
   assert.expect(2);
 
   let task = { id: 'task' };
@@ -228,12 +232,13 @@ test('assignment dropdown renders if user has ability', function(assert) {
 
   renderPage();
 
+  page.mouseenter();
   page.taskAssignment.select.trigger.open();
   assert.equal(page.taskAssignment.select.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
   assert.equal(page.taskAssignment.select.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
 });
 
-test('assignment dropdown renders when records are still being loaded', function(assert) {
+test('assignment dropdown renders when records are still being loaded and card  is hovered', function(assert) {
   let done = assert.async();
   assert.expect(2);
 
@@ -259,6 +264,7 @@ test('assignment dropdown renders when records are still being loaded', function
 
   renderPage();
 
+  page.mouseenter();
   RSVP.all(users).then(() => {
     page.taskAssignment.select.trigger.open();
     assert.equal(page.taskAssignment.select.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
@@ -267,7 +273,7 @@ test('assignment dropdown renders when records are still being loaded', function
   });
 });
 
-test('assignment dropdown does not render if user has no ability', function(assert) {
+test('assignment dropdown does not render if user has no ability and card is hovered', function(assert) {
   assert.expect(2);
 
   let task = { id: 'task' };
@@ -291,6 +297,7 @@ test('assignment dropdown does not render if user has no ability', function(asse
 
   renderPage();
 
+  page.mouseenter();
   assert.notOk(page.taskAssignment.select.triggerRenders, 'Dropdown trigger for assignment does not render.');
   page.taskAssignment.assignedUser.as((user) => {
     assert.equal(user.icon.url, 'test.png');

--- a/tests/pages/components/task-assignment.js
+++ b/tests/pages/components/task-assignment.js
@@ -14,5 +14,9 @@ export default {
     }
   },
 
-  select
+  select,
+
+  unselectedItem: {
+    scope: '.select-inline__unselected-item'
+  }
 };


### PR DESCRIPTION
# What's in this PR?

This is a spike and should not (yet) be considered production-ready code.

The changes made here have so far improved render of a given task list from ~1500ms to ~500ms, resulting in a 3x performance improvement.

- Replaced `svg/sprite-icon` component on `task-card` with simple HTML
  - removes ~1ms render multiplied by `n` cards
- Does not render `ember-power-select` in `task-assignment` until hovering the card
  - this may have implications for mobile usage that needs considered
  - removes ~10ms render multiplied by `n` cards
- Does not render the `github/issue-link` component until hovering the card and instead renders simple HTML
  - removes < 1ms render multiplied by `n` cards

The `tooltip-on-component` from `ember-tooltip` has similarly deleterious effects on performance when rendering across multiple cards.

One thing that we could do is to change the behavior from hovering to whether the card is in the viewport (and could possibly unrender the complex elements when leaving the viewport, though this unrendering does not work for `mouseLeave` because of other UX considerations).

Much of the mobile behavior changes may depend on whether we can reliably sniff the mobile device. Ideally the behavior would be the same across devices and screen sizes.

Fixes #1504 