### PR TITLE
Mark conversations as read

### DIFF
--- a/app/mixins/conversation-route.js
+++ b/app/mixins/conversation-route.js
@@ -1,0 +1,88 @@
+import { get, set } from '@ember/object';
+import { alias, readOnly } from '@ember/object/computed';
+import Mixin from '@ember/object/mixin';
+import { inject as service } from '@ember/service';
+
+export default Mixin.create({
+  conversationChannel: service(),
+  currentUser: service(),
+  store: service(),
+  userIdle: service(),
+
+  conversation: null,
+
+  isIdle: readOnly('userIdle.isIdle'),
+  user: alias('currentUser.user'),
+
+  async afterModel(model) {
+    let conversation = model;
+
+    this.attemptToMarkAsRead();
+
+    let conversationChannel = get(this, 'conversationChannel');
+    let channel = await conversationChannel.join(conversation);
+
+    get(this, 'userIdle').on('idleChanged', this, this.idleHandler);
+    channel.on('new:conversation-part', () => this.refreshModel());
+
+    this._super(...arguments);
+  },
+
+  async attemptToMarkAsRead() {
+    let isIdle = get(this, 'isIdle');
+    if (isIdle) {
+      return; // Exit early since the user's idle
+    }
+
+    let conversation = this.modelFor(this.routeName);
+    let conversationReadAt = get(conversation, 'readAt');
+    let userId = get(this, 'user.id');
+
+    if (conversationReadAt) {
+      // The conversation is read, so check to see if there are unread
+      // conversation parts
+      get(conversation, 'conversationParts').then((conversationParts) => {
+        let otherParts = conversationParts.rejectBy('authorId', userId);
+        let latestPart = get(otherParts, 'lastObject');
+        let readAt = get(latestPart, 'readAt');
+        let authorId = get(latestPart, 'authorId');
+
+        if (!readAt && authorId !== userId) {
+          // The conversation part is unread and the user is not the author
+          this.markAsRead(conversation);
+        }
+      });
+    } else {
+      let message = await get(conversation, 'message');
+      let isAdminMessage = get(message, 'initiatedBy') === 'admin';
+
+      if (isAdminMessage) {
+        if (userId === get(conversation, 'user.id')) {
+          // The message was sent by an admin and the user is the target
+          this.markAsRead(conversation);
+        }
+      } else {
+        if (userId !== get(message, 'authorId')) {
+          // The message was sent to the project and the user did not author it
+          this.markAsRead(conversation);
+        }
+      }
+    }
+  },
+
+  idleHandler(isIdle) {
+    if (!isIdle) {
+      this.attemptToMarkAsRead();
+    }
+  },
+
+  markAsRead(conversation) {
+    set(conversation, 'read', true);
+    conversation.save();
+  },
+
+  refreshModel() {
+    let conversation = this.modelFor(this.routeName);
+    conversation.reload().then(() => this.attemptToMarkAsRead());
+  }
+});

--- a/app/models/conversation.js
+++ b/app/models/conversation.js
@@ -8,6 +8,8 @@ export default Model.extend({
   status: attr(),
   updatedAt: attr(),
 
+  read: attr(), // virtual attr
+
   conversationParts: hasMany('conversation-part', { async: true }),
   message: belongsTo('message', { async: true }),
   user: belongsTo('user', { async: true })

--- a/app/routes/conversations/conversation.js
+++ b/app/routes/conversations/conversation.js
@@ -3,8 +3,9 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { CanMixin } from 'ember-can';
+import ConversationRouteMixin from 'code-corps-ember/mixins/conversation-route';
 
-export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
+export default Route.extend(AuthenticatedRouteMixin, CanMixin, ConversationRouteMixin, {
   conversationChannel: service(),
   store: service(),
 
@@ -12,12 +13,6 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
     let conversation = await get(this, 'store').findRecord('conversation', params.id);
     await get(conversation, 'conversationParts');
     return conversation;
-  },
-
-  afterModel(model) {
-    let conversation = model;
-    let conversationChannel = get(this, 'conversationChannel');
-    conversationChannel.join(conversation);
   },
 
   actions: {

--- a/app/routes/project/conversations/conversation.js
+++ b/app/routes/project/conversations/conversation.js
@@ -3,8 +3,9 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { CanMixin } from 'ember-can';
+import ConversationRouteMixin from 'code-corps-ember/mixins/conversation-route';
 
-export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
+export default Route.extend(AuthenticatedRouteMixin, CanMixin, ConversationRouteMixin, {
   conversationChannel: service(),
   store: service(),
 
@@ -12,12 +13,6 @@ export default Route.extend(AuthenticatedRouteMixin, CanMixin, {
     let conversation = await get(this, 'store').findRecord('conversation', params.id);
     await get(conversation, 'conversationParts');
     return conversation;
-  },
-
-  afterModel(model) {
-    let conversation = model;
-    let conversationChannel = get(this, 'conversationChannel');
-    conversationChannel.join(conversation);
   },
 
   actions: {

--- a/app/services/conversation-channel.js
+++ b/app/services/conversation-channel.js
@@ -13,17 +13,11 @@ export default Service.extend({
     let id = get(conversation, 'id');
     let channel = socket.joinChannel(`conversation:${id}`);
 
-    channel.on('new:conversation-part', () => this._onNewMessage(conversation));
+    return channel;
   },
 
   leave(conversation) {
     let id = get(conversation, 'id');
     return get(this, 'socket').leaveChannel(`conversation:${id}`);
-  },
-
-  _onNewMessage(conversation) {
-    let store = get(this, 'store');
-    let id = get(conversation, 'id');
-    return store.findRecord('conversation', id);
   }
 });

--- a/app/services/user-idle.js
+++ b/app/services/user-idle.js
@@ -1,0 +1,5 @@
+import UserIdleService from 'ember-user-activity/services/user-idle';
+
+export default UserIdleService.extend({
+  IDLE_TIMEOUT: 10000 // 10 seconds
+});

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "ember-truth-helpers": "2.0.0",
     "ember-typed": "0.1.3",
     "ember-uploader": "1.2.3",
+    "ember-user-activity": "^0.9.1",
     "ember-watson": "0.9.1",
     "emberx-select": "^3.1.0",
     "eslint-plugin-ember-suave": "^1.0.0",

--- a/tests/unit/mixins/conversation-route-test.js
+++ b/tests/unit/mixins/conversation-route-test.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import ConversationRouteMixin from 'code-corps-ember/mixins/conversation-route';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | conversation route');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let ConversationRouteObject = EmberObject.extend(ConversationRouteMixin);
+  let subject = ConversationRouteObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/services/user-idle-test.js
+++ b/tests/unit/services/user-idle-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:user-idle', 'Unit | Service | user idle', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,6 +629,12 @@ babel-plugin-ember-modules-api-polyfill@^2.0.1:
   dependencies:
     ember-rfc176-data "^0.3.0"
 
+babel-plugin-ember-modules-api-polyfill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -2619,6 +2625,24 @@ ember-cli-babel@^6.10.0:
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
+ember-cli-babel@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.3.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
+
 ember-cli-bourbon@2.0.0-beta.1:
   version "2.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/ember-cli-bourbon/-/ember-cli-bourbon-2.0.0-beta.1.tgz#9d9b07bd4c7da7b2806ea18fc5cb9b37dd15ad25"
@@ -3787,6 +3811,12 @@ ember-uploader@1.2.3:
     broccoli-file-creator "^1.0.1"
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^5.1.6"
+
+ember-user-activity@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/ember-user-activity/-/ember-user-activity-0.9.1.tgz#e9cbafbd0e341773ea6b76c8a278445260e936ea"
+  dependencies:
+    ember-cli-babel "^6.11.0"
 
 ember-watson@0.9.1:
   version "0.9.1"


### PR DESCRIPTION
# What's in this PR?

WIP.

Basic logic is the following:

- check the conversation or its latest conversation part has not been read _and_ that it can be marked as read by this user
  - if yes, `PATCH` conversation with virtual attribute `read: true`
    - on the server this should update `readAt` for the conversation if the current user can mark it as read
    - sets `readAt` for all conversation parts where `readAt` is `null` and the current user can mark it as read
  - if no, do nothing

We send a message when the user is active and either of the following are true:
- The conversation is unread and either:
  - The message was sent by an admin and the user is the target
  - The message was sent to the project and the user did not author it
- The latest conversation part is unread and either:
  - The user is the target and the part was not written by them
  - The user is a project admin and the part was written by the target

A lot of this logic being done client-side may need to be reimplemented server-side, but my thinking here is that we are saving a potentially large number of network requests by doing some client-side checking. Distributed computing on the client in JS is much cheaper than paid servers.