### PR TITLE
Improve task status and page

### DIFF
--- a/app/styles/components/task-status.scss
+++ b/app/styles/components/task-status.scss
@@ -10,27 +10,17 @@
   float: left;
   padding: 5px 8px;
 
-  &:before {
-    content: "";
-    display: inline-block;
-    margin: 0 8px -4px 0;
-    height: 20px;
-    width: 20px;
+  .fa {
+    font-size: 18px;
+    padding-right: 2px;
+    vertical-align: text-bottom;
   }
 
   &.closed {
     background: $red;
-
-    &:before {
-      @include sprite($closed-white);
-    }
   }
 
   &.open {
     background: $blue;
-
-    &:before {
-      @include sprite($open-white);
-    }
   }
 }

--- a/app/styles/templates/project/tasks/task.scss
+++ b/app/styles/templates/project/tasks/task.scss
@@ -4,7 +4,7 @@
 }
 
 .task-timeline {
-  @include span-columns(9);
+  @include span-columns(8);
   margin-top: 10px;
   position: relative;
 
@@ -22,7 +22,7 @@
 }
 
 .task-sidebar {
-  @include span-columns(3);
+  @include span-columns(4);
 }
 
 .task-sidebar-section {

--- a/app/templates/components/github/issue-link.hbs
+++ b/app/templates/components/github/issue-link.hbs
@@ -5,7 +5,7 @@
         {{svg/sprite-icon icon="github-48"}}
       </span>
       <span class="github__issue-link__text">
-        <span class="github__issue-link__repo-name" data-test-repo-name>{{githubRepo.name}}</span>
+        <span class="github__issue-link__repo-name" data-test-repo-name>{{githubRepo.githubAccountLogin}}/{{githubRepo.name}}</span>
         <span class="github__issue-link__issue-number" data-test-issue-number>#{{githubIssue.number}}</span>
       </span>
     {{else if (eq size "small")}}

--- a/app/templates/components/task-status.hbs
+++ b/app/templates/components/task-status.hbs
@@ -1,1 +1,9 @@
-<div class="task-status {{status}}">{{capitalize status}}</div>
+<div class="task-status {{status}}">
+  {{#if (eq status "open")}}
+    {{fa-icon data-test-open-icon "circle-o"}}
+  {{/if}}
+  {{#if (eq status "closed")}}
+    {{fa-icon data-test-closed-icon "times-circle"}}
+  {{/if}}
+  {{capitalize status}}
+</div>

--- a/tests/integration/components/github/issue-link-test.js
+++ b/tests/integration/components/github/issue-link-test.js
@@ -48,7 +48,7 @@ test('it renders with text and no tooltip when large', function(assert) {
 
   renderPage();
 
-  assert.equal(page.repoName.text, 'code-corps-ember', 'The repo name renders.');
+  assert.equal(page.repoName.text, 'code-corps/code-corps-ember', 'The full repo name renders.');
   assert.equal(page.issueNumber.text, '#123', 'The issue number renders.');
   assert.notOk(page.isTooltipTarget, 'There is no tooltip.');
 });

--- a/tests/integration/components/task-status-test.js
+++ b/tests/integration/components/task-status-test.js
@@ -16,23 +16,25 @@ moduleForComponent('task-status', 'Integration | Component | task status', {
 });
 
 test('it renders closed status', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   let task = { status: 'closed' };
   this.set('task', task);
   page.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isClosed);
+  assert.ok(page.iconClosed.isVisible);
   assert.equal(page.statusText, 'Closed');
 });
 
 test('it renders open status', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   let task = { status: 'open' };
   this.set('task', task);
   page.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isOpen);
+  assert.ok(page.iconOpen.isVisible);
   assert.equal(page.statusText, 'Open');
 });

--- a/tests/pages/components/task-status.js
+++ b/tests/pages/components/task-status.js
@@ -6,6 +6,14 @@ import {
 export default {
   scope: '.task-status',
 
+  iconClosed: {
+    scope: '[data-test-closed-icon]'
+  },
+
+  iconOpen: {
+    scope: '[data-test-open-icon]'
+  },
+
   isClosed: hasClass('closed'),
   isOpen: hasClass('open'),
   statusText: text()


### PR DESCRIPTION
# What's in this PR?

- Uses `fa-icon` in the task status
- Makes the task page a better width
- Improves `issue-link`