### PR TITLE
Remove wait helpers and replace with async/await where needed

### DIFF
--- a/app/components/signup-email-input.js
+++ b/app/components/signup-email-input.js
@@ -2,7 +2,14 @@ import Component from '@ember/component';
 import { not, empty, and, alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { once, debounce, cancel } from '@ember/runloop';
-import { set, observer, get, computed } from '@ember/object';
+import { set, get, computed } from '@ember/object';
+import Ember from 'ember';
+
+const {
+  testing
+} = Ember;
+
+const DEBOUNCE_TIMER = testing ? 0 : 500;
 
 export default Component.extend({
   cachedEmail: '',
@@ -50,10 +57,6 @@ export default Component.extend({
     });
   },
 
-  emailChanged: observer('email', function() {
-    once(this, '_check');
-  }),
-
   sendRequest(email) {
     return get(this, 'ajax').request('/users/email_available', {
       method: 'GET',
@@ -65,6 +68,7 @@ export default Component.extend({
 
   actions: {
     keyDown() {
+      once(this, '_check');
       if (get(this, 'isNotSameEmail')) {
         set(this, 'isChecking', true);
       }
@@ -78,7 +82,7 @@ export default Component.extend({
       cancel(get(this, 'timer'));
       let deferredAction = debounce(this, function() {
         this.checkAvailable();
-      }, 500);
+      }, DEBOUNCE_TIMER);
       set(this, 'timer', deferredAction);
     } else if (get(this, 'isSameEmail') && get(this, 'isNotEmpty')) {
       this.sendAction('emailValidated', get(this, 'canSubmit'));

--- a/app/components/signup-form.js
+++ b/app/components/signup-form.js
@@ -61,9 +61,9 @@ export default Component.extend({
     };
 
     let promise = get(this, 'user').save().then(() => {
-      get(this, 'signIn')(credentials);
+      return get(this, 'signIn')(credentials);
     }).catch((error) => {
-      get(this, 'handleErrors')(error);
+      return get(this, 'handleErrors')(error);
     });
 
     yield promise;

--- a/app/components/signup-username-input.js
+++ b/app/components/signup-username-input.js
@@ -1,8 +1,15 @@
 import Component from '@ember/component';
-import { not, equal, empty, and, alias } from '@ember/object/computed';
+import { computed, get, set } from '@ember/object';
+import { alias, and, empty, not } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { observer } from '@ember/object';
 import { once, debounce, cancel } from '@ember/runloop';
+import Ember from 'ember';
+
+const {
+  testing
+} = Ember;
+
+const DEBOUNCE_TIMER = testing ? 0 : 500;
 
 /**
   `signup-username-input` composes the username input on the signup page. It
@@ -173,15 +180,8 @@ export default Component.extend({
     @property isSameUsername
     @type Boolean
    */
-  isSameUsername: equal('cachedUsername', 'username'),
-
-  /**
-    Checks the username whenever it is changed.
-
-    @method usernameChanged
-   */
-  usernameChanged: observer('username', function() {
-    once(this, '_check');
+  isSameUsername: computed('cachedUsername', 'username', function() {
+    return get(this, 'cachedUsername') === get(this, 'username');
   }),
 
   /**
@@ -191,18 +191,18 @@ export default Component.extend({
     @method checkAvailable
    */
   checkAvailable() {
-    let username = this.get('username');
+    let username = get(this, 'username');
     this.sendRequest(username).then((result) => {
       let { available, valid } = result;
       let validation = valid && available;
 
-      this.set('cachedUsername', this.get('username'));
-      this.set('hasCheckedOnce', true);
-      this.set('isChecking', false);
-      this.set('isAvailableOnServer', available);
-      this.set('isValid', valid);
+      set(this, 'cachedUsername', get(this, 'username'));
+      set(this, 'hasCheckedOnce', true);
+      set(this, 'isChecking', false);
+      set(this, 'isAvailableOnServer', available);
+      set(this, 'isValid', valid);
 
-      this.set('canSubmit', validation);
+      set(this, 'canSubmit', validation);
       this.sendAction('usernameValidated', validation);
     });
   },
@@ -214,7 +214,7 @@ export default Component.extend({
     @return Promise
    */
   sendRequest(username) {
-    return this.get('ajax').request('/users/username_available', {
+    return get(this, 'ajax').request('/users/username_available', {
       method: 'GET',
       data: {
         username
@@ -231,27 +231,28 @@ export default Component.extend({
       @method keyDown
      */
     keyDown() {
-      if (this.get('isNotSameUsername')) {
-        this.set('isChecking', true);
+      once(this, '_check');
+      if (get(this, 'isNotSameUsername')) {
+        set(this, 'isChecking', true);
       }
     }
   },
 
   _check() {
-    this.set('isChecking', true);
+    set(this, 'isChecking', true);
 
-    if (this.get('canCheck')) {
-      cancel(this.get('timer'));
+    if (get(this, 'canCheck')) {
+      cancel(get(this, 'timer'));
       let deferredAction = debounce(this, function() {
         this.checkAvailable();
-      }, 500);
-      this.set('timer', deferredAction);
-    } else if (this.get('isSameUsername') && this.get('isNotEmpty')) {
-      this.sendAction('usernameValidated', this.get('canSubmit'));
-      this.set('isChecking', false);
+      }, DEBOUNCE_TIMER);
+      set(this, 'timer', deferredAction);
+    } else if (get(this, 'isSameUsername') && get(this, 'isNotEmpty')) {
+      this.sendAction('usernameValidated', get(this, 'canSubmit'));
+      set(this, 'isChecking', false);
     } else {
       this.sendAction('usernameValidated', false);
-      this.set('isChecking', false);
+      set(this, 'isChecking', false);
     }
   }
 });

--- a/tests/acceptance/project-checkout-test.js
+++ b/tests/acceptance/project-checkout-test.js
@@ -148,9 +148,11 @@ test('Allows signing up and donating', function(assert) {
 
   andThen(() => {
     assert.equal(currentRouteName(), 'signup', 'User was redirected to signup.');
-    signupPage.form.email(email);
-    signupPage.form.password('password');
     signupPage.form.username('joeuser');
+    signupPage.form.keydownUsername();
+    signupPage.form.email(email);
+    signupPage.form.keydownEmail();
+    signupPage.form.password('password');
     signupPage.form.save();
   });
 

--- a/tests/acceptance/project-donate-test.js
+++ b/tests/acceptance/project-donate-test.js
@@ -95,9 +95,11 @@ test('Requires user to register before getting to checkout', function(assert) {
 
   andThen(() => {
     assert.equal(currentRouteName(), 'signup', 'User was redirected to signup.');
-    signupPage.form.email(email);
-    signupPage.form.password('password');
     signupPage.form.username('joeuser');
+    signupPage.form.keydownUsername();
+    signupPage.form.email(email);
+    signupPage.form.keydownEmail();
+    signupPage.form.password('password');
     signupPage.form.save();
   });
 
@@ -142,9 +144,11 @@ test('Requires user to register before getting to checkout, with custom amount',
 
   andThen(() => {
     assert.equal(currentRouteName(), 'signup', 'User was redirected to signup.');
-    signupPage.form.email(email);
-    signupPage.form.password('password');
     signupPage.form.username('joeuser');
+    signupPage.form.keydownUsername();
+    signupPage.form.email(email);
+    signupPage.form.keydownEmail();
+    signupPage.form.password('password');
     signupPage.form.save();
   });
 

--- a/tests/acceptance/signup-test.js
+++ b/tests/acceptance/signup-test.js
@@ -26,7 +26,13 @@ test('Successful signup', function(assert) {
   signupPage.visit();
 
   andThen(function() {
-    signupPage.form.username('username').email('email@example.com').password('password').save();
+    signupPage.form
+      .username('username')
+      .keydownUsername()
+      .email('email@example.com')
+      .keydownEmail()
+      .password('password')
+      .save();
   });
 
   let signUpDone = assert.async();

--- a/tests/integration/components/category-item-test.js
+++ b/tests/integration/components/category-item-test.js
@@ -4,7 +4,6 @@ import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import wait from 'ember-test-helpers/wait';
 import stubService from 'code-corps-ember/tests/helpers/stub-service';
 import {
   getFlashMessageCount,
@@ -96,9 +95,7 @@ let selectedCategory = {
   description: 'You want to help society.'
 };
 
-test('it works for selecting unselected categories', function(assert) {
-  let done = assert.async();
-
+test('it works for selecting unselected categories', async function(assert) {
   assert.expect(5);
 
   stubService(this, 'user-categories', mockUserCategoriesService);
@@ -111,17 +108,12 @@ test('it works for selecting unselected categories', function(assert) {
   assert.equal(page.description.text, 'You want to help technology.', 'Correct description is rendered.');
   assert.equal(page.button.text, 'Technology', 'Button text is rendered correctly');
 
-  page.button.click();
+  await page.button.click();
 
-  wait().then(() => {
-    assert.ok(page.icon.classContains('technology--selected'), 'is selected');
-    done();
-  });
+  assert.ok(page.icon.classContains('technology--selected'), 'is selected');
 });
 
 test('it works for removing selected categories', function(assert) {
-  let done = assert.async();
-
   assert.expect(3);
 
   stubService(this, 'user-categories', mockUserCategoriesService);
@@ -134,15 +126,10 @@ test('it works for removing selected categories', function(assert) {
 
   page.button.click();
 
-  wait().then(() => {
-    assert.ok(page.icon.classContains('society'), 'is unselected');
-    done();
-  });
+  assert.ok(page.icon.classContains('society'), 'is unselected');
 });
 
 test('it creates a flash message on an error when adding', function(assert) {
-  let done = assert.async();
-
   assert.expect(4);
 
   stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
@@ -152,25 +139,17 @@ test('it creates a flash message on an error when adding', function(assert) {
 
   page.button.click();
 
-  wait().then(() => {
-    assert.ok(page.button.unchecked, 'Operation failed. Button is rendered as unchecked.');
+  assert.ok(page.button.unchecked, 'Operation failed. Button is rendered as unchecked.');
 
-    assert.equal(getFlashMessageCount(this), 1, 'One message is shown');
-
-    let flash = getFlashMessageAt(0, this);
-    let actualOptions = getProperties(flash, 'fixed', 'sticky', 'timeout', 'type');
-    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
-    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
-
-    assert.ok(flash.message.indexOf(unselectedCategory.name) !== -1, 'Message text includes the category name');
-
-    done();
-  });
+  assert.equal(getFlashMessageCount(this), 1, 'One message is shown');
+  let flash = getFlashMessageAt(0, this);
+  let actualOptions = getProperties(flash, 'fixed', 'sticky', 'timeout', 'type');
+  let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+  assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+  assert.ok(flash.message.indexOf(unselectedCategory.name) !== -1, 'Message text includes the category name');
 });
 
 test('it creates a flash message on an error when removing', function(assert) {
-  let done = assert.async();
-
   assert.expect(4);
 
   stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
@@ -180,25 +159,17 @@ test('it creates a flash message on an error when removing', function(assert) {
 
   page.button.click();
 
-  wait().then(() => {
-    assert.ok(page.button.checked, 'Operation failed. Button is rendered as checked.');
+  assert.ok(page.button.checked, 'Operation failed. Button is rendered as checked.');
 
-    assert.equal(getFlashMessageCount(this), 1, 'One message is shown.');
-
-    let flash = getFlashMessageAt(0, this);
-    let actualOptions = getProperties(flash, 'fixed', 'sticky', 'timeout', 'type');
-    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
-    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
-
-    assert.ok(flash.message.indexOf(selectedCategory.name) !== -1, 'Message text includes the category name');
-
-    done();
-  });
+  assert.equal(getFlashMessageCount(this), 1, 'One message is shown.');
+  let flash = getFlashMessageAt(0, this);
+  let actualOptions = getProperties(flash, 'fixed', 'sticky', 'timeout', 'type');
+  let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+  assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+  assert.ok(flash.message.indexOf(selectedCategory.name) !== -1, 'Message text includes the category name');
 });
 
-test('it sets and unsets loading state when adding', function(assert) {
-  let done = assert.async();
-
+test('it sets and unsets loading state when adding', async function(assert) {
   assert.expect(2);
 
   stubService(this, 'user-categories', mockUserCategoriesService);
@@ -206,19 +177,16 @@ test('it sets and unsets loading state when adding', function(assert) {
 
   renderPage();
 
-  page.button.click();
+  let result = page.button.click();
 
   assert.ok(page.button.spinning, 'Button is rendering as busy.');
 
-  wait().then(() => {
-    assert.ok(page.button.checked, 'Operation worked. Button is rendered as checked.');
-    done();
-  });
+  await result;
+
+  assert.ok(page.button.checked, 'Operation worked. Button is rendered as checked.');
 });
 
-test('it sets and unsets loading state when removing', function(assert) {
-  let done = assert.async();
-
+test('it sets and unsets loading state when removing', async function(assert) {
   assert.expect(2);
 
   stubService(this, 'user-categories', mockUserCategoriesService);
@@ -226,12 +194,11 @@ test('it sets and unsets loading state when removing', function(assert) {
 
   renderPage();
 
-  page.button.click();
+  let result = page.button.click();
 
   assert.ok(page.button.spinning, 'Button is rendering as busy.');
 
-  wait().then(() => {
-    assert.ok(page.button.unchecked, 'Operation worked. Button is rendered as unchecked.');
-    done();
-  });
+  await result;
+
+  assert.ok(page.button.unchecked, 'Operation worked. Button is rendered as unchecked.');
 });

--- a/tests/integration/components/role-item-test.js
+++ b/tests/integration/components/role-item-test.js
@@ -4,7 +4,6 @@ import { run } from '@ember/runloop';
 import { set } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import wait from 'ember-test-helpers/wait';
 import {
   getFlashMessageCount,
   getFlashMessageAt
@@ -130,7 +129,6 @@ test('it calls proper action on service when clicking an unselected role', funct
 });
 
 test('it creates a flash message on an error when adding', function(assert) {
-  let done = assert.async();
   assert.expect(3);
 
   set(this, 'userRoles', mockUserRolesServiceForErrors);
@@ -140,21 +138,16 @@ test('it creates a flash message on an error when adding', function(assert) {
 
   page.button.click(),
 
-  wait().then(() => {
-    assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
+  assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
 
-    let flash = getFlashMessageAt(0, this);
-    let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
-    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
-    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
-    assert.ok(flash.message.indexOf(mobileDeveloper.name) !== -1, 'Message text includes the role name');
-
-    done();
-  });
+  let flash = getFlashMessageAt(0, this);
+  let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
+  let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+  assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+  assert.ok(flash.message.indexOf(mobileDeveloper.name) !== -1, 'Message text includes the role name');
 });
 
 test('it creates a flash message on an error when removing', function(assert) {
-  let done = assert.async();
   assert.expect(3);
 
   set(this, 'userRoles', mockUserRolesServiceForErrors);
@@ -162,23 +155,19 @@ test('it creates a flash message on an error when removing', function(assert) {
 
   renderPage();
 
-  run(() => this.$('button').click());
+  page.button.click(),
 
-  wait().then(() => {
-    assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
+  assert.equal(getFlashMessageCount(this), 1, 'One flash message is rendered');
 
-    let flash = getFlashMessageAt(0, this);
-    let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
-    let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
-    assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
-    assert.ok(flash.message.indexOf(mobileDeveloper.name) !== -1, 'Message text includes the role name');
+  let flash = getFlashMessageAt(0, this);
+  let actualOptions = flash.getProperties('fixed', 'sticky', 'timeout', 'type');
+  let expectedOptions = { fixed: true, sticky: false, timeout: 5000, type: 'danger' };
+  assert.deepEqual(actualOptions, expectedOptions, 'Proper message was set');
+  assert.ok(flash.message.indexOf(mobileDeveloper.name) !== -1, 'Message text includes the role name');
 
-    done();
-  });
 });
 
-test('it sets and unsets loading state when adding', function(assert) {
-  let done = assert.async();
+test('it sets and unsets loading state when adding', async function(assert) {
   assert.expect(2);
 
   let userRoles = {
@@ -200,16 +189,12 @@ test('it sets and unsets loading state when adding', function(assert) {
 
   renderPage();
 
-  page.button.click();
+  await page.button.click();
 
-  wait().then(() => {
-    assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
-    done();
-  });
+  assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
 });
 
-test('it sets and unsets loading state on error when adding', function(assert) {
-  let done = assert.async();
+test('it sets and unsets loading state on error when adding', async function(assert) {
   assert.expect(2);
 
   let userRoles = {
@@ -231,16 +216,12 @@ test('it sets and unsets loading state on error when adding', function(assert) {
 
   renderPage();
 
-  page.button.click();
+  await page.button.click();
 
-  wait().then(() => {
-    assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
-    done();
-  });
+  assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
 });
 
-test('it sets and unsets loading state when removing', function(assert) {
-  let done = assert.async();
+test('it sets and unsets loading state when removing', async function(assert) {
   assert.expect(2);
 
   let userRoles = {
@@ -262,16 +243,12 @@ test('it sets and unsets loading state when removing', function(assert) {
 
   renderPage();
 
-  page.button.click();
+  await page.button.click();
 
-  wait().then(() => {
-    assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
-    done();
-  });
+  assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
 });
 
-test('it sets and unsets loading state on error when removing', function(assert) {
-  let done = assert.async();
+test('it sets and unsets loading state on error when removing', async function(assert) {
   assert.expect(2);
 
   let userRoles = {
@@ -293,10 +270,7 @@ test('it sets and unsets loading state on error when removing', function(assert)
 
   renderPage();
 
-  page.button.click();
+  await page.button.click();
 
-  wait().then(() => {
-    assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
-    done();
-  });
+  assert.notOk(page.icon.isLoading, 'Component is no longer in the loading state.');
 });

--- a/tests/integration/components/signup-email-input-test.js
+++ b/tests/integration/components/signup-email-input-test.js
@@ -2,9 +2,8 @@ import { run } from '@ember/runloop';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import startMirage from '../../helpers/setup-mirage-for-integration';
-import wait from 'ember-test-helpers/wait';
 import PageObject from 'ember-cli-page-object';
-import component from 'code-corps-ember/tests/pages/components/signup-password-input';
+import component from 'code-corps-ember/tests/pages/components/signup-email-input';
 
 let page = PageObject.create(component);
 
@@ -27,104 +26,95 @@ test('it shows nothing when empty', function(assert) {
   assert.notOk(page.suggestionsArea.visible);
 });
 
-test('it shows suggestions when invalid', function(assert) {
-  let done = assert.async();
+test('it shows suggestions when invalid', async function(assert) {
   assert.expect(5);
 
   server.get('/users/email_available', () => {
     return { valid: false, available: true };
   });
 
-  this.on('emailValidated', (result) => {
+  this.set('emailValidated', (result) => {
     run.next(() => {
       assert.notOk(result);
     });
   });
-  page.render(hbs`{{signup-email-input user=user emailValidated="emailValidated"}}`);
+  this.set('user', { email: null });
+  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
-  this.set('user', { email: 'incomplete@' });
+  page.fillIn('incomplete@');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.notOk(page.suggestionsArea.ok);
-    assert.ok(page.suggestionsArea.notOk);
-    assert.equal(page.suggestionsArea.suggestions().count, 1);
-    assert.equal(page.suggestionsArea.suggestions(0).text, 'Please enter a valid email.');
-    done();
-  });
+  assert.notOk(page.suggestionsArea.ok);
+  assert.ok(page.suggestionsArea.notOk);
+  assert.equal(page.suggestionsArea.suggestions().count, 1);
+  assert.equal(page.suggestionsArea.suggestions(0).text, 'Please enter a valid email.');
 });
 
-test('it shows suggestions when unavailable', function(assert) {
-  let done = assert.async();
+test('it shows suggestions when unavailable', async function(assert) {
   assert.expect(5);
 
   server.get('/users/email_available', () => {
     return { valid: true, available: false };
   });
 
-  this.on('emailValidated', (result) => {
+  this.set('emailValidated', (result) => {
     run.next(() => {
       assert.notOk(result);
     });
   });
-  page.render(hbs`{{signup-email-input user=user emailValidated="emailValidated"}}`);
+  this.set('user', { email: null });
+  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
-  this.set('user', { email: 'taken@gmail.com' });
+  page.fillIn('taken@gmail.com');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.notOk(page.suggestionsArea.ok);
-    assert.ok(page.suggestionsArea.notOk);
-    assert.equal(page.suggestionsArea.suggestions().count, 1);
-    assert.equal(page.suggestionsArea.suggestions(0).text, 'This email is already registered. Want to login?');
-    done();
-  });
+  assert.notOk(page.suggestionsArea.ok);
+  assert.ok(page.suggestionsArea.notOk);
+  assert.equal(page.suggestionsArea.suggestions().count, 1);
+  assert.equal(page.suggestionsArea.suggestions(0).text, 'This email is already registered. Want to login?');
 });
 
-test('it shows ok when valid and available', function(assert) {
-  let done = assert.async();
+test('it shows ok when valid and available', async function(assert) {
   assert.expect(4);
 
   server.get('/users/email_available', () => {
     return { valid: true, available: true };
   });
 
-  this.on('emailValidated', (result) => {
+  this.set('emailValidated', (result) => {
     run.next(() => {
       assert.ok(result);
     });
   });
-  page.render(hbs`{{signup-email-input user=user emailValidated="emailValidated"}}`);
+  this.set('user', { email: null });
+  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
-  this.set('user', { email: 'available@gmail.com' });
+  page.fillIn('available@gmail.com');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.ok(page.suggestionsArea.ok);
-    assert.notOk(page.suggestionsArea.notOk);
-    assert.equal(page.suggestionsArea.suggestions().count, 0);
-    done();
-  });
+  assert.ok(page.suggestionsArea.ok);
+  assert.notOk(page.suggestionsArea.notOk);
+  assert.equal(page.suggestionsArea.suggestions().count, 0);
 });
 
-test('it resets to invalid when deleted', function(assert) {
-  let done = assert.async();
+test('it resets to invalid when deleted', async function(assert) {
   assert.expect(3);
 
   server.get('/users/email_available', () => {
     return { valid: true, available: true };
   });
 
-  this.on('emailValidated', (result) => {
+  this.set('emailValidated', (result) => {
     run.next(() => {
       assert.notOk(result);
     });
   });
   this.set('user', { email: 'available@gmail.com' });
-  page.render(hbs`{{signup-email-input user=user emailValidated="emailValidated"}}`);
+  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
-  this.set('user', { email: '' });
+  page.fillIn('');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.notOk(page.suggestionsArea.visible);
-    assert.notOk(page.suggestionsArea.visible);
-    done();
-  });
+  assert.notOk(page.suggestionsArea.visible);
+  assert.notOk(page.suggestionsArea.visible);
 });

--- a/tests/integration/components/signup-username-input-test.js
+++ b/tests/integration/components/signup-username-input-test.js
@@ -2,7 +2,6 @@ import { run } from '@ember/runloop';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import startMirage from '../../helpers/setup-mirage-for-integration';
-import wait from 'ember-test-helpers/wait';
 import PageObject from 'ember-cli-page-object';
 import component from 'code-corps-ember/tests/pages/components/signup-username-input';
 
@@ -29,104 +28,95 @@ test('it shows nothing when empty', function(assert) {
   assert.notOk(page.suggestionsArea.visible);
 });
 
-test('it shows suggestions when invalid', function(assert) {
-  let done = assert.async();
+test('it shows suggestions when invalid', async function(assert) {
   assert.expect(5);
 
   server.get('/users/username_available', () => {
     return { valid: false, available: true };
   });
 
-  this.on('usernameValidated', (result) => {
+  this.set('usernameValidated', (result) => {
     run.next(() => {
       assert.notOk(result);
     });
   });
-  page.render(hbs`{{signup-username-input user=user usernameValidated="usernameValidated"}}`);
+  this.set('user', { username: null });
+  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
-  this.set('user', { username: 'lots--of--hypens' });
+  page.fillIn('lots--of--hypens');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.notOk(page.suggestionsArea.ok);
-    assert.ok(page.suggestionsArea.notOk);
-    assert.equal(page.suggestionsArea.suggestions().count, 1);
-    assert.equal(page.suggestionsArea.suggestions(0).text, 'Please enter a username with only letters, numbers, or underscores.');
-    done();
-  });
+  assert.notOk(page.suggestionsArea.ok);
+  assert.ok(page.suggestionsArea.notOk);
+  assert.equal(page.suggestionsArea.suggestions().count, 1);
+  assert.equal(page.suggestionsArea.suggestions(0).text, 'Please enter a username with only letters, numbers, or underscores.');
 });
 
-test('it shows suggestions when unavailable', function(assert) {
-  let done = assert.async();
+test('it shows suggestions when unavailable', async function(assert) {
   assert.expect(5);
 
   server.get('/users/username_available', () => {
     return { valid: true, available: false };
   });
 
-  this.on('usernameValidated', (result) => {
+  this.set('usernameValidated', (result) => {
     run.next(() => {
       assert.notOk(result);
     });
   });
-  page.render(hbs`{{signup-username-input user=user usernameValidated="usernameValidated"}}`);
+  this.set('user', { username: null });
+  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
-  this.set('user', { username: 'taken' });
+  page.fillIn('taken');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.notOk(page.suggestionsArea.ok);
-    assert.ok(page.suggestionsArea.notOk);
-    assert.equal(page.suggestionsArea.suggestions().count, 1);
-    assert.equal(page.suggestionsArea.suggestions(0).text, 'This username is already registered. Want to login?');
-    done();
-  });
+  assert.notOk(page.suggestionsArea.ok);
+  assert.ok(page.suggestionsArea.notOk);
+  assert.equal(page.suggestionsArea.suggestions().count, 1);
+  assert.equal(page.suggestionsArea.suggestions(0).text, 'This username is already registered. Want to login?');
 });
 
-test('it shows ok when valid and available', function(assert) {
-  let done = assert.async();
+test('it shows ok when valid and available', async function(assert) {
   assert.expect(4);
 
   server.get('/users/username_available', () => {
     return { valid: true, available: true };
   });
 
-  this.on('usernameValidated', (result) => {
+  this.set('usernameValidated', (result) => {
     run.next(() => {
       assert.ok(result);
     });
   });
-  page.render(hbs`{{signup-username-input user=user usernameValidated="usernameValidated"}}`);
+  this.set('user', { username: null });
+  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
-  this.set('user', { username: 'available' });
+  page.fillIn('available');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.ok(page.suggestionsArea.ok);
-    assert.notOk(page.suggestionsArea.notOk);
-    assert.equal(page.suggestionsArea.suggestions().count, 0);
-    done();
-  });
+  assert.ok(page.suggestionsArea.ok);
+  assert.notOk(page.suggestionsArea.notOk);
+  assert.equal(page.suggestionsArea.suggestions().count, 0);
 });
 
-test('it resets to show nothing when cleared', function(assert) {
-  let done = assert.async();
+test('it resets to show nothing when cleared', async function(assert) {
   assert.expect(3);
 
   server.get('/users/username_available', () => {
     return { valid: true, available: true };
   });
 
-  this.on('usernameValidated', (result) => {
+  this.set('usernameValidated', (result) => {
     run.next(() => {
       assert.notOk(result);
     });
   });
   this.set('user', { username: 'available' });
-  page.render(hbs`{{signup-username-input user=user usernameValidated="usernameValidated"}}`);
+  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
-  this.set('user', { username: '' });
+  page.fillIn('');
+  await page.keydown();
 
-  wait().then(() => {
-    assert.notOk(page.suggestionsArea.visible);
-    assert.notOk(page.suggestionsArea.visible);
-    done();
-  });
+  assert.notOk(page.suggestionsArea.visible);
+  assert.notOk(page.suggestionsArea.visible);
 });

--- a/tests/integration/components/task-assignment-test.js
+++ b/tests/integration/components/task-assignment-test.js
@@ -7,7 +7,6 @@ import taskAssignmentComponent from 'code-corps-ember/tests/pages/components/tas
 import { Ability } from 'ember-can';
 import DS from 'ember-data';
 import stubService from 'code-corps-ember/tests/helpers/stub-service';
-import wait from 'ember-test-helpers/wait';
 import { initialize as initializeKeyboard } from 'ember-keyboard';
 
 const { PromiseObject } = DS;
@@ -244,7 +243,6 @@ test('when rendering is deffered and user does not have ability and there is an 
 });
 
 test('assignment dropdown typeahead', function(assert) {
-  let done = assert.async();
   assert.expect(2);
 
   let task = { id: 'task' };
@@ -273,10 +271,7 @@ test('assignment dropdown typeahead', function(assert) {
   page.select.trigger.open();
   page.select.dropdown.input.fillIn('testuser2');
 
-  wait().then(() => {
-    assert.equal(page.select.dropdown.options(0).text, 'testuser2', 'Only the second user is rendered.');
-    done();
-  });
+  assert.equal(page.select.dropdown.options(0).text, 'testuser2', 'Only the second user is rendered.');
 });
 
 test('pressing Space assigns self to task when able', function(assert) {

--- a/tests/pages/components/signup-email-input.js
+++ b/tests/pages/components/signup-email-input.js
@@ -1,5 +1,13 @@
+import {
+  fillable,
+  triggerable
+} from 'ember-cli-page-object';
+
 import suggestionsArea from 'code-corps-ember/tests/pages/components/_suggestions-area';
 
 export default {
+  fillIn: fillable('input'),
+  keydown: triggerable('keydown', 'input'),
+
   suggestionsArea
 };

--- a/tests/pages/components/signup-username-input.js
+++ b/tests/pages/components/signup-username-input.js
@@ -1,5 +1,13 @@
+import {
+  fillable,
+  triggerable
+} from 'ember-cli-page-object';
+
 import suggestionsArea from 'code-corps-ember/tests/pages/components/_suggestions-area';
 
 export default {
+  fillIn: fillable('input'),
+  keydown: triggerable('keydown', 'input'),
+
   suggestionsArea
 };

--- a/tests/pages/signup.js
+++ b/tests/pages/signup.js
@@ -2,6 +2,7 @@ import {
   clickable,
   create,
   fillable,
+  triggerable,
   visitable
 } from 'ember-cli-page-object';
 
@@ -11,6 +12,8 @@ export default create({
   form: {
     scope: '.signup-form',
     email: fillable('[name=email]'),
+    keydownEmail: triggerable('keydown', '[name=email]'),
+    keydownUsername: triggerable('keydown', '[name=username]'),
     password: fillable('[name=password]'),
     save: clickable('[name=signup]'),
     username: fillable('[name=username]')


### PR DESCRIPTION
# What's in this PR?

Removes `wait` helpers and replaces with `async`/`await` where they were needed. Should help resolve an issue I've seen where `window.wait` was not available as tests were running in a background tab in Chrome.