### PR TITLE
add canAdminister permissions to conversation-thread

### DIFF
--- a/app/components/conversations/conversation-thread.js
+++ b/app/components/conversations/conversation-thread.js
@@ -1,13 +1,28 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import EmberCan from 'ember-can';
-import { alias } from '@ember/object/computed';
+import { alias, filter } from '@ember/object/computed';
+import { get, getProperties } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
 export default Component.extend({
   classNames: ['conversation-thread'],
 
   ability: EmberCan.computed.ability('project'),
   canAdminister: alias('ability.canAdminister'),
+
+  conversationPartIsAccessibleByUser: filter('sortedConversationParts',
+    function() {
+      let { canAdminister } = getProperties(this, 'canAdminister');
+      if (canAdminister) {
+        return get(this, 'sortedConversationParts');
+      } else {
+        return get(this, 'sortedConversationParts').filter((part) => {
+          let partType = get(part, 'conversationPart.partType');
+          return (isEmpty(partType) || (partType === 'comment'));
+        });
+      }
+    }),
 
   _setup: (function() {
     this.scrollBottomAfterRender();

--- a/app/components/conversations/conversation-thread.js
+++ b/app/components/conversations/conversation-thread.js
@@ -1,8 +1,13 @@
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
+import EmberCan from 'ember-can';
+import { alias } from '@ember/object/computed';
 
 export default Component.extend({
   classNames: ['conversation-thread'],
+
+  ability: EmberCan.computed.ability('project'),
+  canAdminister: alias('ability.canAdminister'),
 
   _setup: (function() {
     this.scrollBottomAfterRender();

--- a/app/components/conversations/conversation-thread.js
+++ b/app/components/conversations/conversation-thread.js
@@ -2,27 +2,33 @@ import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import EmberCan from 'ember-can';
 import { alias, filter } from '@ember/object/computed';
-import { get, getProperties } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 
 export default Component.extend({
   classNames: ['conversation-thread'],
 
+  conversation: null,
+  sortedConversationParts: [],
+
+  project: alias('conversation.project'),
   ability: EmberCan.computed.ability('project'),
   canAdminister: alias('ability.canAdminister'),
 
-  conversationPartIsAccessibleByUser: filter('sortedConversationParts',
-    function() {
-      let { canAdminister } = getProperties(this, 'canAdminister');
-      if (canAdminister) {
-        return get(this, 'sortedConversationParts');
-      } else {
-        return get(this, 'sortedConversationParts').filter((part) => {
-          let partType = get(part, 'conversationPart.partType');
-          return (isEmpty(partType) || (partType === 'comment'));
-        });
-      }
-    }),
+  conversationPartsAccessibleByUser: computed('sortedConversationParts', function() {
+    let canAdminister = get(this, 'canAdminister');
+
+    if (canAdminister) {
+      return get(this, 'sortedConversationParts');
+    } else {
+      return get(this, 'sortedComments');
+    }
+  }),
+
+  sortedComments: filter('sortedConversationParts', function(part) {
+    let partType = get(part, 'partType');
+    return (isEmpty(partType) || (partType === 'comment'));
+  }),
 
   _setup: (function() {
     this.scrollBottomAfterRender();

--- a/app/templates/components/conversations/conversation-thread.hbs
+++ b/app/templates/components/conversations/conversation-thread.hbs
@@ -1,19 +1,26 @@
 <div class="conversation-thread-inner">
   <div class="conversation-thread__messages">
-    {{#if conversation.message.isLoaded}}
+    {{#if conversationPartIsAccessibleByUser}}
+      {{#if conversation.message.isLoaded}}
+        {{conversations/conversation-part-comment
+          author=conversation.message.author
+          body=conversation.message.body
+          readAt=conversation.message.readAt
+          sentAt=conversation.message.insertedAt
+        }}
+        {{/if}}
       {{#each sortedConversationParts as |conversationPart|}}
         {{#if conversationPart.isLoaded}}
-          {{#if (can "administer project" project)}}
-            {{#if (eq conversationPart.partType 'closed')}}
-              {{conversation/conversation-part-closed
-                author=conversationPart.author
-                closedAt=conversationPart.insertedAt
-              }}
-              {{else if (eq conversationPart.partType 'reopened')}}
-                {{conversations/conversation-part-reopened
-                author=conversationPart.author
-                reopenedAt=conversationPart.inserted
-              }}
+          {{#if (eq conversationPart.partType 'closed')}}
+            {{conversation/conversation-part-closed
+              author=conversationPart.author
+              closedAt=conversationPart.insertedAt
+            }}
+            {{else if (eq conversationPart.partType 'reopened')}}
+              {{conversations/conversation-part-reopened
+              author=conversationPart.author
+              reopenedAt=conversationPart.inserted
+            }}
             {{/if}}
           {{else}}
             {{conversations/conversation-part-comment
@@ -23,7 +30,6 @@
               sentAt=conversationPart.insertedAt
             }}
           {{/if}}
-        {{/if}}
       {{/each}}
     {{/if}}
   </div>

--- a/app/templates/components/conversations/conversation-thread.hbs
+++ b/app/templates/components/conversations/conversation-thread.hbs
@@ -1,37 +1,35 @@
 <div class="conversation-thread-inner">
   <div class="conversation-thread__messages">
-    {{#if conversationPartIsAccessibleByUser}}
-      {{#if conversation.message.isLoaded}}
-        {{conversations/conversation-part-comment
-          author=conversation.message.author
-          body=conversation.message.body
-          readAt=conversation.message.readAt
-          sentAt=conversation.message.insertedAt
-        }}
-        {{/if}}
-      {{#each sortedConversationParts as |conversationPart|}}
-        {{#if conversationPart.isLoaded}}
-          {{#if (eq conversationPart.partType 'closed')}}
-            {{conversation/conversation-part-closed
-              author=conversationPart.author
-              closedAt=conversationPart.insertedAt
-            }}
-            {{else if (eq conversationPart.partType 'reopened')}}
-              {{conversations/conversation-part-reopened
-              author=conversationPart.author
-              reopenedAt=conversationPart.inserted
-            }}
-            {{/if}}
-          {{else}}
-            {{conversations/conversation-part-comment
-              author=conversationPart.author
-              body=conversationPart.body
-              readAt=conversationPart.readAt
-              sentAt=conversationPart.insertedAt
-            }}
-          {{/if}}
-      {{/each}}
+    {{#if conversation.message.isLoaded}}
+      {{conversations/conversation-part-comment
+        author=conversation.message.author
+        body=conversation.message.body
+        readAt=conversation.message.readAt
+        sentAt=conversation.message.insertedAt
+      }}
     {{/if}}
+    {{#each conversationPartsAccessibleByUser as |conversationPart|}}
+      {{#if conversationPart.isLoaded}}
+        {{#if (eq conversationPart.partType 'closed')}}
+          {{conversations/conversation-part-closed
+            author=conversationPart.author
+            closedAt=conversationPart.insertedAt
+          }}
+        {{else if (eq conversationPart.partType 'reopened')}}
+          {{conversations/conversation-part-reopened
+            author=conversationPart.author
+            reopenedAt=conversationPart.inserted
+          }}
+        {{else}}
+          {{conversations/conversation-part-comment
+            author=conversationPart.author
+            body=conversationPart.body
+            readAt=conversationPart.readAt
+            sentAt=conversationPart.insertedAt
+          }}
+        {{/if}}
+      {{/if}}
+    {{/each}}
   </div>
   <div class="conversation-thread__composer">
     {{conversations/conversation-composer

--- a/app/templates/components/conversations/conversation-thread.hbs
+++ b/app/templates/components/conversations/conversation-thread.hbs
@@ -1,37 +1,31 @@
 <div class="conversation-thread-inner">
   <div class="conversation-thread__messages">
     {{#if conversation.message.isLoaded}}
-      {{conversations/conversation-part-comment
-        author=conversation.message.author
-        body=conversation.message.body
-        readAt=conversation.message.readAt
-        sentAt=conversation.message.insertedAt
-      }}
-    {{/if}}
-    {{#each sortedConversationParts as |conversationPart|}}
-      {{#if conversationPart.isLoaded}}
-        {{#if (eq conversationPart.partType 'closed')}}
-          {{conversation/conversation-part-closed
-            author=conversationPart.author
-            closedAt=conversationPart.insertedAt
-          }}
-        {{else if (eq conversationPart.partType 'reopened')}}
-          {{conversations/conversation-part-comment
-            author=conversationPart.author
-            body=conversationPart.body
-            readAt=conversationPart.readAt
-            sentAt=conversationPart.insertedAt
-          }}
-        {{else}}
-          {{conversations/conversation-part-comment
-            author=conversationPart.author
-            body=conversationPart.body
-            readAt=conversationPart.readAt
-            sentAt=conversationPart.insertedAt
-          }}
+      {{#each sortedConversationParts as |conversationPart|}}
+        {{#if conversationPart.isLoaded}}
+          {{#if (can "administer project" project)}}
+            {{#if (eq conversationPart.partType 'closed')}}
+              {{conversation/conversation-part-closed
+                author=conversationPart.author
+                closedAt=conversationPart.insertedAt
+              }}
+              {{else if (eq conversationPart.partType 'reopened')}}
+                {{conversations/conversation-part-reopened
+                author=conversationPart.author
+                reopenedAt=conversationPart.inserted
+              }}
+            {{/if}}
+          {{else}}
+            {{conversations/conversation-part-comment
+              author=conversationPart.author
+              body=conversationPart.body
+              readAt=conversationPart.readAt
+              sentAt=conversationPart.insertedAt
+            }}
+          {{/if}}
         {{/if}}
-      {{/if}}
-    {{/each}}
+      {{/each}}
+    {{/if}}
   </div>
   <div class="conversation-thread__composer">
     {{conversations/conversation-composer

--- a/mirage/factories/conversation.js
+++ b/mirage/factories/conversation.js
@@ -15,8 +15,9 @@ export default Factory.extend({
       conversation.save();
     }
 
-    if (!conversation.message) {
-      conversation.message = server.create('message');
+    if (!conversation.message.project) {
+      conversation.message.project = server.create('message');
+      server.create('project');
       conversation.save();
     }
   },

--- a/tests/acceptance/project-conversations-test.js
+++ b/tests/acceptance/project-conversations-test.js
@@ -58,9 +58,9 @@ test('Project admin can view list of conversations', async function(assert) {
     Date.now() - 1 * hour
   ];
 
-  server.create('conversation', { message:  message1, user, updatedAt: date1 });
-  server.create('conversation', { message:  message2, user, updatedAt: date2 });
-  server.create('conversation', { message:  message3, user, updatedAt: date3 });
+  server.create('conversation', 'withConversationParts', { partType: 'comment', message:  message1, user, updatedAt: date1 });
+  server.create('conversation', 'withConversationParts', { message:  message2, user, updatedAt: date2 });
+  server.create('conversation', 'withConversationParts', { message:  message3, user, updatedAt: date3 });
 
   await page.visit({
     organization: project.organization.slug,

--- a/tests/integration/components/conversations/conversation-thread-test.js
+++ b/tests/integration/components/conversations/conversation-thread-test.js
@@ -11,7 +11,7 @@ let page = PageObject.create(component);
 function renderPage() {
   page.render(hbs`
     {{conversations/conversation-thread
-      sortedConversationParts=conversation.sortedConversationParts
+      sortedConversationParts=sortedConversationParts
       conversation=conversation
       send=send
       project=project
@@ -26,6 +26,8 @@ moduleForComponent('conversations/conversation-thread', 'Integration | Component
     set(this, 'send', () => {
       return resolve();
     });
+    set(this, 'conversation', { });
+    set(this, 'sortedConversationParts', []);
   },
   afterEach() {
     page.removeContext();
@@ -34,6 +36,7 @@ moduleForComponent('conversations/conversation-thread', 'Integration | Component
 
 test('it renders composer', function(assert) {
   assert.expect(1);
+
   renderPage();
   assert.ok(page.conversationComposer.isVisible, 'Composer is rendered');
 });
@@ -63,44 +66,17 @@ test('it delays rendering head until loaded', function(assert) {
   assert.equal(page.conversationParts().count, 0, 'No part is rendered.');
 });
 
-test('it renders each conversation part if user can administer', function(assert) {
-  assert.expect(4);
-
-  this.register('ability:project', Ability.extend({ canAdminister: true }));
-
-  let sortedConversationParts = [
-    { isLoaded: true, body: 'foo 1', insertedAt: new Date('2017-11-01') },
-    { isLoaded: true, body: 'foo 2', insertedAt: new Date('2017-12-01') },
-    { isLoaded: true, body: 'foo 3', insertedAt: new Date('2017-10-01') }
-  ];
-
-  let project = {
-    projectUsers: [
-      { role: 'admin' }
-    ]
-  };
-
-  set(this, 'conversation', { sortedConversationParts });
-  set(this, 'project', project);
-
-  renderPage();
-
-  assert.equal(page.conversationParts().count, 3, 'Each part is rendered if user can administer.');
-  assert.equal(page.conversationParts(0).body.text, 'foo 1', 'Part 1 is rendered first');
-  assert.equal(page.conversationParts(1).body.text, 'foo 2', 'Part 2 is rendered second');
-  assert.equal(page.conversationParts(2).body.text, 'foo 3', 'Part 3 is rendered last');
-});
-
 test('it delays rendering conversation parts not yet loaded', function(assert) {
   assert.expect(1);
 
   let sortedConversationParts = [
-    { isLoaded: true, body: 'foo 1' },
-    { isLoaded: false, body: 'foo 2' },
-    { isLoaded: false, body: 'foo 3' }
+    { partType: 'comment', isLoaded: true, body: 'foo 1' },
+    { partType: 'comment', isLoaded: false, body: 'foo 2' },
+    { partType: 'comment', isLoaded: false, body: 'foo 3' }
   ];
 
-  set(this, 'conversation', { sortedConversationParts });
+  set(this, 'sortedConversationParts', sortedConversationParts);
+
   renderPage();
 
   assert.equal(page.conversationParts().count, 1, 'Only loaded parts are rendered.');
@@ -120,22 +96,36 @@ test('it delegates send action from composer', function(assert) {
   page.conversationComposer.submitButton.click();
 });
 
-test('conversation part filtering works if user has ability', function(assert) {
-  assert.expect(2);
-
+test('it shows all parts if user has ability', function(assert) {
+  assert.expect(1);
   this.register('ability:project', Ability.extend({ canAdminister: true }));
 
   let sortedConversationParts = [
-    { isComment: true, isLoaded: true, body: 'foo 1' },
-    { isClosed: true, isLoaded: true, body: 'foo 2'  },
-    { isReopened:true, isLoaded: true, body: 'foo 3' }
+    { partType: 'closed', isLoaded: true, body: 'foo 1' },
+    { partType: 'reopened', isLoaded: true, body: 'foo 2' },
+    { partType: 'comment', isLoaded: true, body: 'foo 3' }
   ];
 
-  set(this, 'conversation', { sortedConversationParts });
+  set(this, 'sortedConversationParts', sortedConversationParts);
 
   renderPage();
 
   assert.equal(page.conversationParts().count, 3, 'all conversation parts are rendered.');
 });
 
-// test('only comment parts are shown if user cannot administer')
+test('it shows only comment parts if user has no ability', function(assert) {
+  assert.expect(1);
+  this.register('ability:project', Ability.extend({ canAdminister: false }));
+
+  let sortedConversationParts = [
+    { partType: 'closed', isLoaded: true, body: 'foo 1' },
+    { partType: 'reopened', isLoaded: true, body: 'foo 2' },
+    { partType: 'comment', isLoaded: true, body: 'foo 3' }
+  ];
+
+  set(this, 'sortedConversationParts', sortedConversationParts);
+
+  renderPage();
+
+  assert.equal(page.conversationParts().count, 1, 'only comment parts are rendered.');
+});

--- a/tests/integration/components/conversations/conversation-thread-test.js
+++ b/tests/integration/components/conversations/conversation-thread-test.js
@@ -137,3 +137,5 @@ test('conversation part filtering works if user has ability', function(assert) {
 
   assert.equal(page.conversationParts().count, 3, 'all conversation parts are rendered.');
 });
+
+// test('only comment parts are shown if user cannot administer')


### PR DESCRIPTION
# What's in this PR?

Add the ability for authorized users (admin) to filter by conversation part type.

## References #1692 

Progress on: #1597 
