### PR TITLE
Update GithubEvent model and the show page

### DIFF
--- a/app/models/github-event.js
+++ b/app/models/github-event.js
@@ -4,11 +4,13 @@ import { computed, get } from '@ember/object';
 
 export default Model.extend({
   action: attr(),
+  error: attr(),
   eventType: attr(),
   failureReason: attr(),
   githubDeliveryId: attr(),
   insertedAt: attr('date'),
   payload: attr(),
+  recordData: attr(),
   status: attr(),
   updatedAt: attr('date'),
 

--- a/app/templates/admin/github-events/github-event.hbs
+++ b/app/templates/admin/github-events/github-event.hbs
@@ -18,3 +18,19 @@
   {{code-theme-selector}}
   <pre data-test-payload>{{model.prettyPayload}}</pre>
 </div>
+
+{{#if model.error}}
+  <div>
+    <h4>Error</h4>
+    <p>The error that prevented the webhook from syncing.</p>
+    <pre data-test-error>{{model.error}}</pre>
+  </div>
+{{/if}}
+
+{{#if model.recordData}}
+  <div>
+    <h4>Data</h4>
+    <p>The record's data prior to the sync attempt.</p>
+    <pre data-test-record-data>{{model.recordData}}</pre>
+  </div>
+{{/if}}

--- a/tests/acceptance/admin-github-event-test.js
+++ b/tests/acceptance/admin-github-event-test.js
@@ -7,16 +7,18 @@ import moment from 'moment';
 moduleForAcceptance('Acceptance | Admin | GitHub Event | Show');
 
 test('Displays all the logged events', function(assert) {
-  assert.expect(8);
+  assert.expect(10);
 
   let user = server.create('user', { admin: true, id: 1 });
   let event = server.create('github-event', {
     action: 'labeled',
+    error: 'Error',
     eventType: 'pull_request',
     failureReason: 'not_fully_implemented',
     githubDeliveryId: '71aeab80-9e59-11e7-81ac-198364bececc',
     insertedAt: moment(),
     payload: JSON.parse('{"key": "value"}'),
+    recordData: 'Data',
     status: 'errored'
   });
 
@@ -33,5 +35,7 @@ test('Displays all the logged events', function(assert) {
     assert.equal(page.status.text, event.status);
     assert.equal(page.failureReason.text, event.failureReason);
     assert.equal(page.payload.text, '{ "key": "value" }');
+    assert.equal(page.error.text, event.error);
+    assert.equal(page.recordData.text, event.recordData);
   });
 });

--- a/tests/pages/admin/github-events/show.js
+++ b/tests/pages/admin/github-events/show.js
@@ -3,6 +3,10 @@ import { create, visitable } from 'ember-cli-page-object';
 export default create({
   visit: visitable('/admin/github/events/:id'),
 
+  error: {
+    scope: '[data-test-error]'
+  },
+
   eventTitle: {
     scope: '[data-test-event-title]'
   },
@@ -17,6 +21,10 @@ export default create({
 
   payload: {
     scope: '[data-test-payload]'
+  },
+
+  recordData: {
+    scope: '[data-test-record-data]'
   },
 
   status: {

--- a/tests/unit/models/github-event-test.js
+++ b/tests/unit/models/github-event-test.js
@@ -7,11 +7,13 @@ moduleForModel('github-event', 'Unit | Model | github event', {
 
 testForAttributes('github-event', [
   'action',
+  'error',
   'eventType',
   'failureReason',
   'githubDeliveryId',
   'insertedAt',
   'payload',
+  'recordData',
   'status',
   'updatedAt'
 ]);


### PR DESCRIPTION
# What's in this PR?

Allows us to see the `recordData` and `error` on the github event in the admin panel.