### PR TITLE
Fix task assignment filtering and focus bug

### DIFF
--- a/app/components/power-select/before-task-options.js
+++ b/app/components/power-select/before-task-options.js
@@ -1,7 +1,25 @@
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
+import { on } from '@ember/object/evented';
 import BeforeOptionsComponent from 'ember-power-select/components/power-select/before-options';
+import {
+  EKMixin as EmberKeyboardMixin,
+  keyDown
+} from 'ember-keyboard';
 
-export default BeforeOptionsComponent.extend({
+export default BeforeOptionsComponent.extend(EmberKeyboardMixin, {
+  init() {
+    this._super(...arguments);
+
+    set(this, 'keyboardActivated', true);
+  },
+
+  keydown: on(keyDown(), function(event, ekEvent) {
+    ekEvent.stopPropagation();
+    ekEvent.stopImmediatePropagation();
+    // Send the action ember-power-select expects
+    this.sendAction('onKeydown', event);
+  }),
+
   actions: {
     close() {
       get(this, 'selectRemoteController').actions.close();

--- a/app/components/task-assignment.js
+++ b/app/components/task-assignment.js
@@ -1,14 +1,18 @@
 import Component from '@ember/component';
 import { alias } from '@ember/object/computed';
+import { run } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { set, getProperties, computed } from '@ember/object';
 import EmberCan from 'ember-can';
 import createTaskUserOptions from 'code-corps-ember/utils/create-task-user-options';
 
+const TRIGGER_CLASS = '.ember-power-select-trigger';
+
 export default Component.extend({
   classNames: ['task-assignment'],
 
   currentUser: service(),
+  store: service(),
   taskAssignment: service(),
 
   deferredRendering: null,
@@ -65,6 +69,15 @@ export default Component.extend({
       } else {
         return taskAssignment.unassign(task);
       }
+    },
+
+    closeDropdown() {
+      this.sendAction('onclose');
+      run.next(() => this.$(TRIGGER_CLASS).trigger('blur'));
+    },
+
+    openDropdown() {
+      this.sendAction('onopen');
     },
 
     searchUsers(query) {

--- a/app/components/task-card.js
+++ b/app/components/task-card.js
@@ -20,6 +20,7 @@ export default Component.extend(EmberKeyboardMixin, {
   store: service(),
 
   bound: false,
+  editingDetails: false,
   hasHovered: false,
   hovering: false,
   shouldShowUsers: false,
@@ -66,6 +67,14 @@ export default Component.extend(EmberKeyboardMixin, {
     this.$().trigger('mouseleave');
   },
 
+  assignmentClosed() {
+    set(this, 'editingDetails', false);
+  },
+
+  assignmentOpened() {
+    set(this, 'editingDetails', true);
+  },
+
   click(e) {
     if (e.target instanceof SVGElement) {
       return;
@@ -98,8 +107,9 @@ export default Component.extend(EmberKeyboardMixin, {
 
   triggerArchive: on(keyDown('KeyC'), function() {
     let hovering = get(this, 'hovering');
+    let editingDetails = get(this, 'editingDetails');
     let canArchive = get(this, 'canArchive');
-    if (hovering && canArchive) {
+    if (hovering && !editingDetails && canArchive) {
       get(this, 'archiveTask').perform();
     }
   })

--- a/app/styles/layout/_select-inline.scss
+++ b/app/styles/layout/_select-inline.scss
@@ -200,7 +200,7 @@ $list-height: 220px;
       content: "";
       height: 10px;
       left: 10px; // fix for firefox inline
-      margin: 5px 7px 0 0;
+      margin: 7px 7px 0 0;
       position: absolute;
       width: $icon-width;
     }

--- a/app/templates/components/power-select/before-task-options.hbs
+++ b/app/templates/components/power-select/before-task-options.hbs
@@ -13,7 +13,6 @@
       placeholder={{searchPlaceholder}}
       oninput={{onInput}}
       onfocus={{onFocus}}
-      onblur={{onBlur}}
-      onkeydown={{action "onKeydown"}}>
+      onblur={{onBlur}}>
   </div>
 {{/if}}

--- a/app/templates/components/task-assignment.hbs
+++ b/app/templates/components/task-assignment.hbs
@@ -25,6 +25,8 @@
         loadingMessage=""
         matchTriggerWidth=false
         onchange=(action "changeUser")
+        onclose=(action "closeDropdown")
+        onopen=(action "openDropdown")
         options=userOptions
         placeholderComponent=(component "task-card/user/unselected-item" click=(action "stopClickPropagation") task=task)
         registerAPI=(action (mut selectRemoteController))

--- a/app/templates/components/task-card.hbs
+++ b/app/templates/components/task-card.hbs
@@ -37,6 +37,8 @@
   </p>
   {{task-assignment
     deferredRendering=(not hasHovered)
+    onclose=(action assignmentClosed)
+    onopen=(action assignmentOpened)
     task=task
     taskUser=taskUser
     users=users

--- a/config/environment.js
+++ b/config/environment.js
@@ -26,8 +26,8 @@ module.exports = function(environment) {
 
     cloudinary: {},
 
-    github: {
-      scope: 'public_repo,admin:org,user:email'
+    emberKeyboard: {
+      propagation: true
     },
 
     flashMessageDefaults: {
@@ -45,6 +45,10 @@ module.exports = function(environment) {
       // since that's the new Ember convention
       injectionFactories: [],
       preventDuplicates: true
+    },
+
+    github: {
+      scope: 'public_repo,admin:org,user:email'
     },
 
     i18n: {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",
     "ember-i18n": "^5.0.2",
-    "ember-keyboard": "^2.1.9",
+    "ember-keyboard": "^2.3.0",
     "ember-link-action": "^0.0.36",
     "ember-load": "^0.0.12",
     "ember-load-initializers": "^1.0.0",

--- a/tests/integration/components/task-card-test.js
+++ b/tests/integration/components/task-card-test.js
@@ -337,7 +337,7 @@ test('it does not archive task when not hovering and pressing C key', function(a
       return this;
     },
     then() {
-      assert.notOk(true);
+      assert.notOk(true, 'The task should not be archived.');
     }
   };
 
@@ -349,6 +349,47 @@ test('it does not archive task when not hovering and pressing C key', function(a
 
   page.triggerKeyDown('KeyC');
   assert.ok(true);
+});
+
+test('it does not archive task when assigning a user and pressing C key', function(assert) {
+  assert.expect(2);
+
+  let user = { id: 'user', username: 'testuser1' };
+  let users = [user];
+
+  stubService(this, 'task-assignment', {
+    isAssignedTo() {
+      return RSVP.resolve(false);
+    }
+  });
+
+  let task = {
+    archived: false,
+    isLoading: false,
+    save() {
+      return this;
+    },
+    then() {
+      assert.ok(true, 'Task is only archived once.');
+    }
+  };
+
+  setProperties(this, { task, users });
+  this.register('ability:task', Ability.extend({ canArchive: true, canAssign: true }));
+  set(this, 'keyboardActivated', true); // manually activate the keyboard
+
+  renderPage();
+
+  // Hover, open the dropdown, press C key
+  page.mouseenter();
+  page.taskAssignment.select.trigger.open();
+  page.triggerKeyDown('KeyC');
+
+  // Close the dropdown, press C key
+  page.taskAssignment.select.trigger.close();
+  page.triggerKeyDown('KeyC');
+
+  assert.notOk(page.taskAssignment.select.trigger.activeElement, 'The trigger does not have focus after closing');
 });
 
 test('it does not archive task when left hovering and pressing C key', function(assert) {

--- a/tests/pages/components/power-select.js
+++ b/tests/pages/components/power-select.js
@@ -20,6 +20,9 @@ export default {
   dropdown: {
     resetScope: true,
     testContainer: '.ember-power-select-dropdown',
+    input: {
+      scope: 'input'
+    },
     options: collection({
       itemScope: '.ember-power-select-option',
       item: {
@@ -43,6 +46,7 @@ export default {
         return !this.unassigned;
       }
     },
+    close: clickTrigger,
     open: clickTrigger,
     unassigned: {
       isDescriptor: true,

--- a/tests/unit/components/power-select/before-task-options-test.js
+++ b/tests/unit/components/power-select/before-task-options-test.js
@@ -6,7 +6,8 @@ moduleForComponent(
   'power-select/before-task-options',
   'Unit | Component | power select before task options',
   {
-    unit: true
+    unit: true,
+    needs: ['service:keyboard']
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3454,11 +3454,11 @@ ember-k-codemod@^0.1.0:
     glob "^7.1.1"
     jscodeshift "^0.3.29"
 
-ember-keyboard@^2.1.9:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-2.2.0.tgz#2632fec5c13dd01be0f74d626a2fd71de65f3294"
+ember-keyboard@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-2.3.0.tgz#6a210ccfc3ad8ca19e73cbef291ed2a0afd08ad0"
   dependencies:
-    ember-cli-babel "^6.3.0"
+    ember-cli-babel "^6.8.2"
 
 ember-link-action@^0.0.36:
   version "0.0.36"


### PR DESCRIPTION
# What's in this PR?

Fixes issues with task assignment filtering and also blurs the trigger when the dropdown is closed to prevent it from acting like a native `select` with focus.

## References
Fixes #1443 
Fixes #1524 