### PR TITLE
Add organizations/new

### DIFF
--- a/app/components/image-drop.js
+++ b/app/components/image-drop.js
@@ -21,7 +21,7 @@ export default Component.extend({
     'active:image-drop--active',
     'circle:image-drop--circle',
     'isDraggingOnApp:image-drop--drag',
-    'hasImage',
+    'hasImage:has-image',
     'large:is-large'
   ],
   droppedImage: null,

--- a/app/components/project-skill-item.js
+++ b/app/components/project-skill-item.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { getProperties } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['skill', 'has-spinner', 'default', 'small'],
+  classNames: ['skill', 'has-spinner', 'small'],
   tagName: 'button',
 
   click() {

--- a/app/components/skill-button.js
+++ b/app/components/skill-button.js
@@ -5,7 +5,7 @@ import { set, get, computed } from '@ember/object';
 export default Component.extend({
   alwaysShowX: false,
   attributeBindings: ['isLoading:disabled'],
-  classNames: ['default', 'has-spinner', 'skill'],
+  classNames: ['has-spinner', 'skill'],
   classNameBindings: ['isHovering:can-delete', 'size', 'type'],
   hasCheck: false,
   iconAfter: not('iconBefore'),

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -1,0 +1,105 @@
+import Controller from '@ember/controller';
+import {
+  computed, get, observer, set, setProperties
+} from '@ember/object';
+import { not } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import { isPresent } from '@ember/utils';
+import { isNonValidationError } from 'code-corps-ember/utils/error-utils';
+
+const ALREADY_FULFILLED = 'An organization has already been created with this invite code.';
+const NOT_FOUND = 'We couldn\'t find an invite code matching the one you provided.';
+
+export default Controller.extend({
+  flashMessages: service(),
+  loadingBar: service(),
+  store: service(),
+
+  inviteError: null,
+  organization: null,
+  organizationInvite: null,
+
+  isInvalid: not('isValid'),
+
+  isValid: computed('organizationInvite', function() {
+    let invite = get(this, 'organizationInvite');
+    if (!invite) {
+      set(this, 'inviteError', NOT_FOUND);
+      return false;
+    }
+    let hasOrganization = isPresent(get(invite, 'organization.id'));
+    if (hasOrganization) {
+      set(this, 'inviteError', ALREADY_FULFILLED);
+      return false;
+    } else {
+      return true;
+    }
+  }),
+
+  organizationInviteChanged: observer('organizationInvite', function() {
+    let organizationInvite = get(this, 'organizationInvite');
+    if (organizationInvite) {
+      let organization = get(this, 'organization');
+      let name = get(organizationInvite, 'organizationName');
+      let inviteCode = get(this, 'code');
+      setProperties(organization, { name, inviteCode });
+    }
+  }),
+
+  organizationNameChanged: observer('organization.name', function() {
+    let organization = get(this, 'organization');
+    if (organization) {
+      let name = get(organization, 'name');
+      let slug = name ? name.dasherize() : '';
+      set(organization, 'slug', slug);
+    }
+  }),
+
+  uploadDone(cloudinaryPublicId) {
+    let organization = get(this, 'organization');
+    set(organization, 'cloudinaryPublicId', cloudinaryPublicId);
+    this._stopLoadingBar();
+  },
+
+  uploadErrored() {
+    this._stopLoadingBar();
+    get(this, 'flashMessages').clearMessages().danger('Upload failed');
+  },
+
+  uploadStarted() {
+    this._startLoadingBar();
+  },
+
+  actions: {
+    save() {
+      let organization = get(this, 'organization');
+
+      let onCreated = (organization) => {
+        get(this, 'flashMessages').clearMessages().success('Organization created successfully');
+        // TODO: Need a projects.new route to transition to
+        this.transitionToRoute(
+          'slugged-route',
+          { slugged_route_slug: get(organization, 'slug') }
+        );
+      };
+
+      let onFailedSave = (payload) => {
+        if (isNonValidationError(payload)) {
+          // TODO: Just a temporary handler. We should parse specific messages instead
+          let { message } = payload;
+          get(this, 'flashMessages').clearMessages().danger(message);
+        }
+      };
+
+      organization.save().then(onCreated).catch(onFailedSave);
+    }
+  },
+
+  _startLoadingBar() {
+    get(this, 'loadingBar').start();
+  },
+
+  _stopLoadingBar() {
+    get(this, 'loadingBar').stop();
+  }
+});

--- a/app/models/organization-invite.js
+++ b/app/models/organization-invite.js
@@ -1,0 +1,9 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { belongsTo } from 'ember-data/relationships';
+
+export default Model.extend({
+  organizationName: attr(),
+
+  organization: belongsTo('organization', { async: true })
+});

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -7,6 +7,8 @@ export default Model.extend({
   description: attr(),
   iconLargeUrl: attr(),
   iconThumbUrl: attr(),
+  // virtual, used to create the organization via invite
+  inviteCode: attr(),
   name: attr(),
   slug: attr(),
 

--- a/app/router.js
+++ b/app/router.js
@@ -45,6 +45,7 @@ Router.map(function() {
   });
 
   this.route('organizations', function() {
+    this.route('new');
     this.route('slugged-route', {
       path: '/:slugged_route_slug'
     }, function() {

--- a/app/routes/organizations/new.js
+++ b/app/routes/organizations/new.js
@@ -1,0 +1,75 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
+import { isPresent } from '@ember/utils';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { resolve } from 'rsvp';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  currentUser: service(),
+  flashMessages: service(),
+
+  queryParams: { code: 'code' },
+
+  async beforeModel(transition) {
+    if (get(this, 'session.isAuthenticated')) {
+      let invite = await this._loadInvite(transition);
+      // Pass data along into the `model` hook
+      return set(transition, 'data', { organizationInvite: invite });
+    } else {
+      // call `beforeModel` in `AuthenticatedRouteMixin`
+      return this._super(transition);
+    }
+  },
+
+  async model({ code }, transition) {
+    let organizationInvite = get(transition, 'data.organizationInvite');
+    if (isPresent(organizationInvite)) {
+      let organization = await this._initOrganization(organizationInvite, code);
+      return { organization, organizationInvite };
+    } else {
+      return { organization: null, organizationInvite: null };
+    }
+  },
+
+  setupController(controller, { organization, organizationInvite }) {
+    controller.set('organization', organization);
+    controller.set('organizationInvite', organizationInvite);
+  },
+
+  async _loadInvite(transition) {
+    let { queryParams: { code } } = transition;
+    if (code) {
+      let invites = await get(this, 'store').query('organization-invite', { code });
+      return get(invites, 'firstObject');
+    } else {
+      return resolve(null);
+    }
+  },
+
+  async _initOrganization(organizationInvite, inviteCode) {
+    let name = get(organizationInvite, 'name');
+    let owner = await get(this, 'currentUser.user');
+    return get(this, 'store').createRecord('organization', { name, owner, inviteCode });
+  },
+
+  actions: {
+    willTransition(transition) {
+      let organization = get(this, 'controller.organization');
+      let inviteError = get(this, 'controller.inviteError');
+      // prompt to confirm if the user did not save
+      if (!isPresent(inviteError) && get(organization, ('isNew'))) {
+        let confirmed = window.confirm('You will lose any unsaved information if you leave this page. Are you sure?');
+        if (confirmed) {
+          organization.destroyRecord();
+        } else {
+          transition.abort();
+        }
+      }
+    },
+
+    verifyInvite() {
+      this.refresh();
+    }
+  }
+});

--- a/app/styles/_buttons.scss
+++ b/app/styles/_buttons.scss
@@ -37,6 +37,8 @@
 }
 
 #{$all-buttons}, .button {
+  background: $gray--light;
+  border-color: $gray--light;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
@@ -68,7 +70,6 @@
   }
 
   &.normal {
-    background: $gray--light;
     &.skill {
       font-size: $body-font-size-normal;
       padding: 8px 11px;
@@ -267,9 +268,10 @@
   }
 
   &.can-delete {
-    transition: background 0s ease-in;
     background: $red;
     border: 1px solid $red;
+    color: white;
+    transition: background 0s ease-in;
   }
 
   &:disabled, &.disabled {

--- a/app/styles/components/image-drop.scss
+++ b/app/styles/components/image-drop.scss
@@ -34,6 +34,12 @@
   background-repeat: no-repeat;
   position: relative;
 
+  @include outside-border(2px, solid, transparent);
+
+  &:not(.has-image) {
+    background: $gray--light;
+  }
+
   &.is-large {
     $size: 200px;
     height: $size;
@@ -47,6 +53,12 @@
 
   .hover {
     border-radius: 5px;
+    color: white;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 2;
+  }
+
+  .hover, .text {
     display: none;
     position: absolute;
     top: 0;
@@ -54,9 +66,6 @@
     left: 0;
     right: 0;
     padding: 5px;
-    color: white;
-    background: rgba(0, 0, 0, 0.6);
-    z-index: 2;
 
     p {
       &:before {
@@ -74,6 +83,11 @@
       text-align: center;
       width: 100%;
     }
+  }
+
+  &:not(.image-drop--active) .text {
+    align-items: center;
+    display: flex;
   }
 
   &--circle {
@@ -120,37 +134,19 @@
     &.image-drop--circle {
       @include outside-border(2px, solid, $blue--dark, $border-radius);
     }
+  }
 
-    .hover {
-      display: flex;
-      align-items: center;
-    }
+  &:hover:not(.image-drop--active):not(.image-drop--drag) .hover {
+    align-items: center;
+    display: flex;
   }
 }
 
 .image-drop p {
   color: #a9a9a9;
   display: none;
-  width: 80%;
   text-align: center;
-}
-
-.image-drop p.help-text {
-  font-size: $body-font-size-normal;
-  line-height: 22px;
-  margin: 0 auto;
-}
-
-.image-drop .text {
-  width: 100%;
-  position: absolute;
-  top: 50%;
-
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-
+  width: 80%;
 }
 
 .image-drop input[type=file] {

--- a/app/styles/layout/_footer.scss
+++ b/app/styles/layout/_footer.scss
@@ -1,5 +1,6 @@
 .site-footer {
-  padding: 2em 0 1em 0;
+  padding: 2em 0 1em 0 !important;
+
   h4 {
     margin: 7px 0;
     white-space: nowrap;

--- a/app/styles/layout/_forms.scss
+++ b/app/styles/layout/_forms.scss
@@ -75,6 +75,10 @@ $outer-border-radius: 4px;
     text-align: center;
   }
 
+  &--hidden:not(.has-error) {
+    display: none;
+  }
+
   .input-group {
     margin-bottom: 0;
   }
@@ -84,6 +88,14 @@ $outer-border-radius: 4px;
     float: left;
     max-width: 100%;
     width: 100%;
+
+    &.input-control {
+      max-width: 440px;
+
+      &--medium {
+        max-width: 300px;
+      }
+    }
 
     &:first-child {
       border-bottom-left-radius: $outer-border-radius;
@@ -134,6 +146,11 @@ $outer-border-radius: 4px;
       left: 8px;
     }
   }
+}
+
+.input-group.has-error {
+  input { border-color: $red; }
+  .input-label label { color: $red; }
 }
 
 .input-label {
@@ -218,6 +235,18 @@ textarea {
   min-height: 100px;
 }
 
+.input-explain {
+  margin: 0.5em 0 1em 0;
+
+  p {
+    color: $gray--dark !important;
+    font-size: $body-font-size-small !important;
+    font-weight: 500;
+    margin: 0 0 5px 0;
+    width: 100%;
+  }
+}
+
 form {
   h2 {
     font-family: $body-font-family;
@@ -230,6 +259,14 @@ form {
 .error {
   color: $red;
   margin: 1em 0;
+}
+
+p.input-error {
+  color: $red !important;
+  float: left;
+  font-size: $body-font-size-small !important;
+  margin: 0.5em 0;
+  width: 100%;
 }
 
 .login-form, .signup-form, .reset-password-form, .forgot-password-form {
@@ -303,33 +340,6 @@ select {
   height: 41px;
   padding: 0 16px;
   cursor: pointer;
-}
-
-.task-type {
-  select {
-    border: none;
-    height: 34px;
-    width: 100px;
-
-    &:focus {
-      outline: none;
-    }
-
-    &.issue {
-      background: $red;
-      color: white;
-    }
-
-    &.task {
-      background: $blue;
-      color: white;
-    }
-
-    &.idea {
-      background: $yellow;
-      color: $text--dark;
-    }
-  }
 }
 
 .settings-form {

--- a/app/styles/templates/start/hello.scss
+++ b/app/styles/templates/start/hello.scss
@@ -42,10 +42,9 @@
   @include media($sm-screen) {
     width: 100%;
   }
-}
-
-.image-drop {
-  margin: 0 auto;
+  .image-drop {
+    margin: 0 auto;
+  }
 }
 
 .hello__column--name-input {

--- a/app/templates/components/error-wrapper.hbs
+++ b/app/templates/components/error-wrapper.hbs
@@ -5,7 +5,7 @@
       <h1>404 Error</h1>
       <p>We can't find the page you're looking for.</p>
       <p>
-        {{#link-to 'index' class="button on-solid warning"}}Go Home{{/link-to}}
+        {{#link-to 'index' class="button on-solid warning"}}Go home{{/link-to}}
       </p>
     {{else if is503}}
       <div class="maintenance-icon">{{fa-icon "gears"}}</div>
@@ -13,14 +13,14 @@
       <p>We're currently conducting maintenance.</p>
       <p>Please try again shortly.</p>
       <p>
-        {{#link-to 'index' class="button on-solid warning"}}Go Home{{/link-to}}
+        {{#link-to 'index' class="button on-solid warning"}}Go home{{/link-to}}
       </p>
     {{else}}
       <div class="server-error-img"></div>
       <h1>Server Error</h1>
       <p>Something went wrong. Try again and if the problem persists, please report your problem and mention what caused it.</p>
       <p>
-        {{#link-to 'index' class="button on-solid danger"}}Go Home{{/link-to}}
+        {{#link-to 'index' class="button on-solid danger"}}Go home{{/link-to}}
       </p>
     {{/if}}
   </div>

--- a/app/templates/components/image-drop.hbs
+++ b/app/templates/components/image-drop.hbs
@@ -2,15 +2,9 @@
 <div class="hover">
   <p>{{hoverText}}</p>
 </div>
-<div class="text">
-  <p class="help-text">{{helpText}}</p>
-</div>
+{{#if (and helpText (not hasImage))}}
+  <div class="text">
+    <p class="help-text">{{helpText}}</p>
+  </div>
+{{/if}}
 <input type="file" onchange={{action filesDidChange value="target.files"}}>
-{{!-- {{image-upload
-  fileInputChange=(action fileInputChange)
-  files=files
-  uploadStarted=(action onUploadStarted)
-  uploadProgress=(action onUploadProgress)
-  uploadDone=(action onUploadDone)
-  uploadError=(action onUploadError)
-}} --}}

--- a/app/templates/components/organization-settings-form.hbs
+++ b/app/templates/components/organization-settings-form.hbs
@@ -30,6 +30,6 @@
   </div>
 
   <div class="input-group">
-    <button class="save default" {{action 'save'}}>Update Settings</button>
+    <button class="save default" {{action 'save'}}>Update settings</button>
   </div>
 </div>

--- a/app/templates/components/project-join-modal.hbs
+++ b/app/templates/components/project-join-modal.hbs
@@ -20,7 +20,7 @@
       {{related-skills isClickable=true skills=skills}}
     </div>
     <div class="project-join-modal__button">
-      <button class="button default" {{action "joinProject" project}}>Request to Join</button>
+      <button class="button default" {{action "joinProject" project}}>Request to join</button>
     </div>
   {{/modal-dialog}}
 {{/if}}

--- a/app/templates/components/project-settings-form.hbs
+++ b/app/templates/components/project-settings-form.hbs
@@ -38,6 +38,6 @@
   </div>
 
   <div class="input-group">
-    <button class="save default" {{action 'save'}}>Update Settings</button>
+    <button class="save default" {{action 'save'}}>Update settings</button>
   </div>
 </div>

--- a/app/templates/components/task-title.hbs
+++ b/app/templates/components/task-title.hbs
@@ -11,7 +11,7 @@
   <h2 class="title">{{task.title}} <span class="task-number">#{{task.number}}</span></h2>
   {{#if canEdit}}
   <div class="title-actions">
-    <button class="clear right edit" {{action 'edit'}}>Edit Title</button>
+    <button class="clear right edit" {{action 'edit'}}>Edit title</button>
   </div>
   {{/if}}
 {{/if}}

--- a/app/templates/components/user-settings-form.hbs
+++ b/app/templates/components/user-settings-form.hbs
@@ -57,6 +57,6 @@
   </div>
 
   <div class="input-group">
-    <button class="default save" {{action 'save'}}>Update Profile</button>
+    <button class="default save" {{action 'save'}}>Update profile</button>
   </div>
 </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -5,7 +5,7 @@
       <h2>Build a better future.</h2>
       <h3>Contribute to software projects for {{typed-string strings=typedStrings typeSpeed=70 backDelay=1500 loop=true loopCount=false}}</h3>
       <div class="icons-header"></div>
-      {{#link-to "signup" class="button default large"}}Start Helping{{/link-to}}
+      {{#link-to "signup" class="button default large"}}Start helping{{/link-to}}
     </div>
 
     <div class="landing-section">

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -1,0 +1,119 @@
+<div class="container">
+  <h2>Let's get started</h2>
+
+  <div class="panel {{if isValid "panel--highlighted-green" "panel--highlighted"}}">
+    <section>
+      <aside>
+        {{#if isValid}}
+          <h3>{{fa-icon "check-circle"}} Your invite's verified!</h3>
+          <p>Your invite code looks good: <strong>{{code}}</strong></p>
+        {{else}}
+          <h3>{{fa-icon "lock"}} Verify your invite</h3>
+          <p>Check the short code you got in your email.</p>
+        {{/if}}
+      </aside>
+
+      {{#if isInvalid}}
+        <section data-test-invite-code-form>
+          <div class="input-group has-error">
+            <div class="input-label">
+              <label for="slug">
+                <span class="input-label__text">Invite code</span>
+              </label>
+            </div>
+            <div class="input-explain">
+              <p>The invite code you got in your email.</p>
+            </div>
+            {{input class="input-control input-control--medium" type="text" name="code" value=code}}
+            {{#if inviteError}}
+              <p class="input-error">{{inviteError}}</p>
+            {{/if}}
+          </div>
+
+          <div class="input-group">
+            <button class="save default" {{action 'verifyInvite'}} data-test-submit>Verify invite</button>
+          </div>
+        </section>
+      {{/if}}
+    </section>
+  </div>
+
+  <div class="panel">
+    <section>
+      <aside>
+        <h3>{{fa-icon "address-card"}} Create your organization</h3>
+        <p>Organizations allow you to host multiple projects on Code Corps.</p>
+      </aside>
+
+      {{#if isValid}}
+        <section data-test-organization-form>
+          <div class="input-group {{if organization.errors.cloudinaryPublicId "has-error"}}">
+            {{image-drop
+              helpText="Upload your logo."
+              hoverText="Upload your logo."
+              large=true
+              onDone=(action uploadDone)
+              onError=(action uploadErrored)
+              onStart=(action uploadStarted)
+              originalImage=organization.iconLargeUrl
+            }}
+            {{#each organization.errors.cloudinaryPublicId as |error|}}
+              <p class="input-error">{{error.message}}</p>
+            {{/each}}
+          </div>
+
+          <div class="input-group {{if organization.errors.name "has-error"}}">
+            <div class="input-label">
+              <label for="name">
+                <span class="input-label__text">Organization name</span>
+              </label>
+            </div>
+            <div class="input-explain">
+              <p>Your organization's name on Code Corps.</p>
+              <p>If you only plan to create a single project, just use your project name here.</p>
+            </div>
+            {{input class="input-control input-control--medium" type="text" name="name" value=organization.name}}
+            {{#each organization.errors.name as |error|}}
+              <p class="input-error">{{error.message}}</p>
+            {{/each}}
+          </div>
+
+          <div class="input-group {{if organization.errors.slug "has-error"}}">
+            <div class="input-label">
+              <label for="slug">
+                <span class="input-label__text">Vanity URL</span>
+              </label>
+            </div>
+            <div class="input-explain">
+              <p>Your organization's page at https://codecorps.org/<strong>{{organization.slug}}</strong>.</p>
+            </div>
+            {{input class="input-control input-control--medium" type="text" name="slug" value=organization.slug}}
+            {{#each organization.errors.slug as |error|}}
+              <p class="input-error">{{error.message}}</p>
+              <p class="input-error">If your URL is already taken, you can change your organization name or just change the slug from <strong>{{organization.slug}}</strong> to something else.</p>
+            {{/each}}
+          </div>
+
+          <div class="input-group {{if organization.errors.description "has-error"}}">
+            <div class="input-label">
+              <label for="description">
+                <span class="input-label__text">Description</span>
+              </label>
+            </div>
+            <div class="input-explain">
+              <p>What your organization does in a few words.</p>
+            </div>
+            {{textarea class="input-control" type="text" name="description" value=organization.description}}
+            {{#each organization.errors.description as |error|}}
+              <p class="input-error">{{error.message}}</p>
+            {{/each}}
+          </div>
+
+          <div class="input-group">
+            <button class="save default" {{action 'save'}} data-test-submit>Create organization</button>
+          </div>
+        </section>
+      {{/if}}
+    </section>
+  </div>
+</div>

--- a/app/templates/start/skills.hbs
+++ b/app/templates/start/skills.hbs
@@ -7,6 +7,7 @@
   <div data-test-user-skills-list class="skills__list skills__list--main">
     {{#each userSkills as |userSkill|}}
       {{skill-button
+        class="default"
         hasCheck=true
         isLoading=userSkill.isLoading
         remove=(action removeUserSkill userSkill)
@@ -40,5 +41,5 @@
 
 <div class="start__footer">
   <p>Finished adding your skills?</p>
-  <button class="{{if userSkills.isEmpty "clear" "default"}}" disabled={{userSkills.isEmpty}} {{action 'continue'}}>Find Projects</button>
+  <button class="{{if userSkills.isEmpty "clear" "default"}}" disabled={{userSkills.isEmpty}} {{action 'continue'}}>Find projects</button>
 </div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -70,11 +70,12 @@ function generatePreviewMentions(schema, preview) {
 // The set of routes we have defined; needs updated when adding new routes
 const routes = [
   'categories', 'comment-user-mentions', 'comments', 'donation-goals',
-  'github-events', 'organizations', 'task-lists', 'task-skills',
-  'task-user-mentions', 'tasks', 'previews', 'projects', 'project-categories',
-  'slugged-routes', 'stripe-connect-accounts', 'stripe-connect-subscriptions',
-  'stripe-connect-plans', 'stripe-platform-cards', 'stripe-platform-customers',
-  'user-categories', 'users'
+  'github-events', 'organizations', 'organization-invites', 'task-lists',
+  'task-skills', 'task-user-mentions', 'tasks', 'previews', 'projects',
+  'project-categories', 'slugged-routes', 'stripe-connect-accounts',
+  'stripe-connect-subscriptions', 'stripe-connect-plans',
+  'stripe-platform-cards', 'stripe-platform-customers', 'user-categories',
+  'users'
 ];
 
 export default function() {
@@ -239,6 +240,20 @@ export default function() {
   this.post('/organization-github-app-installations');
   this.get('/organization-github-app-installations/:id');
   this.delete('/organization-github-app-installations/:id');
+
+  /**
+  * Organization Github App Installations
+  */
+
+  this.get('/organization-invites', function(schema, request) {
+    let { queryParams } = request;
+    let { code } = queryParams;
+    if (code) {
+      return schema.organizationInvites.where({ code });
+    } else {
+      return schema.organizationInvites.all();
+    }
+  });
 
   /**
   * Password

--- a/mirage/models/organization-invite.js
+++ b/mirage/models/organization-invite.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  organization: belongsTo()
+});

--- a/tests/acceptance/organization-creation-test.js
+++ b/tests/acceptance/organization-creation-test.js
@@ -1,0 +1,268 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'code-corps-ember/tests/helpers/module-for-acceptance';
+import { authenticateSession } from 'code-corps-ember/tests/helpers/ember-simple-auth';
+import Mirage from 'ember-cli-mirage';
+import sinon from 'sinon';
+import loginPage from 'code-corps-ember/tests/pages/login';
+import page from 'code-corps-ember/tests/pages/organizations/new';
+
+moduleForAcceptance('Acceptance | Organization Creation');
+
+test('Creating an organization requires logging in', function(assert) {
+  assert.expect(2);
+
+  let { code } = server.create('organization-invite', { code: 'valid' });
+
+  page.visit({ code });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'login', 'Got redirected to login');
+
+    let email = 'test@test.com';
+    let password = 'password';
+    server.create('user', { email, password });
+
+    loginPage.form.loginSuccessfully(email, password);
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), `/organizations/new?code=${code}`);
+  });
+});
+
+test('If the code is not provided, the user is allowed to type it in', function(assert) {
+  assert.expect(5);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let code = 'valid';
+  server.create('organization-invite', { code });
+
+  page.visit();
+
+  andThen(() => {
+    assert.ok(page.inviteCodeForm.isVisible, 'Invite code form ui is rendered');
+    assert.notOk(page.organizationForm.isVisible, 'Organization form is not rendered');
+    page.inviteCodeForm.inputCode('valid').clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'organizations.new', 'User is back on the same page');
+    assert.notOk(page.inviteCodeForm.isVisible, 'Invite form is no longer rendered');
+    assert.ok(page.organizationForm.isVisible, 'Organization form is rendered');
+  });
+});
+
+test('If the code has already been used, the user is allowed to type in another one', function(assert) {
+  assert.expect(5);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let organization = server.create('organization');
+  server.create('organization-invite', { code: 'used', organization });
+  server.create('organization-invite', { code: 'valid' });
+
+  page.visit({ code: 'used' });
+
+  andThen(() => {
+    assert.ok(page.inviteCodeForm.isVisible, 'Invite code form ui is rendered');
+    assert.notOk(page.organizationForm.isVisible, 'Organization form is not rendered');
+    page.inviteCodeForm.inputCode('valid').clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'organizations.new', 'User is back on the same page');
+    assert.notOk(page.inviteCodeForm.isVisible, 'Invite form is no longer rendered');
+    assert.ok(page.organizationForm.isVisible, 'Organization form is rendered');
+  });
+});
+
+test('If the code is invalid, the user is allowed to type in another one', function(assert) {
+  assert.expect(5);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let code = 'valid';
+  server.create('organization-invite', { code });
+
+  page.visit({ code: 'invalid' });
+
+  andThen(() => {
+    assert.ok(page.inviteCodeForm.isVisible, 'Invite code form ui is rendered');
+    assert.notOk(page.organizationForm.isVisible, 'Organization form is not rendered');
+    page.inviteCodeForm.inputCode('valid').clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'organizations.new', 'User is back on the same page');
+    assert.notOk(page.inviteCodeForm.isVisible, 'Invite form is no longer rendered');
+    assert.ok(page.organizationForm.isVisible, 'Organization form is rendered');
+  });
+});
+
+test('Creating an organization can fail with validation errors', function(assert) {
+  assert.expect(1);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let code = 'valid';
+  server.create('organization-invite', { code });
+  page.visit({ code });
+
+  andThen(() => {
+    let saveDone = assert.async();
+    server.post('/organizations', function() {
+      saveDone();
+
+      return new Mirage.Response(422, {}, {
+        errors: [
+          {
+            source: { pointer: 'data/attributes/cloudinary-public-id' },
+            detail: "can't be blank",
+            status: 422
+          },
+          {
+            source: { pointer: 'data/attributes/description' },
+            detail: "can't be blank",
+            status: 422
+          },
+          {
+            source: { pointer: 'data/attributes/name' },
+            detail: "can't be blank",
+            status: 422
+          },
+          {
+            source: { pointer: 'data/attributes/slug' },
+            detail: "can't be blank",
+            status: 422
+          }
+        ]
+      });
+    });
+  });
+
+  andThen(() => {
+    page.organizationForm.clickSubmit();
+  });
+
+  andThen(() => assert.equal(page.organizationForm.errors().count, 4));
+});
+
+test('Creating an organization can fail with an unknown error', function(assert) {
+  assert.expect(1);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let code = 'valid';
+  server.create('organization-invite', { code });
+  page.visit({ code });
+
+  andThen(() => {
+    let saveDone = assert.async();
+    server.post('/organizations', function() {
+      saveDone();
+
+      return new Mirage.Response(500, {}, {
+        errors: [
+          {
+            title: '500 Internal Server Error',
+            detail: '500 Internal Server Error',
+            status: 500
+          }
+        ]
+      });
+    });
+  });
+
+  andThen(() => {
+    page.organizationForm.clickSubmit();
+  });
+
+  andThen(() => assert.equal(page.flashMessages().count, 1, 'A flash was displayed'));
+});
+
+test('A user with a valid invite can create an organization', function(assert) {
+  assert.expect(5);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let droppedImageString = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+  let code = 'valid';
+  let organizationName = 'Foo';
+  server.create('organization-invite', { code, organizationName });
+  page.visit({ code });
+
+  andThen(() => {
+    assert.equal(page.organizationForm.name, organizationName, 'Organization name was prefiled');
+    page.organizationForm.imageDrop.dropZone.dropFile(droppedImageString);
+    assert.equal(page.organizationForm.imageDrop.dropZone.backgroundImageData(), `url(${droppedImageString})`, 'Image dropped successfully');
+    page.organizationForm
+      .inputName('Bar')
+      .inputDescription('Baz')
+      .clickSubmit();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'slugged-route', 'User was redirected correctly');
+    let organization = server.schema.organizations.findBy({ name: 'Bar', description: 'Baz' });
+    assert.ok(organization, 'Organization was created.');
+    assert.ok(organization.cloudinaryPublicId, 'Organization has image.');
+  });
+});
+
+test('Navigation is successful if user answers positively to prompt', function(assert) {
+  assert.expect(2);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let code = 'valid';
+  server.create('organization-invite', { code });
+  page.visit({ code });
+
+  let stub = sinon.stub(window, 'confirm').callsFake(() => {
+    assert.ok(true, 'Confirmation prompt was called.');
+    return true;
+  });
+
+  andThen(() => {
+    page.navigationMenu.projectsLink.click();
+  });
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'projects-list', 'Navigation was successful.');
+    stub.restore();
+  });
+});
+
+test('Navigation is aborted if user answers negatively to prompt', function(assert) {
+  assert.expect(2);
+
+  let user = server.create('user');
+  authenticateSession(this.application, { user_id: user.id });
+
+  let code = 'valid';
+  server.create('organization-invite', { code });
+  page.visit({ code });
+
+  let stub = sinon.stub(window, 'confirm').callsFake(() => {
+    assert.ok(true, 'Confirmation prompt was called.');
+    return false;
+  });
+
+  andThen(() => {
+    page.navigationMenu.projectsLink.click();
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), `organizations/new?code=${code}`);
+    stub.restore();
+  });
+});

--- a/tests/acceptance/settings-profile-test.js
+++ b/tests/acceptance/settings-profile-test.js
@@ -76,13 +76,13 @@ test('it allows editing of users image', function(assert) {
   settingsProfilePage.visit();
 
   andThen(() => {
-    settingsProfilePage.userSettingsForm.imageDrop.dropFile(droppedImageString);
+    settingsProfilePage.userSettingsForm.imageDrop.dropZone.dropFile(droppedImageString);
   });
 
   andThen(() => {
     assert.ok(settingsProfilePage.successAlert.isVisible);
     assert.equal(settingsProfilePage.successAlert.message, 'Photo uploaded successfully');
-    assert.equal(settingsProfilePage.userSettingsForm.imageDrop.backgroundImageData(), `url(${droppedImageString})`);
+    assert.equal(settingsProfilePage.userSettingsForm.imageDrop.dropZone.backgroundImageData(), `url(${droppedImageString})`);
     done();
   });
 });

--- a/tests/integration/components/error-wrapper-test.js
+++ b/tests/integration/components/error-wrapper-test.js
@@ -30,7 +30,7 @@ test('it renders all required elements for the 404 case', function(assert) {
   assert.ok(page.has404Image, 'The 404 image renders');
   assert.equal(page.title, '404 Error', 'The title renders');
   assert.equal(page.body, "We can't find the page you're looking for.", 'The body renders');
-  assert.equal(page.button.text, 'Go Home', 'The button renders');
+  assert.equal(page.button.text, 'Go home', 'The button renders');
   assert.ok($('html').hasClass('warning'), 'The html element has the right class');
   assert.notEqual($('html').css('background-color'), 'rgba(0, 0, 0, 0)', 'The html element does not have a white background');
 });
@@ -50,7 +50,7 @@ test('it renders all required elements for the 503 case', function(assert) {
   assert.ok(page.hasMaintenanceIcon, 'The maintenance icon renders');
   assert.equal(page.title, 'Down for maintenance', 'The title renders');
   assert.equal(page.body, "We're currently conducting maintenance.", 'The body renders');
-  assert.equal(page.button.text, 'Go Home', 'The button renders');
+  assert.equal(page.button.text, 'Go home', 'The button renders');
   assert.ok($('html').hasClass('warning'), 'The html element has the right class');
   assert.notEqual($('html').css('background-color'), 'rgba(0, 0, 0, 0)', 'The html element does not have a white background');
 });
@@ -70,7 +70,7 @@ test('it renders all required elements for the general error case', function(ass
   assert.ok(page.hasServerErrorImage, 'The general error image renders');
   assert.equal(page.title, 'Server Error', 'The title renders');
   assert.equal(page.body, 'Something went wrong. Try again and if the problem persists, please report your problem and mention what caused it.', 'The body renders');
-  assert.equal(page.button.text, 'Go Home', 'The button renders');
+  assert.equal(page.button.text, 'Go home', 'The button renders');
   assert.ok($('html').hasClass('danger'), 'The html element has the right class');
   assert.notEqual($('html').css('background-color'), 'rgba(0, 0, 0, 0)', 'The html element does not have a white background');
 });

--- a/tests/pages/components/image-drop.js
+++ b/tests/pages/components/image-drop.js
@@ -1,13 +1,27 @@
 import {
+  findElement,
   hasClass
 } from 'ember-cli-page-object';
+
 import dragZone from 'code-corps-ember/tests/pages/components/drag-zone';
+import fillInFileInput from 'code-corps-ember/tests/helpers/fill-in-file-input';
+import removeDoubleQuotes from 'code-corps-ember/tests/helpers/remove-double-quotes';
 
 export default {
   dragZone,
 
   dropZone: {
     scope: '.image-drop',
+
+    backgroundImageData() {
+      let $el = findElement(this);
+      let backgroundImageData = $el.css('background-image');
+      return removeDoubleQuotes(backgroundImageData);
+    },
+
+    dropFile(content) {
+      fillInFileInput(`${this.scope} input[type=file]`, { name: 'file.png', content });
+    },
 
     isActive: hasClass('image-drop--active'),
     isCircle: hasClass('image-drop--circle'),

--- a/tests/pages/components/user-settings-form.js
+++ b/tests/pages/components/user-settings-form.js
@@ -1,13 +1,11 @@
 import {
   clickable,
   fillable,
-  findElement,
   isVisible,
   value
 } from 'ember-cli-page-object';
 
-import fillInFileInput from '../../helpers/fill-in-file-input';
-import removeDoubleQuotes from '../../helpers/remove-double-quotes';
+import imageDrop from 'code-corps-ember/tests/pages/components/image-drop';
 
 export default {
   scope: '.user-settings-form',
@@ -28,17 +26,5 @@ export default {
 
   clickSave: clickable('.save'),
 
-  imageDrop: {
-    scope: '.image-drop',
-
-    backgroundImageData() {
-      let $el = findElement(this);
-      let backgroundImageData = $el.css('background-image');
-      return removeDoubleQuotes(backgroundImageData);
-    },
-
-    dropFile(content) {
-      fillInFileInput(`${this.scope} input[type=file]`, { name: 'file.png', content });
-    }
-  }
+  imageDrop
 };

--- a/tests/pages/organizations/new.js
+++ b/tests/pages/organizations/new.js
@@ -1,0 +1,50 @@
+import {
+  clickable,
+  collection,
+  create,
+  fillable,
+  value,
+  visitable
+} from 'ember-cli-page-object';
+
+import imageDrop from 'code-corps-ember/tests/pages/components/image-drop';
+import navigationMenu from 'code-corps-ember/tests/pages/components/navigation-menu';
+
+export default create({
+  visit: visitable('organizations/new'),
+
+  flashMessages: collection({
+    itemScope: '.flash > div'
+  }),
+
+  inviteCodeForm: {
+    scope: '[data-test-invite-code-form]',
+
+    clickSubmit: clickable('[data-test-submit]'),
+
+    errors: collection({
+      itemScope: '.input-group.has-error'
+    }),
+
+    inputCode: fillable('[name=code]')
+  },
+
+  navigationMenu,
+
+  organizationForm: {
+    scope: '[data-test-organization-form]',
+
+    clickSubmit: clickable('[data-test-submit]'),
+
+    errors: collection({
+      itemScope: '.input-group.has-error'
+    }),
+
+    imageDrop,
+
+    inputDescription: fillable('[name=description]'),
+    inputName: fillable('[name=name]'),
+
+    name: value('[name=name]')
+  }
+});

--- a/tests/unit/models/organization-invite-test.js
+++ b/tests/unit/models/organization-invite-test.js
@@ -1,0 +1,16 @@
+import { moduleForModel, test } from 'ember-qunit';
+import { testForAttributes } from 'code-corps-ember/tests/helpers/attributes';
+import { testForBelongsTo } from 'code-corps-ember/tests/helpers/relationship';
+import 'code-corps-ember/tests/helpers/has-attributes';
+
+moduleForModel('organization-invite', 'Unit | Model | organization invite', {
+  needs: ['model:organization']
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  assert.ok(!!model);
+});
+
+testForAttributes('organizationInvite', ['organizationName']);
+testForBelongsTo('organizationInvite', 'organization');

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -22,6 +22,7 @@ testForAttributes('organization', [
   'description',
   'iconLargeUrl',
   'iconThumbUrl',
+  'inviteCode',
   'name',
   'slug'
 ]);


### PR DESCRIPTION
# What's in this PR?

This still a WIP.

Was doing a lot of styling work that I think is mostly there now. What remains is everything else. 😄 

- [x] Need `code` and `organization_name` as query parameters
- [x] Code is used to verify if we can create an organization (in `beforeModel`)
  - [x] we should validate code initially and redirect somewhere else if it fails
  - [x] we can prefill the form with the `organization_name` #1543
- [x] Submitting form hits create route on API
- [ ] Successful save redirects to `/org-slug/projects/new`

### Additional requirements

- [ ] use `ember-concurrency` for saving
- [x] failed saved due to validation errors shows those errors
- [x] failed save due to invalid token shows flash
- [x] needs some copy to make the onboarding friendlier
- [x] maybe needs copy emphasizing this is not project creation yet
- [x] native confirm dialog when trying to leave the page to prevent losing information (maybe we should add a mixin for this?)

### Required tests

- [x] acceptance test for token redirection 
- [x] acceptance test for successful save 
- [x] acceptance test for failed save due to validations
- [ ] acceptance test for failed save due to token

### Notes

- [ ] will require an API issue to implement the create route - code-corps/code-corps-api#1229

## References
Fixes #1542 
Fixes #1543 