### PR TITLE
Update socket connection based on session state

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -10,9 +10,10 @@ import LoadingBar from 'code-corps-ember/mixins/loading-bar';
 export default Route.extend(ApplicationRouteMixin, LoadingBar, {
   currentUser: service(),
   flashMessages: service(),
+  i18n: service(),
   metrics: service(),
   onboarding: service(),
-  i18n: service(),
+  socket: service(),
 
   isOnboarding: alias('onboarding.isOnboarding'),
   onboardingRoute: alias('onboarding.routeForCurrentStep'),
@@ -158,6 +159,11 @@ export default Route.extend(ApplicationRouteMixin, LoadingBar, {
         }
       })
       .catch(() => this._invalidateSession());
+  },
+
+  model() {
+    get(this, 'socket').toggleConnection();
+    return this._super(...arguments);
   },
 
   afterModel() {

--- a/app/services/conversation-channel.js
+++ b/app/services/conversation-channel.js
@@ -1,39 +1,29 @@
-import PhoenixSocket from 'phoenix/services/phoenix-socket';
 import { get } from '@ember/object';
-import { inject as service } from '@ember/service';
-import ENV from 'code-corps-ember/config/environment';
+import Service, { inject as service } from '@ember/service';
 
-export default PhoenixSocket.extend({
-  session: service(),
+export default Service.extend({
+  socket: service(),
   store: service(),
 
-  connect() {
-    if (!get(this, 'socket')) { // Only create one socket at a time
-      let token = get(this, 'session.session.authenticated.token');
-      this._super(ENV.SOCKETS_BASE_URL, {
-        params: { token }
-      });
-    }
-  },
-
   async join(conversation) {
-    await this.connect();
+    let socket = get(this, 'socket');
+
+    await socket.connect();
+
     let id = get(conversation, 'id');
-    let channel = this.joinChannel(`conversation:${id}`);
+    let channel = socket.joinChannel(`conversation:${id}`);
 
     channel.on('new:conversation-part', () => this._onNewMessage(conversation));
   },
 
   leave(conversation) {
-    let socket = get(this, 'socket');
     let id = get(conversation, 'id');
-    let channel = socket.channel(`conversation:${id}`);
-    channel.leave();
+    return get(this, 'socket').leaveChannel(`conversation:${id}`);
   },
 
   _onNewMessage(conversation) {
     let store = get(this, 'store');
     let id = get(conversation, 'id');
-    store.findRecord('conversation', id);
+    return store.findRecord('conversation', id);
   }
 });

--- a/app/services/socket.js
+++ b/app/services/socket.js
@@ -1,0 +1,52 @@
+import PhoenixSocket from 'phoenix/services/phoenix-socket';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+import ENV from 'code-corps-ember/config/environment';
+
+export default PhoenixSocket.extend({
+  session: service(),
+
+  init() {
+    let session = get(this, 'session');
+    session.on('authenticationSucceeded', () => this.toggleConnection());
+    session.on('invalidationSucceeded', () => this.toggleConnection());
+  },
+
+  connect() {
+    let socket = get(this, 'socket');
+    let token = get(this, 'session.session.authenticated.token');
+    let params = token ? { token } : {};
+
+    // Only create a socket when:
+    // - no socket exists
+    // - we're exchanging an unauthenticated socket for an authenticated one
+    if (!socket) {
+      this._super(ENV.SOCKETS_BASE_URL, { params });
+    } else if (socket && token) {
+      this.disconnect(() => this._super(ENV.SOCKETS_BASE_URL, { params }));
+    }
+  },
+
+  disconnect(callback) {
+    let socket = get(this, 'socket');
+    if (socket) {
+      socket.disconnect(callback);
+    } else {
+      return callback && callback();
+    }
+  },
+
+  joinChannel(channelName) {
+    return this._super(channelName);
+  },
+
+  leaveChannel(channelName) {
+    let socket = get(this, 'socket');
+    let channel = socket.channel(channelName);
+    return channel.leave();
+  },
+
+  toggleConnection() {
+    this.disconnect(() => this.connect());
+  }
+});

--- a/tests/acceptance/project-conversations-test.js
+++ b/tests/acceptance/project-conversations-test.js
@@ -109,7 +109,7 @@ test('System is notified of new conversation part', function(assert) {
   andThen(() => {
     assert.equal(page.conversationThread.conversationParts().count, 1, 'No notification yet, so new part was not rendered.');
     let conversationChannelService = this.application.__container__.lookup('service:conversation-channel');
-    let socket = get(conversationChannelService, 'socket');
+    let socket = get(conversationChannelService, 'socket.socket');
     let [channel] = socket.channels;
     channel.trigger('new:conversation-part', {});
   });

--- a/tests/acceptance/user-conversations-test.js
+++ b/tests/acceptance/user-conversations-test.js
@@ -72,7 +72,7 @@ test('System is notified of new conversation part', function(assert) {
   andThen(() => {
     assert.equal(page.conversationThread.conversationParts().count, 1, 'No notification yet, so new part was not rendered.');
     let conversationChannelService = this.application.__container__.lookup('service:conversation-channel');
-    let socket = get(conversationChannelService, 'socket');
+    let socket = get(conversationChannelService, 'socket.socket');
     let [channel] = socket.channels;
     channel.trigger('new:conversation-part', {});
   });

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -11,7 +11,8 @@ moduleFor('route:application', 'Unit | Route | application', {
     'service:onboarding',
     'service:router-scroll',
     'service:scheduler',
-    'service:session'
+    'service:session',
+    'service:socket'
   ]
 });
 

--- a/tests/unit/routes/conversations/conversation-test.js
+++ b/tests/unit/routes/conversations/conversation-test.js
@@ -10,7 +10,8 @@ moduleFor('route:conversations/conversation', 'Unit | Route | conversations/conv
     'service:metrics',
     'service:router-scroll',
     'service:scheduler',
-    'service:session'
+    'service:session',
+    'service:socket'
   ]
 });
 

--- a/tests/unit/routes/project/conversations/conversation-test.js
+++ b/tests/unit/routes/project/conversations/conversation-test.js
@@ -10,7 +10,8 @@ moduleFor('route:project/conversations/conversation', 'Unit | Route | project/co
     'service:metrics',
     'service:router-scroll',
     'service:scheduler',
-    'service:session'
+    'service:session',
+    'service:socket'
   ]
 });
 

--- a/tests/unit/services/socket-test.js
+++ b/tests/unit/services/socket-test.js
@@ -1,10 +1,8 @@
 import { moduleFor, test } from 'ember-qunit';
 
-moduleFor('service:conversation-channel', 'Unit | Service | conversation channel', {
+moduleFor('service:socket', 'Unit | Service | socket', {
   // Specify the other units that are required for this test.
-  needs: [
-    'service:socket'
-  ]
+  needs: ['service:session']
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
# What's in this PR?

This binds the conversation channel service to session `authenticationSucceeded` and `invalidationSucceeded` events. 

The former is handled by calling `connect`, while the later is handled by calling disconnect.

I could not find an effective way to test for this, however.

## References

Progress on: #1597
