### PR TITLE
Remove unused ember-deferred-content addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "ember-composable-helpers": "2.1.0",
     "ember-concurrency": "^0.8.1",
     "ember-data": "~2.18.0",
-    "ember-deferred-content": "0.2.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-dragula": "1.9.3",
     "ember-exam": "1.0.0",


### PR DESCRIPTION
This PR removes an unused addon.

While the addon might have a benefit for us in the future, at the moment, we are not using it, so it has no effect other than potentially slowing down our builds.