### PR TITLE
Add conversation mirage setup and remove un-needed mirage models

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -173,7 +173,6 @@ module.exports = function(environment) {
     ENV['simple-auth'] = {
       store: 'simple-auth-session-store:ephemeral'
     };
-    ENV.SOCKETS_BASE_URL = '';
   }
 
   if (environment === 'staging') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -173,6 +173,7 @@ module.exports = function(environment) {
     ENV['simple-auth'] = {
       store: 'simple-auth-session-store:ephemeral'
     };
+    ENV.SOCKETS_BASE_URL = '';
   }
 
   if (environment === 'staging') {

--- a/mirage/factories/conversation-part.js
+++ b/mirage/factories/conversation-part.js
@@ -13,6 +13,4 @@ export default Factory.extend({
   updatedAt(i) {
     return moment().subtract(i, 'days');
   }
-  // author: belongsTo('user', { async: true }),
-  // conversation: belongsTo('conversation', { async: true })
 });

--- a/mirage/factories/conversation-part.js
+++ b/mirage/factories/conversation-part.js
@@ -1,0 +1,18 @@
+import { Factory, faker } from 'ember-cli-mirage';
+import moment from 'moment';
+
+export default Factory.extend({
+  body: faker.lorem.paragraph,
+
+  insertedAt(i) {
+    return moment().subtract(i, 'days');
+  },
+  readAt(i) {
+    return moment().subtract(i, 'days');
+  },
+  updatedAt(i) {
+    return moment().subtract(i, 'days');
+  }
+  // author: belongsTo('user', { async: true }),
+  // conversation: belongsTo('conversation', { async: true })
+});

--- a/mirage/factories/conversation.js
+++ b/mirage/factories/conversation.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 import moment from 'moment';
 
 export default Factory.extend({
@@ -19,5 +19,11 @@ export default Factory.extend({
       conversation.message = server.create('message');
       conversation.save();
     }
-  }
+  },
+
+  withConversationParts: trait({
+    afterCreate(conversation, server) {
+      server.createList('conversation-part', 10, { conversation });
+    }
+  })
 });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -303,4 +303,6 @@ We can make regular, ongoing improvements with two full-time developers and one 
 `,
     project
   });
+
+  server.createList('conversation', 3, 'withConversationParts');
 }


### PR DESCRIPTION
Getting something showing in 4200 land.  

Another note/question is if we want mirage to auto-detect the model, thus removing the need to define a mirage model (got in version 0.3.2 I think).  Lmk if that is something you want me to remove if the mirage model isn't needed.