### PR TITLE
Rewrite integration tests for user-dropdown component to use page objects

### DIFF
--- a/tests/integration/components/user-dropdown-test.js
+++ b/tests/integration/components/user-dropdown-test.js
@@ -7,11 +7,7 @@ import userDropdownComponent from 'code-corps-ember/tests/pages/component/user-d
 let page = PageObject.create(userDropdownComponent);
 
 function renderPage() {
-  page.render(hbs`
-{{user-dropdown
-  user=user
-  action='hide'
-   }}`);
+  page.render(hbs`{{user-dropdown user=user action='hide'}}`);
 }
 
 moduleForComponent('user-dropdown', 'Integration | Component | user dropdown', {

--- a/tests/integration/components/user-dropdown-test.js
+++ b/tests/integration/components/user-dropdown-test.js
@@ -2,7 +2,7 @@ import { computed } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import PageObject from 'ember-cli-page-object';
 import hbs from 'htmlbars-inline-precompile';
-import userDropdownComponent from 'code-corps-ember/tests/pages/components/user-dropdown';
+import userDropdownComponent from 'code-corps-ember/tests/pages/component/user-dropdown';
 
 let page = PageObject.create(userDropdownComponent);
 
@@ -15,7 +15,13 @@ function renderPage() {
 }
 
 moduleForComponent('user-dropdown', 'Integration | Component | user dropdown', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    page.setContext(this);
+  },
+  afterEach() {
+    page.removeContext();
+  }
 });
 
 const stubUser = {
@@ -38,7 +44,7 @@ test('it renders', function(assert) {
   this.set('user', stubUser);
   renderPage();
 
-  assert.equal(page.length, 1, 'The component renders');
+  assert.ok(page.isVisible, 'The component renders');
 });
 
 test('it triggers the hide action when clicked', function(assert) {

--- a/tests/integration/components/user-dropdown-test.js
+++ b/tests/integration/components/user-dropdown-test.js
@@ -1,7 +1,18 @@
 import { computed } from '@ember/object';
-import { run } from '@ember/runloop';
 import { moduleForComponent, test } from 'ember-qunit';
+import PageObject from 'ember-cli-page-object';
 import hbs from 'htmlbars-inline-precompile';
+import userDropdownComponent from 'code-corps-ember/tests/pages/components/user-dropdown';
+
+let page = PageObject.create(userDropdownComponent);
+
+function renderPage() {
+  page.render(hbs`
+{{user-dropdown
+  user=user
+  action='hide'
+   }}`);
+}
 
 moduleForComponent('user-dropdown', 'Integration | Component | user dropdown', {
   integration: true
@@ -23,10 +34,11 @@ const stubUser = {
 
 test('it renders', function(assert) {
   assert.expect(1);
-  this.set('user', stubUser);
-  this.render(hbs`{{user-dropdown user=user}}`);
 
-  assert.equal(this.$('.dropdown-menu').length, 1, 'The component renders');
+  this.set('user', stubUser);
+  renderPage();
+
+  assert.equal(page.length, 1, 'The component renders');
 });
 
 test('it triggers the hide action when clicked', function(assert) {
@@ -36,6 +48,8 @@ test('it triggers the hide action when clicked', function(assert) {
   this.on('hide', function() {
     assert.ok(true, 'It triggers the hide action when clicked');
   });
-  this.render(hbs`{{user-dropdown user=user action='hide'}}`);
-  run(() => this.$('.dropdown-menu').click());
+
+  renderPage();
+  page.click();
+
 });

--- a/tests/pages/component/user-dropdown.js
+++ b/tests/pages/component/user-dropdown.js
@@ -1,0 +1,11 @@
+import {
+  clickable,
+  hasClass
+} from 'ember-cli-page-object';
+
+export default {
+  scope: '.dropdown-menu',
+
+  clickDropdownMenu: clickable('.dropdown-menu'),
+  dropdownIsHidden: hasClass('menu-hidden')
+};


### PR DESCRIPTION
# What's in this PR?
- page object for user-dropdown
- rewritten integration test to include page object

## References
Fixes # 772

Progress on: #
