### PR TITLE
chore(package): update ember-cli-page-object to version 1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-mirage": "^0.3.4",
     "ember-cli-moment-shim": "^3.4.0",
     "ember-cli-neat": "^0.0.6",
-    "ember-cli-page-object": "1.13.0",
+    "ember-cli-page-object": "1.14.1",
     "ember-cli-password-strength": "^2.0.0",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-release": "^0.2.9",

--- a/tests/acceptance/admin-github-event-test.js
+++ b/tests/acceptance/admin-github-event-test.js
@@ -27,7 +27,7 @@ test('The page requires user to be admin', function(assert) {
   page.visit({ id: event.id });
 
   andThen(() => {
-    assert.equal(page.flashErrors().count, 1, 'Flash error was rendered');
+    assert.equal(page.flashErrors.length, 1, 'Flash error was rendered');
     assert.equal(currentRouteName(), 'projects-list', 'Got redirected');
   });
 });
@@ -67,7 +67,7 @@ test('Displays all the logged events', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(page.flashMessages().count, 1, 'A flash was displayed');
+    assert.equal(page.flashMessages.length, 1, 'A flash was displayed');
     assert.equal(page.status.text, 'reprocessing', 'The event status changes');
   });
 });

--- a/tests/acceptance/admin-github-events-test.js
+++ b/tests/acceptance/admin-github-events-test.js
@@ -24,7 +24,7 @@ test('The page requires user to be admin', function(assert) {
   page.visit();
 
   andThen(() => {
-    assert.equal(page.flashErrors().count, 1, 'Flash error was rendered');
+    assert.equal(page.flashErrors.length, 1, 'Flash error was rendered');
     assert.equal(currentRouteName(), 'projects-list', 'Got redirected');
   });
 });
@@ -42,26 +42,26 @@ test('Displays all the logged events', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), '/admin/github/events');
     assert.equal(currentRouteName(), 'admin.github-events.index');
-    assert.equal(page.logItems().count, 20, 'There are 20 log rows by default.');
-    assert.equal(page.logItems(0).action.text, githubEvents[0].action);
-    assert.equal(page.logItems(0).eventType.text, githubEvents[0].eventType);
-    assert.equal(page.logItems(0).failureReason.text, githubEvents[0].failureReason);
-    assert.equal(page.logItems(0).status.text, githubEvents[0].status);
-    assert.ok(page.logItems(0).time.isVisible);
+    assert.equal(page.logItems.length, 20, 'There are 20 log rows by default.');
+    assert.equal(page.logItems.objectAt(0).action.text, githubEvents[0].action);
+    assert.equal(page.logItems.objectAt(0).eventType.text, githubEvents[0].eventType);
+    assert.equal(page.logItems.objectAt(0).failureReason.text, githubEvents[0].failureReason);
+    assert.equal(page.logItems.objectAt(0).status.text, githubEvents[0].status);
+    assert.ok(page.logItems.objectAt(0).time.isVisible);
     assert.ok(page.prev.isDisabled, 'Previous button is disabled.');
     assert.notOk(page.next.isDisabled, 'Next button is not disabled.');
     page.next.click();
   });
 
   andThen(function() {
-    assert.equal(page.logItems().count, 5, 'There are 5 log rows after navigating to the second page.');
+    assert.equal(page.logItems.length, 5, 'There are 5 log rows after navigating to the second page.');
     assert.notOk(page.prev.isDisabled, 'Previous button is not disabled.');
     assert.ok(page.next.isDisabled, 'Next button is disabled.');
     page.prev.click();
   });
 
   andThen(function() {
-    assert.equal(page.logItems().count, 20, 'There are 20 log rows after navigating back.');
+    assert.equal(page.logItems.length, 20, 'There are 20 log rows after navigating back.');
     assert.ok(page.prev.isDisabled, 'Previous button is disabled.');
     assert.notOk(page.next.isDisabled, 'Next button is not disabled.');
   });
@@ -79,38 +79,38 @@ test('Filters the logged events', function(assert) {
   page.visit();
 
   andThen(() => {
-    assert.equal(page.logItems().count, 2, 'There are 2 log rows by default.');
+    assert.equal(page.logItems.length, 2, 'There are 2 log rows by default.');
     page.filterStatus.fillIn('errored');
     assert.notOk(page.filterAction.isVisible, 'Action filter is not visible.');
   });
 
   andThen(() => {
-    assert.equal(page.logItems().count, 1, 'There are 1 log rows after filtering.');
-    assert.equal(page.logItems(0).action.text, expectedEvent.action);
-    assert.equal(page.logItems(0).eventType.text, expectedEvent.eventType);
-    assert.equal(page.logItems(0).status.text, expectedEvent.status);
+    assert.equal(page.logItems.length, 1, 'There are 1 log rows after filtering.');
+    assert.equal(page.logItems.objectAt(0).action.text, expectedEvent.action);
+    assert.equal(page.logItems.objectAt(0).eventType.text, expectedEvent.eventType);
+    assert.equal(page.logItems.objectAt(0).status.text, expectedEvent.status);
     assert.notOk(page.filterAction.isVisible, 'Action filter is not visible.');
     page.filterType.fillIn('issues');
   });
 
   andThen(() => {
-    assert.equal(page.logItems().count, 1, 'There are 1 log rows after filtering.');
-    assert.equal(page.logItems(0).action.text, expectedEvent.action);
-    assert.equal(page.logItems(0).eventType.text, expectedEvent.eventType);
-    assert.equal(page.logItems(0).status.text, expectedEvent.status);
+    assert.equal(page.logItems.length, 1, 'There are 1 log rows after filtering.');
+    assert.equal(page.logItems.objectAt(0).action.text, expectedEvent.action);
+    assert.equal(page.logItems.objectAt(0).eventType.text, expectedEvent.eventType);
+    assert.equal(page.logItems.objectAt(0).status.text, expectedEvent.status);
     assert.ok(page.filterAction.isVisible, 'Action filter is visible.');
     page.filterStatus.fillIn('opened');
   });
 
   andThen(() => {
-    assert.equal(page.logItems().count, 1, 'There are 1 log rows after filtering.');
-    assert.equal(page.logItems(0).action.text, expectedEvent.action);
-    assert.equal(page.logItems(0).eventType.text, expectedEvent.eventType);
-    assert.equal(page.logItems(0).status.text, expectedEvent.status);
+    assert.equal(page.logItems.length, 1, 'There are 1 log rows after filtering.');
+    assert.equal(page.logItems.objectAt(0).action.text, expectedEvent.action);
+    assert.equal(page.logItems.objectAt(0).eventType.text, expectedEvent.eventType);
+    assert.equal(page.logItems.objectAt(0).status.text, expectedEvent.status);
     page.clear.click();
   });
 
   andThen(() => {
-    assert.equal(page.logItems().count, 2, 'All items are listed again after clearing filters.');
+    assert.equal(page.logItems.length, 2, 'All items are listed again after clearing filters.');
   });
 });

--- a/tests/acceptance/admin-organization-invite-new-test.js
+++ b/tests/acceptance/admin-organization-invite-new-test.js
@@ -26,7 +26,7 @@ test('The page requires user to be admin', function(assert) {
   page.visit();
 
   andThen(() => {
-    assert.equal(page.flashErrors().count, 1, 'Flash error was rendered');
+    assert.equal(page.flashErrors.length, 1, 'Flash error was rendered');
     assert.equal(currentRouteName(), 'projects-list', 'Got redirected');
   });
 });
@@ -50,7 +50,7 @@ test('An admin can create and send an organization invite', function(assert) {
 
   andThen(() => {
     assert.equal(currentRouteName(), 'admin.organization-invites.index', 'We get redirected to the index');
-    assert.equal(page.flashMessages().count, 1, 'A flash was displayed');
+    assert.equal(page.flashMessages.length, 1, 'A flash was displayed');
   });
 });
 
@@ -88,7 +88,7 @@ test('Sending an invite can fail with validation errors', function(assert) {
     page.inviteForm.clickSubmit();
   });
 
-  andThen(() => assert.equal(page.inviteForm.errors().count, 2));
+  andThen(() => assert.equal(page.inviteForm.errors.length, 2));
 });
 
 test('Sending an invite can fail with an unknown error', function(assert) {
@@ -120,7 +120,7 @@ test('Sending an invite can fail with an unknown error', function(assert) {
     page.inviteForm.clickSubmit();
   });
 
-  andThen(() => assert.equal(page.flashMessages().count, 1, 'A flash was displayed'));
+  andThen(() => assert.equal(page.flashMessages.length, 1, 'A flash was displayed'));
 });
 
 test('Navigation is successful if user answers positively to prompt', function(assert) {

--- a/tests/acceptance/admin-organization-invites-index-test.js
+++ b/tests/acceptance/admin-organization-invites-index-test.js
@@ -24,7 +24,7 @@ test('The page requires user to be admin', function(assert) {
   page.visit();
 
   andThen(() => {
-    assert.equal(page.flashErrors().count, 1, 'Flash error was rendered');
+    assert.equal(page.flashErrors.length, 1, 'Flash error was rendered');
     assert.equal(currentRouteName(), 'projects-list', 'Got redirected');
   });
 });
@@ -47,32 +47,32 @@ test('Displays all the invites', function(assert) {
   andThen(() => {
     assert.equal(currentURL(), '/admin/organization-invites');
     assert.equal(currentRouteName(), 'admin.organization-invites.index');
-    assert.equal(page.logItems().count, 3, 'There are 3 rows.');
+    assert.equal(page.logItems.length, 3, 'There are 3 rows.');
 
-    assert.ok(page.logItems(0).icon.isVisible);
-    assert.equal(page.logItems(0).name.text, invites[0].organization.name);
-    assert.equal(page.logItems(0).email.text, invites[0].email);
-    assert.equal(page.logItems(0).approvalStatus.text, 'Pending approval');
-    assert.ok(page.logItems(0).actions.button.isVisible, 'The approve button renders');
+    assert.ok(page.logItems.objectAt(0).icon.isVisible);
+    assert.equal(page.logItems.objectAt(0).name.text, invites[0].organization.name);
+    assert.equal(page.logItems.objectAt(0).email.text, invites[0].email);
+    assert.equal(page.logItems.objectAt(0).approvalStatus.text, 'Pending approval');
+    assert.ok(page.logItems.objectAt(0).actions.button.isVisible, 'The approve button renders');
 
-    assert.ok(page.logItems(1).icon.isVisible);
-    assert.equal(page.logItems(1).name.text, invites[1].organization.name);
-    assert.equal(page.logItems(1).email.text, invites[1].email);
-    assert.equal(page.logItems(1).approvalStatus.text, 'Approved');
-    assert.notOk(page.logItems(1).actions.button.isVisible, 'The approve button does not render');
+    assert.ok(page.logItems.objectAt(1).icon.isVisible);
+    assert.equal(page.logItems.objectAt(1).name.text, invites[1].organization.name);
+    assert.equal(page.logItems.objectAt(1).email.text, invites[1].email);
+    assert.equal(page.logItems.objectAt(1).approvalStatus.text, 'Approved');
+    assert.notOk(page.logItems.objectAt(1).actions.button.isVisible, 'The approve button does not render');
 
-    assert.ok(page.logItems(2).icon.isVisible);
-    assert.equal(page.logItems(2).name.text, invites[2].organizationName);
-    assert.equal(page.logItems(2).email.text, invites[2].email);
-    assert.equal(page.logItems(2).approvalStatus.text, 'Invite sent');
-    assert.notOk(page.logItems(2).actions.button.isVisible, 'The approve button does not render');
+    assert.ok(page.logItems.objectAt(2).icon.isVisible);
+    assert.equal(page.logItems.objectAt(2).name.text, invites[2].organizationName);
+    assert.equal(page.logItems.objectAt(2).email.text, invites[2].email);
+    assert.equal(page.logItems.objectAt(2).approvalStatus.text, 'Invite sent');
+    assert.notOk(page.logItems.objectAt(2).actions.button.isVisible, 'The approve button does not render');
 
-    page.logItems(0).actions.button.click();
+    page.logItems.objectAt(0).actions.button.click();
   });
 
   andThen(() => {
-    assert.equal(page.flashMessages().count, 1, 'A flash was displayed');
-    assert.equal(page.logItems(0).approvalStatus.text, 'Approved');
-    assert.notOk(page.logItems(0).actions.button.isVisible, 'The approve button does not render');
+    assert.equal(page.flashMessages.length, 1, 'A flash was displayed');
+    assert.equal(page.logItems.objectAt(0).approvalStatus.text, 'Approved');
+    assert.notOk(page.logItems.objectAt(0).actions.button.isVisible, 'The approve button does not render');
   });
 });

--- a/tests/acceptance/admin-projects-test.js
+++ b/tests/acceptance/admin-projects-test.js
@@ -25,7 +25,7 @@ test('The page requires user to be admin', function(assert) {
   page.visit();
 
   andThen(() => {
-    assert.equal(page.flashErrors().count, 1, 'Flash error was rendered');
+    assert.equal(page.flashErrors.length, 1, 'Flash error was rendered');
     assert.equal(currentRouteName(), 'projects-list', 'Got redirected');
   });
 });
@@ -51,21 +51,21 @@ test('An admin can view a list of projects', function(assert) {
     assert.equal(currentURL(), '/admin/projects');
     assert.equal(currentRouteName(), 'admin.projects.index');
 
-    assert.equal(page.items().count, 3, 'There are 3 rows.');
+    assert.equal(page.items.length, 3, 'There are 3 rows.');
 
     [unapprovedProject, projectPendingApproval, approvedProject].forEach((project, index) => {
-      assert.equal(page.items(index).title.text, project.title, 'Project title is rendered.');
-      assert.equal(page.items(index).icon.src, project.iconThumbUrl, 'Project icon is rendered.');
+      assert.equal(page.items.objectAt(index).title.text, project.title, 'Project title is rendered.');
+      assert.equal(page.items.objectAt(index).icon.src, project.iconThumbUrl, 'Project icon is rendered.');
     });
 
-    assert.equal(page.items(0).approvalStatus.text, 'Created', 'Correct status is rendered for newly created project.');
-    assert.notOk(page.items(0).actions.approve.isVisible, 'Approve button is not rendered for newly created project.');
+    assert.equal(page.items.objectAt(0).approvalStatus.text, 'Created', 'Correct status is rendered for newly created project.');
+    assert.notOk(page.items.objectAt(0).actions.approve.isVisible, 'Approve button is not rendered for newly created project.');
 
-    assert.equal(page.items(1).approvalStatus.text, 'Pending approval', 'Correct status is rendered for project pending approval.');
-    assert.ok(page.items(1).actions.approve.isVisible, 'Approve button is rendered for project pending approval.');
+    assert.equal(page.items.objectAt(1).approvalStatus.text, 'Pending approval', 'Correct status is rendered for project pending approval.');
+    assert.ok(page.items.objectAt(1).actions.approve.isVisible, 'Approve button is rendered for project pending approval.');
 
-    assert.equal(page.items(2).approvalStatus.text, 'Approved', 'Correct status is rendered for approved project.');
-    assert.notOk(page.items(2).actions.approve.isVisible, 'Approve button is not rendered for approved project');
+    assert.equal(page.items.objectAt(2).approvalStatus.text, 'Approved', 'Correct status is rendered for approved project.');
+    assert.notOk(page.items.objectAt(2).actions.approve.isVisible, 'Approve button is not rendered for approved project');
   });
 });
 
@@ -80,12 +80,12 @@ test('An admin can approve a project', function(assert) {
   page.visit();
 
   andThen(() => {
-    page.items(0).actions.approve.click();
+    page.items.objectAt(0).actions.approve.click();
   });
 
   andThen(() => {
     assert.ok(unapprovedProject.approved, 'Project is approved.');
-    assert.equal(page.items(0).approvalStatus.text, 'Approved', 'Project status is rendered correctly.');
+    assert.equal(page.items.objectAt(0).approvalStatus.text, 'Approved', 'Project status is rendered correctly.');
   });
 });
 
@@ -115,10 +115,10 @@ test('A flash error renders when project approval fails', function(assert) {
   });
 
   andThen(() => {
-    page.items(0).actions.approve.click();
+    page.items.objectAt(0).actions.approve.click();
   });
 
   andThen(() => {
-    assert.equal(page.flashErrors().count, 1, 'Flash error is rendered.');
+    assert.equal(page.flashErrors.length, 1, 'Flash error is rendered.');
   });
 });

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -25,7 +25,7 @@ test('Redirects when not an admin', function(assert) {
 
   andThen(() => {
     assert.equal(currentRouteName(), 'projects-list');
-    assert.equal(page.flashMessages().count, 1, 'A flash was displayed');
+    assert.equal(page.flashMessages.length, 1, 'A flash was displayed');
   });
 });
 

--- a/tests/acceptance/footer-test.js
+++ b/tests/acceptance/footer-test.js
@@ -9,7 +9,7 @@ test('can visit links from footer on index', function(assert) {
   indexPage.visit();
 
   andThen(function() {
-    assert.equal(indexPage.siteFooter.columns().count, 4);
+    assert.equal(indexPage.siteFooter.columns.length, 4);
     indexPage.siteFooter.clickAboutLink();
   });
 
@@ -34,8 +34,8 @@ test('renders horizontal on smaller screens', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(indexPage.siteFooter.columns().count, 0);
-    assert.equal(indexPage.siteFooter.rows().count, 6);
+    assert.equal(indexPage.siteFooter.columns.length, 0);
+    assert.equal(indexPage.siteFooter.rows.length, 6);
   });
 });
 
@@ -45,7 +45,7 @@ test('renders horizontal on most pages', function(assert) {
   setBreakpoint('full');
 
   andThen(function() {
-    assert.equal(indexPage.siteFooter.columns().count, 0);
-    assert.equal(indexPage.siteFooter.rows().count, 6);
+    assert.equal(indexPage.siteFooter.columns.length, 0);
+    assert.equal(indexPage.siteFooter.rows.length, 6);
   });
 });

--- a/tests/acceptance/github-test.js
+++ b/tests/acceptance/github-test.js
@@ -35,7 +35,7 @@ test('if state is invalid, goes back to ingtegrations page with a flash error', 
       'User was redirected back to integrations.'
     );
 
-    assert.equal(page.flashMessages().count, 1, 'A flash was displayed');
+    assert.equal(page.flashMessages.length, 1, 'A flash was displayed');
   });
 });
 
@@ -93,6 +93,6 @@ test('if connect request fails, redirects to integrations with a flash error', f
       'User was redirected to the integrations page.'
     );
 
-    assert.equal(page.flashMessages().count, 1, 'A flash was displayed');
+    assert.equal(page.flashMessages.length, 1, 'A flash was displayed');
   });
 });

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -42,8 +42,8 @@ test('Login failure', function(assert) {
   });
 
   andThen(() => {
-    assert.equal(loginPage.form.errors().count, 1, 'One error is shown');
-    assert.equal(loginPage.form.errors(0).text, ERROR_TEXT, 'Page contains login error');
+    assert.equal(loginPage.form.errors.length, 1, 'One error is shown');
+    assert.equal(loginPage.form.errors.objectAt(0).text, ERROR_TEXT, 'Page contains login error');
   });
 });
 

--- a/tests/acceptance/navigation-test.js
+++ b/tests/acceptance/navigation-test.js
@@ -119,7 +119,7 @@ test('Logged in, user with organizations can navigate to projects', function(ass
     indexPage.navMenu.projectSwitcher.menuLink.click();
   });
   andThen(function() {
-    indexPage.navMenu.projectSwitcher.projectSwitcherMenu.menu.projects(0).icon.click();
+    indexPage.navMenu.projectSwitcher.projectSwitcherMenu.menu.projects.objectAt(0).icon.click();
   });
   andThen(function() {
     assert.equal(currentRouteName(), 'project.index');

--- a/tests/acceptance/onboarding-test.js
+++ b/tests/acceptance/onboarding-test.js
@@ -70,30 +70,30 @@ test('A user can onboard as expected', function(assert) {
   andThen(() => {
     assert.equal(currentURL(), '/start/expertise');
 
-    assert.equal(onboardingPage.roleColumns(0).header.title, 'Technology');
-    assert.ok(onboardingPage.roleColumns(0).hasClass('expertise__column--technology'));
-    assert.equal(onboardingPage.roleColumns(0).roles(0).button.text, 'Backend Development');
+    assert.equal(onboardingPage.roleColumns.objectAt(0).header.title, 'Technology');
+    assert.ok(onboardingPage.roleColumns.objectAt(0).hasClass('expertise__column--technology'));
+    assert.equal(onboardingPage.roleColumns.objectAt(0).roles.objectAt(0).button.text, 'Backend Development');
 
-    assert.equal(onboardingPage.roleColumns(1).header.title, 'Creative');
-    assert.ok(onboardingPage.roleColumns(1).hasClass('expertise__column--creative'));
-    assert.equal(onboardingPage.roleColumns(1).roles(0).button.text, 'Marketing');
+    assert.equal(onboardingPage.roleColumns.objectAt(1).header.title, 'Creative');
+    assert.ok(onboardingPage.roleColumns.objectAt(1).hasClass('expertise__column--creative'));
+    assert.equal(onboardingPage.roleColumns.objectAt(1).roles.objectAt(0).button.text, 'Marketing');
 
-    assert.equal(onboardingPage.roleColumns(2).header.title, 'Support');
-    assert.ok(onboardingPage.roleColumns(2).hasClass('expertise__column--support'));
-    assert.equal(onboardingPage.roleColumns(2).roles(0).button.text, 'Donations');
+    assert.equal(onboardingPage.roleColumns.objectAt(2).header.title, 'Support');
+    assert.ok(onboardingPage.roleColumns.objectAt(2).hasClass('expertise__column--support'));
+    assert.equal(onboardingPage.roleColumns.objectAt(2).roles.objectAt(0).button.text, 'Donations');
 
     assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
-    onboardingPage.roleColumns(0).roles(0).button.click();
+    onboardingPage.roleColumns.objectAt(0).roles.objectAt(0).button.click();
   });
 
   andThen(() => {
     assert.notOk(onboardingPage.startFooterButton.isDisabled, 'start button is enabled');
-    onboardingPage.roleColumns(0).roles(0).button.click();
+    onboardingPage.roleColumns.objectAt(0).roles.objectAt(0).button.click();
   });
 
   andThen(() => {
     assert.ok(onboardingPage.startFooterButton.isDisabled, 'start button is disabled');
-    onboardingPage.roleColumns(0).roles(0).button.click();
+    onboardingPage.roleColumns.objectAt(0).roles.objectAt(0).button.click();
   });
 
   andThen(() => {
@@ -106,29 +106,29 @@ test('A user can onboard as expected', function(assert) {
   });
 
   andThen(() => {
-    assert.equal(onboardingPage.skillsTypeahead.dropdown.inputItems(0).text, 'Ruby');
-    onboardingPage.skillsTypeahead.dropdown.inputItems(0).click();
+    assert.equal(onboardingPage.skillsTypeahead.dropdown.inputItems.objectAt(0).text, 'Ruby');
+    onboardingPage.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(onboardingPage.userSkillsList(0).text, 'Ruby');
-    onboardingPage.userSkillsList(0).click();
+    assert.equal(onboardingPage.userSkillsList.objectAt(0).text, 'Ruby');
+    onboardingPage.userSkillsList.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(onboardingPage.userSkillsList().count, 0, 'No skills have been added yet');
-    assert.equal(onboardingPage.popularSkillsList().count, 2, 'Popular skills are listed');
+    assert.equal(onboardingPage.userSkillsList.length, 0, 'No skills have been added yet');
+    assert.equal(onboardingPage.popularSkillsList.length, 2, 'Popular skills are listed');
     onboardingPage.skillsTypeahead.searchFor('r');
   });
 
   andThen(() => {
-    assert.equal(onboardingPage.skillsTypeahead.dropdown.inputItems(0).text, 'Ruby');
-    onboardingPage.skillsTypeahead.dropdown.inputItems(0).click();
+    assert.equal(onboardingPage.skillsTypeahead.dropdown.inputItems.objectAt(0).text, 'Ruby');
+    onboardingPage.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(onboardingPage.userSkillsList().count, 1, 'A user skill was added');
-    assert.equal(onboardingPage.popularSkillsList().count, 1, 'The popular skills were updated');
+    assert.equal(onboardingPage.userSkillsList.length, 1, 'A user skill was added');
+    assert.equal(onboardingPage.popularSkillsList.length, 1, 'The popular skills were updated');
     onboardingPage.startFooterButton.click();
   });
 

--- a/tests/acceptance/organization-creation-test.js
+++ b/tests/acceptance/organization-creation-test.js
@@ -149,7 +149,7 @@ test('Creating an organization can fail with validation errors', function(assert
     page.organizationForm.clickSubmit();
   });
 
-  andThen(() => assert.equal(page.organizationForm.errors().count, 4));
+  andThen(() => assert.equal(page.organizationForm.errors.length, 4));
 });
 
 test('Creating an organization can fail with an unknown error', function(assert) {
@@ -183,7 +183,7 @@ test('Creating an organization can fail with an unknown error', function(assert)
     page.organizationForm.clickSubmit();
   });
 
-  andThen(() => assert.equal(page.flashMessages().count, 1, 'A flash was displayed'));
+  andThen(() => assert.equal(page.flashMessages.length, 1, 'A flash was displayed'));
 });
 
 test('A user with a valid invite can create an organization', function(assert) {

--- a/tests/acceptance/organization-projects-test.js
+++ b/tests/acceptance/organization-projects-test.js
@@ -14,9 +14,9 @@ test('It renders all the required ui elements', function(assert) {
 
   andThen(function() {
     assert.ok(organizationProjects.project.isVisible, 'project-list component is rendered');
-    assert.equal(organizationProjects.project.items().count, 5, 'correct number of project-items is rendered');
+    assert.equal(organizationProjects.project.items.length, 5, 'correct number of project-items is rendered');
 
-    let firstProjectHref = organizationProjects.project.items(0).href;
+    let firstProjectHref = organizationProjects.project.items.objectAt(0).href;
     assert.ok(firstProjectHref.indexOf(`/${organization.slug}/${projects[0].slug}`) > -1, 'The link to a project is properly rendered');
   });
 });

--- a/tests/acceptance/organization-settings-profile-test.js
+++ b/tests/acceptance/organization-settings-profile-test.js
@@ -59,8 +59,8 @@ test('it allows editing of organization profile', function(assert) {
   });
 
   andThen(() => {
-    assert.equal(organizationPage.successAlerts().count, 1);
-    assert.ok(organizationPage.successAlerts(0).contains('Organization updated successfully'));
+    assert.equal(organizationPage.successAlerts.length, 1);
+    assert.ok(organizationPage.successAlerts.objectAt(0).contains('Organization updated successfully'));
   });
 });
 
@@ -83,8 +83,8 @@ test("it allows editing of organization's image", function(assert) {
   });
 
   andThen(() => {
-    assert.equal(organizationPage.successAlerts().count, 1);
-    assert.ok(organizationPage.successAlerts(0).contains('Organization icon uploaded successfully'));
+    assert.equal(organizationPage.successAlerts.length, 1);
+    assert.ok(organizationPage.successAlerts.objectAt(0).contains('Organization icon uploaded successfully'));
     let expectedStyle = `url(${droppedImageString})`;
     assert.equal(removeDoubleQuotes(find('.image-drop').css('background-image')), expectedStyle);
     done();

--- a/tests/acceptance/organization-test.js
+++ b/tests/acceptance/organization-test.js
@@ -22,7 +22,7 @@ test("it displays the organization's details", function(assert) {
     assert.ok(organizationPage.projectList.isVisible, 'The projects list component renders');
     assert.equal(organizationPage.orgTitle.text, organization.name, 'The organization title renders');
     assert.equal(organizationPage.orgDescription.text, organization.description, 'The organization description renders');
-    assert.equal(organizationPage.projectListItems().count, 3, 'The projects render');
+    assert.equal(organizationPage.projectListItems.length, 3, 'The projects render');
   });
 });
 
@@ -64,8 +64,8 @@ test('anyone can navigate to projects', function(assert) {
   organizationPage.visitIndex({ organization: organization.slug });
 
   andThen(() => {
-    assert.equal(organizationPage.projectListItems(0).text, project.title, 'The project in the list is correct');
-    organizationPage.projectListItems(0).click();
+    assert.equal(organizationPage.projectListItems.objectAt(0).text, project.title, 'The project in the list is correct');
+    organizationPage.projectListItems.objectAt(0).click();
   });
 
   andThen(() => {

--- a/tests/acceptance/password-test.js
+++ b/tests/acceptance/password-test.js
@@ -48,7 +48,7 @@ test('visiting /password/reset and entering diff passwords returns 422', functio
   andThen(() => {
     assert.equal(currentURL(), '/password/reset?token=abc123');
     assert.equal(getFlashMessageCount(this), 0, 'No flash message was shown.');
-    assert.equal(passwordPage.errorFormatter.errors().count, 1, 'Each error message is rendered');
+    assert.equal(passwordPage.errorFormatter.errors.length, 1, 'Each error message is rendered');
   });
 });
 

--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -17,7 +17,7 @@ test('it displays the user-details component with user details', function(assert
     assert.equal(userProfile.userDetails.twitter.text, `@${user.twitter}`, "The user's twitter renders");
     assert.equal(userProfile.userDetails.twitter.link.href, `https://twitter.com/${user.twitter}`, "The user's twitter URL renders");
     assert.equal(userProfile.userDetails.website.text, user.website, "The user's website renders");
-    assert.equal(userProfile.projects().count, 3, "The user's organizations are rendered");
+    assert.equal(userProfile.projects.length, 3, "The user's organizations are rendered");
   });
 });
 
@@ -30,8 +30,8 @@ test('the user can navigate to a project from the projects list', function(asser
   let href = `/${project.organization.slug}/${project.slug}`;
 
   andThen(() => {
-    assert.equal(userProfile.projects(0).href, href, 'The link is rendered');
-    userProfile.projects(0).click();
+    assert.equal(userProfile.projects.objectAt(0).href, href, 'The link is rendered');
+    userProfile.projects.objectAt(0).click();
   });
 
   andThen(() => {

--- a/tests/acceptance/project-checkout-test.js
+++ b/tests/acceptance/project-checkout-test.js
@@ -205,8 +205,8 @@ test('Shows stripe errors when creating a card token fails', function(assert) {
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.checkout');
-    assert.equal(projectCheckoutPage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
-    assert.equal(projectCheckoutPage.errorFormatter.errors(0).message, stripeCardError.error.message, 'Correct error is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.length, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.objectAt(0).message, stripeCardError.error.message, 'Correct error is displayed.');
   });
 });
 
@@ -244,8 +244,8 @@ test('Shows error indicating problem with stripe customer if that part of the pr
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.checkout');
-    assert.equal(projectCheckoutPage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
-    assert.equal(projectCheckoutPage.errorFormatter.errors(0).message, 'There was a problem in connecting your account with our payment processor. Please try again.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.length, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.objectAt(0).message, 'There was a problem in connecting your account with our payment processor. Please try again.');
   });
 });
 
@@ -283,8 +283,8 @@ test('Shows error indicating problem with stripe card if that part of the proces
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.checkout');
-    assert.equal(projectCheckoutPage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
-    assert.equal(projectCheckoutPage.errorFormatter.errors(0).message, 'There was a problem in using your payment information. Please try again.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.length, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.objectAt(0).message, 'There was a problem in using your payment information. Please try again.');
   });
 });
 
@@ -325,8 +325,8 @@ test('Shows subscription validation errors if that part of the process fails due
   andThen(() => {
     assert.notOk(server.schema.stripeConnectSubscriptions.findBy({ quantity: 1000 }), 'Subscription was not created.');
     assert.equal(currentRouteName(), 'project.checkout');
-    assert.equal(projectCheckoutPage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
-    assert.equal(projectCheckoutPage.errorFormatter.errors(0).message, "The amount you've set for your monthly donation is invalid.", 'Correct error is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.length, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.objectAt(0).message, "The amount you've set for your monthly donation is invalid.", 'Correct error is displayed.');
   });
 });
 
@@ -364,7 +364,7 @@ test('Shows error indicating problem with creating subscription if that part of 
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.checkout');
-    assert.equal(projectCheckoutPage.errorFormatter.errors().count, 1, 'Correct number of errors is displayed.');
-    assert.equal(projectCheckoutPage.errorFormatter.errors(0).message, 'There was a problem in setting up your monthly donation. Please try again.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.length, 1, 'Correct number of errors is displayed.');
+    assert.equal(projectCheckoutPage.errorFormatter.errors.objectAt(0).message, 'There was a problem in setting up your monthly donation. Please try again.');
   });
 });

--- a/tests/acceptance/project-conversations-test.js
+++ b/tests/acceptance/project-conversations-test.js
@@ -67,11 +67,11 @@ test('Project admin can view list of conversations', async function(assert) {
     project: project.slug
   });
 
-  assert.equal(page.conversations().count, 3, 'Conversations are rendered');
+  assert.equal(page.conversations.length, 3, 'Conversations are rendered');
   let renderedTimeStampOrder = [
-    page.conversations(0).updatedAt.text,
-    page.conversations(1).updatedAt.text,
-    page.conversations(2).updatedAt.text
+    page.conversations.objectAt(0).updatedAt.text,
+    page.conversations.objectAt(1).updatedAt.text,
+    page.conversations.objectAt(2).updatedAt.text
   ];
 
   let expectedTimeStampOrder = [
@@ -101,7 +101,7 @@ test('Project admin can view single conversations', async function(assert) {
     project: project.slug
   });
 
-  await page.conversations(1).click();
+  await page.conversations.objectAt(1).click();
 
   andThen(() => {
     assert.equal(currentRouteName(), 'project.conversations.conversation');
@@ -109,9 +109,9 @@ test('Project admin can view single conversations', async function(assert) {
     let conversation = store.peekRecord('conversation', server.db.conversations[1].id);
     let firstPart = conversation.get('sortedConversationParts').get('firstObject');
     let lastPart = conversation.get('sortedConversationParts').get('lastObject');
-    assert.equal(page.conversationThread.conversationParts().count, 11, 'Message head and conversation parts rendered');
-    assert.equal(page.conversationThread.conversationParts(1).body.text, firstPart.get('body'), 'first conversation part is rendered correctly');
-    assert.equal(page.conversationThread.conversationParts(10).body.text, lastPart.get('body'), 'last conversation part is rendered correctly');
+    assert.equal(page.conversationThread.conversationParts.length, 11, 'Message head and conversation parts rendered');
+    assert.equal(page.conversationThread.conversationParts.objectAt(1).body.text, firstPart.get('body'), 'first conversation part is rendered correctly');
+    assert.equal(page.conversationThread.conversationParts.objectAt(10).body.text, lastPart.get('body'), 'last conversation part is rendered correctly');
     assert.ok(firstPart.get('insertedAt') < lastPart.get('insertedAt'), 'conversations are sorted correctly');
   });
 });
@@ -129,19 +129,19 @@ test('System is notified of new conversation part', async function(assert) {
     project: project.slug
   });
 
-  page.conversations(0).click();
+  page.conversations.objectAt(0).click();
 
-  assert.equal(page.conversationThread.conversationParts().count, 11, 'Just the message head and conversation parts is rendered.');
+  assert.equal(page.conversationThread.conversationParts.length, 11, 'Just the message head and conversation parts is rendered.');
   server.create('conversation-part', { conversation });
 
-  assert.equal(page.conversationThread.conversationParts().count, 11, 'No notification yet, so new part was not rendered.');
+  assert.equal(page.conversationThread.conversationParts.length, 11, 'No notification yet, so new part was not rendered.');
   let conversationChannelService = this.application.__container__.lookup('service:conversation-channel');
   let socket = get(conversationChannelService, 'socket.socket');
   let [channel] = socket.channels;
   channel.trigger('new:conversation-part', {});
 
   andThen(() => {
-    assert.equal(page.conversationThread.conversationParts().count, 12, 'Notification was sent. New part is rendered.');
+    assert.equal(page.conversationThread.conversationParts.length, 12, 'Notification was sent. New part is rendered.');
   });
 });
 
@@ -158,7 +158,7 @@ test('Project admin can post to a conversation', async function(assert) {
     project: project.slug
   });
 
-  page.conversations(0).click();
+  page.conversations.objectAt(0).click();
 
   page.conversationThread.conversationComposer.as((composer) => {
     composer.submittableTextarea.fillIn('Foo');
@@ -184,7 +184,7 @@ test('Project admin can close a conversation', async function(assert) {
     project: project.slug
   });
 
-  await page.conversations(0).closeButton.click();
+  await page.conversations.objectAt(0).closeButton.click();
 
   assert.equal(server.schema.conversations.first().status, 'closed', 'Conversation was closed.');
 });
@@ -205,10 +205,10 @@ test('Project admin can reopen a conversation', async function(assert) {
 
   await page.statusSelect.openButton.click();
   await page.statusSelect.closedLink.click();
-  await page.conversations(0).reopenButton.click();
+  await page.conversations.objectAt(0).reopenButton.click();
   await page.statusSelect.closedButton.click();
   await page.statusSelect.openLink.click();
 
-  assert.ok(page.conversations(0).isVisible, 'The conversation is in the open list.');
+  assert.ok(page.conversations.objectAt(0).isVisible, 'The conversation is in the open list.');
   assert.equal(server.schema.conversations.first().status, 'open', 'Conversation was reopened.');
 });

--- a/tests/acceptance/project-creation-test.js
+++ b/tests/acceptance/project-creation-test.js
@@ -85,7 +85,7 @@ test('Creating a project can fail with validation errors', function(assert) {
     page.projectForm.clickSubmit();
   });
 
-  andThen(() => assert.equal(page.projectForm.errors().count, 6));
+  andThen(() => assert.equal(page.projectForm.errors.length, 6));
 });
 
 test('Creating a project can fail with an unknown error', function(assert) {
@@ -118,7 +118,7 @@ test('Creating a project can fail with an unknown error', function(assert) {
     page.projectForm.clickSubmit();
   });
 
-  andThen(() => assert.equal(page.flashMessages().count, 1, 'A flash was displayed'));
+  andThen(() => assert.equal(page.flashMessages.length, 1, 'A flash was displayed'));
 });
 
 test('A user can copy details from their organization', function(assert) {
@@ -172,23 +172,23 @@ test('A user can create a project', function(assert) {
   });
 
   andThen(() => {
-    page.projectForm.categoryCheckboxes.checkboxes(0).label.click();
+    page.projectForm.categoryCheckboxes.checkboxes.objectAt(0).label.click();
   });
 
   andThen(() => {
-    assert.ok(page.projectForm.categoryCheckboxes.checkboxes(0).isChecked, 'The category was added.');
+    assert.ok(page.projectForm.categoryCheckboxes.checkboxes.objectAt(0).isChecked, 'The category was added.');
 
     page.projectForm.skillsTypeahead.searchFor('ru');
   });
 
   andThen(() => {
     focus('input');
-    assert.equal(page.projectForm.skillsTypeahead.dropdown.inputItems(0).text, 'Ruby', 'The text in the typeahead matches the searched text');
-    page.projectForm.skillsTypeahead.dropdown.inputItems(0).click();
+    assert.equal(page.projectForm.skillsTypeahead.dropdown.inputItems.objectAt(0).text, 'Ruby', 'The text in the typeahead matches the searched text');
+    page.projectForm.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(page.projectForm.skillsList(0).text, 'Ruby', 'The skill was added to the list');
+    assert.equal(page.projectForm.skillsList.objectAt(0).text, 'Ruby', 'The skill was added to the list');
 
     page.projectForm
       .inputTitle('Bar')

--- a/tests/acceptance/project-donation-goals-test.js
+++ b/tests/acceptance/project-donation-goals-test.js
@@ -45,7 +45,7 @@ test('it renders existing donation goals', function(assert) {
   projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.donationGoals().count, 3, 'All project donation goals are rendered');
+    assert.equal(projectSettingsDonationsPage.donationGoals.length, 3, 'All project donation goals are rendered');
   });
 });
 
@@ -59,8 +59,8 @@ test('it sets up a new unsaved donation goal if there are no donation goals, whi
   projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.editedDonationGoals().count, 1, 'A single edited donation goal form is rendered');
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    assert.equal(projectSettingsDonationsPage.editedDonationGoals.length, 1, 'A single edited donation goal form is rendered');
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
 
     form.amount(200);
     form.description('Lorem ipsum');
@@ -68,7 +68,7 @@ test('it sets up a new unsaved donation goal if there are no donation goals, whi
   });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals.length, 1, 'A single donation goal is rendered.');
     assert.equal(server.schema.donationGoals.all().models.length, 1, 'Donation goal has been saved.');
     // mirage doesn't support custom transforms, so we search by cents amount
     assert.ok(server.schema.donationGoals.findBy({ amount: 20000, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
@@ -87,7 +87,7 @@ test('it is possible to add a donation goal when donation goals already exists',
 
   andThen(() => {
     projectSettingsDonationsPage.clickAddNew();
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
 
     form.amount(200);
     form.description('Lorem ipsum');
@@ -95,7 +95,7 @@ test('it is possible to add a donation goal when donation goals already exists',
   });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.donationGoals().count, 2, 'Both donation goals are rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals.length, 2, 'Both donation goals are rendered.');
     assert.equal(server.schema.donationGoals.all().models.length, 2, 'Donation goal has been saved.');
     // mirage doesn't support custom transforms, so we search by cents amount
     assert.ok(server.schema.donationGoals.findBy({ amount: 20000, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
@@ -113,16 +113,16 @@ test('it allows editing of existing donation goals', function(assert) {
   projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
-    projectSettingsDonationsPage.donationGoals(0).clickEdit();
+    projectSettingsDonationsPage.donationGoals.objectAt(0).clickEdit();
 
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
     form.amount(200.50);
     form.description('Lorem ipsum');
     form.clickSave();
   });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'A single donation goal is rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals.length, 1, 'A single donation goal is rendered.');
     assert.equal(server.schema.donationGoals.all().models.length, 1, 'Donation goal has been saved as update.');
     // mirage doesn't support custom transforms, so we search by cents amount
     assert.ok(server.schema.donationGoals.findBy({ amount: 20050, description: 'Lorem ipsum' }), 'Attributes have been saved properly');
@@ -142,12 +142,12 @@ test('cancelling edit of an unsaved new goal removes that goal from the list', f
   andThen(() => {
     projectSettingsDonationsPage.clickAddNew();
 
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
     form.clickCancel();
   });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'New goal is not rendered anymore.');
+    assert.equal(projectSettingsDonationsPage.donationGoals.length, 1, 'New goal is not rendered anymore.');
   });
 });
 
@@ -162,14 +162,14 @@ test('cancelling edit of an unsaved existing goal keeps that goal in the list', 
   projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
-    projectSettingsDonationsPage.donationGoals(0).clickEdit();
+    projectSettingsDonationsPage.donationGoals.objectAt(0).clickEdit();
 
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
     form.clickCancel();
   });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.donationGoals().count, 1, 'Existing goal is still rendered.');
+    assert.equal(projectSettingsDonationsPage.donationGoals.length, 1, 'Existing goal is still rendered.');
   });
 });
 
@@ -256,16 +256,16 @@ test('it renders validation errors', function(assert) {
   projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
     form.clickSave();
   });
 
   andThen(() => {
-    let form = projectSettingsDonationsPage.editedDonationGoals(0);
+    let form = projectSettingsDonationsPage.editedDonationGoals.objectAt(0);
 
-    assert.equal(form.validationErrors().count, 2, 'Both validation errors are rendered.');
-    assert.equal(form.validationErrors(0).message, 'Amount is required');
-    assert.equal(form.validationErrors(1).message, 'Description is required');
+    assert.equal(form.validationErrors.length, 2, 'Both validation errors are rendered.');
+    assert.equal(form.validationErrors.objectAt(0).message, 'Amount is required');
+    assert.equal(form.validationErrors.objectAt(1).message, 'Description is required');
   });
 });
 
@@ -293,10 +293,10 @@ test('it renders other errors', function(assert) {
   projectSettingsDonationsPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(() => {
-    projectSettingsDonationsPage.editedDonationGoals(0).clickSave();
+    projectSettingsDonationsPage.editedDonationGoals.objectAt(0).clickSave();
   });
 
   andThen(() => {
-    assert.equal(projectSettingsDonationsPage.errorFormatter.errors().count, 1, 'The error is displayed');
+    assert.equal(projectSettingsDonationsPage.errorFormatter.errors.length, 1, 'The error is displayed');
   });
 });

--- a/tests/acceptance/project-people-test.js
+++ b/tests/acceptance/project-people-test.js
@@ -61,17 +61,17 @@ test('Lists owner when owner is the only contributor.', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), urlParts.url);
 
-    assert.ok(page.admins().isEmpty, 'Admins list is empty');
-    assert.equal(page.admins().count, 0, 'Admins has no users listed');
+    assert.ok(page.adminSection.isEmpty, 'Admins list is empty');
+    assert.equal(page.adminSection.users.length, 0, 'Admins has no users listed');
 
-    assert.ok(page.others().isEmpty, 'Others list is empty');
-    assert.equal(page.others().count, 0, 'Others has no users listed');
+    assert.ok(page.contributorSection.isEmpty, 'Others list is empty');
+    assert.equal(page.contributorSection.users.length, 0, 'Others has no users listed');
 
-    assert.notOk(page.owners().isEmpty, 'Owners list is NOT empty');
-    assert.equal(page.owners().count, 1, 'Owners has 1 user listed');
+    assert.notOk(page.ownerSection.isEmpty, 'Owners list is NOT empty');
+    assert.equal(page.ownerSection.users.length, 1, 'Owners has 1 user listed');
 
-    assert.ok(page.pendingContributors().isEmpty, 'Pending contributors list is empty');
-    assert.equal(page.pendingContributors().count, 0, 'Pending contributors has no users listed');
+    assert.ok(page.pendingSection.isEmpty, 'Pending contributors list is empty');
+    assert.equal(page.pendingSection.users.length, 0, 'Pending contributors has no users listed');
   });
 });
 
@@ -99,41 +99,41 @@ test('lists multiple contributors if they exist', function(assert) {
 
     assert.equal(page.projectMenu.peopleLink.infoText, '2 pending');
 
-    assert.notOk(page.admins().isEmpty, 'Admins list is not empty');
-    assert.equal(page.admins().count, 1, 'Admins has 1 user listed');
+    assert.notOk(page.adminSection.isEmpty, 'Admins list is not empty');
+    assert.equal(page.adminSection.users.length, 1, 'Admins has 1 user listed');
 
-    assert.notOk(page.others().isEmpty, 'Others list is not empty');
-    assert.equal(page.others().count, 1, 'Others has 1 user listed');
+    assert.notOk(page.contributorSection.isEmpty, 'Others list is not empty');
+    assert.equal(page.contributorSection.users.length, 1, 'Others has 1 user listed');
 
-    assert.notOk(page.owners().isEmpty, 'Owners list is not empty');
-    assert.equal(page.owners().count, 1, 'Owners has 1 user listed');
+    assert.notOk(page.ownerSection.isEmpty, 'Owners list is not empty');
+    assert.equal(page.ownerSection.users.length, 1, 'Owners has 1 user listed');
 
-    assert.notOk(page.pendingContributors().isEmpty, 'Pending contributors list is not empty');
-    assert.equal(page.pendingContributors().count, 2, 'Pending contributors has 2 users listed');
-    page.pendingContributors(0).approveButton.click();
+    assert.notOk(page.pendingSection.isEmpty, 'Pending contributors list is not empty');
+    assert.equal(page.pendingSection.users.length, 2, 'Pending contributors has 2 users listed');
+    page.pendingSection.users.objectAt(0).approveButton.click();
   });
 
   andThen(function() {
     assert.equal(page.projectMenu.peopleLink.infoText, '1 pending');
-    assert.equal(page.pendingContributors().count, 1, 'Pending contributors has 1 user listed');
-    assert.equal(page.others().count, 2, 'Others has 2 users listed');
+    assert.equal(page.pendingSection.users.length, 1, 'Pending contributors has 1 user listed');
+    assert.equal(page.contributorSection.users.length, 2, 'Others has 2 users listed');
 
-    page.pendingContributors(0).denyButton.click();
+    page.pendingSection.users.objectAt(0).denyButton.click();
   });
 
   andThen(function() {
     assert.notOk(page.projectMenu.peopleLink.infoVisible);
-    assert.equal(page.pendingContributors().count, 0, 'Pending contributors has no users listed');
-    assert.equal(page.others().count, 2, 'Others has 2 users listed');
+    assert.equal(page.pendingSection.users.length, 0, 'Pending contributors has no users listed');
+    assert.equal(page.contributorSection.users.length, 2, 'Others has 2 users listed');
 
-    page.others(0).projectUserRoleModal.openButton.click();
-    page.others(0).projectUserRoleModal.modal.radioGroupAdmin.radioButton.click();
-    page.others(0).projectUserRoleModal.modal.save();
+    page.contributorSection.users.objectAt(0).projectUserRoleModal.openButton.click();
+    page.contributorSection.users.objectAt(0).projectUserRoleModal.modal.radioGroupAdmin.radioButton.click();
+    page.contributorSection.users.objectAt(0).projectUserRoleModal.modal.save();
   });
 
   andThen(function() {
-    assert.equal(page.admins().count, 2, 'Admins has 2 users listed');
-    assert.equal(page.others().count, 1, 'Others has 1 user listed');
+    assert.equal(page.adminSection.users.length, 2, 'Admins has 2 users listed');
+    assert.equal(page.contributorSection.users.length, 1, 'Others has 1 user listed');
     stub.restore();
   });
 });
@@ -152,18 +152,18 @@ test('A project admin can message a member', function(assert) {
   page.visit(urlParts.args);
 
   andThen(() => {
-    page.others(0).newConversationModal.openButton.click();
+    page.contributorSection.users.objectAt(0).newConversationModal.openButton.click();
   });
 
   andThen(() => {
-    assert.ok(page.others(0).newConversationModal.modal.isVisible, 'The modal is visible');
-    page.others(0).newConversationModal.modal.subject.fillIn('Test message');
-    page.others(0).newConversationModal.modal.body.fillIn('Lorem ipsum');
-    page.others(0).newConversationModal.modal.save();
+    assert.ok(page.contributorSection.users.objectAt(0).newConversationModal.modal.isVisible, 'The modal is visible');
+    page.contributorSection.users.objectAt(0).newConversationModal.modal.subject.fillIn('Test message');
+    page.contributorSection.users.objectAt(0).newConversationModal.modal.body.fillIn('Lorem ipsum');
+    page.contributorSection.users.objectAt(0).newConversationModal.modal.save();
   });
 
   andThen(() => {
-    assert.notOk(page.others(0).newConversationModal.modal.isVisible, 'The modal closed');
+    assert.notOk(page.contributorSection.users.objectAt(0).newConversationModal.modal.isVisible, 'The modal closed');
     let message = server.schema.messages.findBy({ authorId: user.id });
     assert.ok(message, 'Created the message');
   });

--- a/tests/acceptance/project-settings-integrations-test.js
+++ b/tests/acceptance/project-settings-integrations-test.js
@@ -75,31 +75,31 @@ test('it allows connecting and unconnecting installations', function(assert) {
 
   andThen(() => {
     assert.equal(
-      projectIntegrationsPage.unconnectedInstallations().count, 1,
+      projectIntegrationsPage.unconnectedInstallations.length, 1,
       'Installation is initially rendered as unconnected.'
     );
-    projectIntegrationsPage.unconnectedInstallations(0).connect.click();
+    projectIntegrationsPage.unconnectedInstallations.objectAt(0).connect.click();
   });
 
   andThen(() => {
     assert.equal(
-      projectIntegrationsPage.unconnectedInstallations().count, 0,
+      projectIntegrationsPage.unconnectedInstallations.length, 0,
       'Upon hitting "connect", installation is no longer rendered as unconnected.'
     );
     assert.equal(
-      projectIntegrationsPage.connectedInstallations().count, 1,
+      projectIntegrationsPage.connectedInstallations.length, 1,
       'Upon hitting "connect", installation is now rendered as connected.'
     );
-    projectIntegrationsPage.connectedInstallations(0).disconnect.click();
+    projectIntegrationsPage.connectedInstallations.objectAt(0).disconnect.click();
   });
 
   andThen(() => {
     assert.equal(
-      projectIntegrationsPage.connectedInstallations().count, 0,
+      projectIntegrationsPage.connectedInstallations.length, 0,
       'Upon hitting "disconnect", installation is no longer rendered as connected.'
     );
     assert.equal(
-      projectIntegrationsPage.unconnectedInstallations().count, 1,
+      projectIntegrationsPage.unconnectedInstallations.length, 1,
       'Upon hitting "disconnect", innstallation is now rendered as unconnected again.'
     );
   });
@@ -124,63 +124,63 @@ test('it allows connecting and unconnecting repos for a connected installation',
 
   andThen(() => {
     assert.equal(
-      projectIntegrationsPage.connectedInstallations().count, 1,
+      projectIntegrationsPage.connectedInstallations.length, 1,
       'Installation is initially rendered as connected.'
     );
 
-    projectIntegrationsPage.connectedInstallations(0).as((installation) => {
-      assert.equal(installation.githubRepos().count, 1, 'Github repo is rendered');
+    projectIntegrationsPage.connectedInstallations.objectAt(0).as((installation) => {
+      assert.equal(installation.githubRepos.length, 1, 'Github repo is rendered');
       assert.ok(
-        installation.githubRepos(0).actions.connect.isVisible,
+        installation.githubRepos.objectAt(0).actions.connect.isVisible,
         'Github repo is unconnected, so "connect" is visible'
       );
-      installation.githubRepos(0).actions.connect.click();
-      installation.githubRepos(0).callout.button.click();
+      installation.githubRepos.objectAt(0).actions.connect.click();
+      installation.githubRepos.objectAt(0).callout.button.click();
     });
   });
 
   andThen(() => {
     assert.equal(
-      projectIntegrationsPage.connectedInstallations().count, 1,
+      projectIntegrationsPage.connectedInstallations.length, 1,
       'Installation is still rendered as connected, after connecting repo.'
     );
 
-    projectIntegrationsPage.connectedInstallations(0).as((installation) => {
+    projectIntegrationsPage.connectedInstallations.objectAt(0).as((installation) => {
       assert.equal(
-        installation.githubRepos().count, 1,
+        installation.githubRepos.length, 1,
         'Github repo is still rendered after connecting it.'
       );
       assert.notOk(
-        installation.githubRepos(0).actions.connect.isVisible,
+        installation.githubRepos.objectAt(0).actions.connect.isVisible,
         'Github repo is now connected, so "connect" is no longer visible'
       );
       assert.ok(
-        installation.githubRepos(0).actions.edit.isVisible,
+        installation.githubRepos.objectAt(0).actions.edit.isVisible,
         'Github repo is now connected, so "edit" is visible'
       );
-      installation.githubRepos(0).click();
-      installation.githubRepos(0).callout.repoDisconnectConfirmModal.openButton.click();
-      installation.githubRepos(0).callout.repoDisconnectConfirmModal.modal.input.fillIn('code-corps-ember');
-      installation.githubRepos(0).callout.repoDisconnectConfirmModal.modal.disconnectButton.click();
+      installation.githubRepos.objectAt(0).click();
+      installation.githubRepos.objectAt(0).callout.repoDisconnectConfirmModal.openButton.click();
+      installation.githubRepos.objectAt(0).callout.repoDisconnectConfirmModal.modal.input.fillIn('code-corps-ember');
+      installation.githubRepos.objectAt(0).callout.repoDisconnectConfirmModal.modal.disconnectButton.click();
     });
   });
 
   andThen(() => {
     assert.equal(
-      projectIntegrationsPage.connectedInstallations().count, 1,
+      projectIntegrationsPage.connectedInstallations.length, 1,
       'Installation is still rendered as connected, after disconnecting again.'
     );
 
-    projectIntegrationsPage.connectedInstallations(0).as((installation) => {
+    projectIntegrationsPage.connectedInstallations.objectAt(0).as((installation) => {
       assert.equal(
-        installation.githubRepos().count, 1,
+        installation.githubRepos.length, 1,
         'Github repo is still rendered, after disconnecting it again.');
       assert.ok(
-        installation.githubRepos(0).actions.connect.isVisible,
+        installation.githubRepos.objectAt(0).actions.connect.isVisible,
         'Github repo is now disconnected again, so "connect" is visible'
       );
       assert.notOk(
-        installation.githubRepos(0).actions.edit.isVisible,
+        installation.githubRepos.objectAt(0).actions.edit.isVisible,
         'Github repo is now disconnected again, so "edit" is no longer visible'
       );
     });

--- a/tests/acceptance/project-settings-test.js
+++ b/tests/acceptance/project-settings-test.js
@@ -101,18 +101,18 @@ test("it allows editing of project's categories for owners", function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), `${project.organization.slug}/${project.slug}/settings/profile`, 'The project settings profile page loaded');
-    assert.equal(projectSettingsPage.categoryCheckboxes.checkboxes(0).label.name, 'Technology', 'The checkbox renders');
-    projectSettingsPage.categoryCheckboxes.checkboxes(0).label.click();
+    assert.equal(projectSettingsPage.categoryCheckboxes.checkboxes.objectAt(0).label.name, 'Technology', 'The checkbox renders');
+    projectSettingsPage.categoryCheckboxes.checkboxes.objectAt(0).label.click();
   });
 
   andThen(() => {
-    assert.ok(projectSettingsPage.categoryCheckboxes.checkboxes(0).isChecked, 'The category was added.');
+    assert.ok(projectSettingsPage.categoryCheckboxes.checkboxes.objectAt(0).isChecked, 'The category was added.');
     assert.ok(server.schema.projectCategories.findBy(params), 'Project category was created.');
-    projectSettingsPage.categoryCheckboxes.checkboxes(0).label.click();
+    projectSettingsPage.categoryCheckboxes.checkboxes.objectAt(0).label.click();
   });
 
   andThen(() => {
-    assert.notOk(projectSettingsPage.categoryCheckboxes.checkboxes(0).isChecked, 'The category was removed.');
+    assert.notOk(projectSettingsPage.categoryCheckboxes.checkboxes.objectAt(0).isChecked, 'The category was removed.');
     assert.notOk(server.schema.projectCategories.findBy(params), 'Project category was deleted.');
   });
 });
@@ -136,16 +136,16 @@ test("it allows editing of project's skills for owners", function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), `${project.organization.slug}/${project.slug}/settings/profile`, 'The project settings profile page loaded');
-    assert.equal(projectSettingsPage.skillsTypeahead.dropdown.inputItems(0).text, 'Ruby', 'The text in the typeahead matches the searched text');
-    projectSettingsPage.skillsTypeahead.dropdown.inputItems(0).click();
+    assert.equal(projectSettingsPage.skillsTypeahead.dropdown.inputItems.objectAt(0).text, 'Ruby', 'The text in the typeahead matches the searched text');
+    projectSettingsPage.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(projectSettingsPage.projectSkillsList(0).text, 'Ruby', 'The skill was added to the list');
-    projectSettingsPage.projectSkillsList(0).click();
+    assert.equal(projectSettingsPage.projectSkillsList.objectAt(0).text, 'Ruby', 'The skill was added to the list');
+    projectSettingsPage.projectSkillsList.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(projectSettingsPage.projectSkillsList().count, 0, 'The skill was removed from the list');
+    assert.equal(projectSettingsPage.projectSkillsList.length, 0, 'The skill was removed from the list');
   });
 });

--- a/tests/acceptance/project-test.js
+++ b/tests/acceptance/project-test.js
@@ -15,8 +15,8 @@ test('It renders navigation properly', function(assert) {
   projectTasksIndexPage.visit({ organization: project.organization.slug, project: project.slug });
 
   andThen(function() {
-    assert.equal(projectTasksIndexPage.projectMenu.links(0).href, aboutURL, 'Link to about is properly rendered');
-    assert.equal(projectTasksIndexPage.projectMenu.links(1).href, tasksURL, 'Link to tasks is properly rendered');
+    assert.equal(projectTasksIndexPage.projectMenu.links.objectAt(0).href, aboutURL, 'Link to about is properly rendered');
+    assert.equal(projectTasksIndexPage.projectMenu.links.objectAt(1).href, tasksURL, 'Link to tasks is properly rendered');
   });
 });
 
@@ -44,17 +44,17 @@ test('Navigation works', function(assert) {
 
   andThen(function() {
     assert.equal(currentRouteName(), 'project.tasks.index');
-    assert.ok(projectTasksIndexPage.projectMenu.links(1).isActive, 'Tasks link is active');
-    projectTasksIndexPage.projectMenu.links(0).click();
+    assert.ok(projectTasksIndexPage.projectMenu.links.objectAt(1).isActive, 'Tasks link is active');
+    projectTasksIndexPage.projectMenu.links.objectAt(0).click();
   });
   andThen(() => {
     assert.equal(currentRouteName(), 'project.index');
-    assert.ok(projectTasksIndexPage.projectMenu.links(0).isActive, 'About link is active');
-    projectTasksIndexPage.projectMenu.links(1).click();
+    assert.ok(projectTasksIndexPage.projectMenu.links.objectAt(0).isActive, 'About link is active');
+    projectTasksIndexPage.projectMenu.links.objectAt(1).click();
   });
   andThen(() => {
     assert.equal(currentRouteName(), 'project.tasks.index');
-    assert.ok(projectTasksIndexPage.projectMenu.links(1).isActive, 'Tasks link is active');
+    assert.ok(projectTasksIndexPage.projectMenu.links.objectAt(1).isActive, 'Tasks link is active');
   });
 });
 

--- a/tests/acceptance/projects-test.js
+++ b/tests/acceptance/projects-test.js
@@ -34,8 +34,8 @@ test('project users are displayed correctly', function(assert) {
 
   projectsPage.visit();
   andThen(() => {
-    assert.equal(projectsPage.projects(0).projectUsers.users().count, 8, '8 users are rendered');
-    assert.equal(projectsPage.projects(0).projectUsers.userCount.text, '+2 more', 'The "+2 more" text is rendered');
+    assert.equal(projectsPage.projects.objectAt(0).projectUsers.users.length, 8, '8 users are rendered');
+    assert.equal(projectsPage.projects.objectAt(0).projectUsers.userCount.text, '+2 more', 'The "+2 more" text is rendered');
   });
 });
 
@@ -49,8 +49,8 @@ test('an authenticated user can quickly join a project', function(assert) {
   projectsPage.visit();
 
   andThen(() => {
-    projectsPage.projects(0).projectJoinModal.openButton.click();
-    projectsPage.projects(0).projectJoinModal.modal.joinProjectButton.click();
+    projectsPage.projects.objectAt(0).projectJoinModal.openButton.click();
+    projectsPage.projects.objectAt(0).projectJoinModal.modal.joinProjectButton.click();
   });
 
   andThen(() => {

--- a/tests/acceptance/settings-profile-test.js
+++ b/tests/acceptance/settings-profile-test.js
@@ -99,18 +99,18 @@ test("it allows editing of project's categories for owners", function(assert) {
   settingsProfilePage.visit();
 
   andThen(() => {
-    assert.equal(settingsProfilePage.categoryCheckboxes.checkboxes(0).label.name, 'Technology', 'The checkbox renders');
-    settingsProfilePage.categoryCheckboxes.checkboxes(0).label.click();
+    assert.equal(settingsProfilePage.categoryCheckboxes.checkboxes.objectAt(0).label.name, 'Technology', 'The checkbox renders');
+    settingsProfilePage.categoryCheckboxes.checkboxes.objectAt(0).label.click();
   });
 
   andThen(() => {
-    assert.ok(settingsProfilePage.categoryCheckboxes.checkboxes(0).isChecked, 'The category was added.');
+    assert.ok(settingsProfilePage.categoryCheckboxes.checkboxes.objectAt(0).isChecked, 'The category was added.');
     assert.ok(server.schema.userCategories.findBy(params), 'User category was created.');
-    settingsProfilePage.categoryCheckboxes.checkboxes(0).label.click();
+    settingsProfilePage.categoryCheckboxes.checkboxes.objectAt(0).label.click();
   });
 
   andThen(() => {
-    assert.notOk(settingsProfilePage.categoryCheckboxes.checkboxes(0).isChecked, 'The category was removed.');
+    assert.notOk(settingsProfilePage.categoryCheckboxes.checkboxes.objectAt(0).isChecked, 'The category was removed.');
     assert.notOk(server.schema.userCategories.findBy(params), 'User category was deleted.');
   });
 });
@@ -130,16 +130,16 @@ test("it allows editing of user's skills", function(assert) {
   });
 
   andThen(() => {
-    assert.equal(settingsProfilePage.skillsTypeahead.dropdown.inputItems(0).text, 'Ruby', 'The text in the typeahead matches the searched text');
-    settingsProfilePage.skillsTypeahead.dropdown.inputItems(0).click();
+    assert.equal(settingsProfilePage.skillsTypeahead.dropdown.inputItems.objectAt(0).text, 'Ruby', 'The text in the typeahead matches the searched text');
+    settingsProfilePage.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(settingsProfilePage.userSkillsList(0).text, 'Ruby', 'The skill was added to the list');
-    settingsProfilePage.userSkillsList(0).click();
+    assert.equal(settingsProfilePage.userSkillsList.objectAt(0).text, 'Ruby', 'The skill was added to the list');
+    settingsProfilePage.userSkillsList.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(settingsProfilePage.userSkillsList().count, 0, 'The skill was removed from the list');
+    assert.equal(settingsProfilePage.userSkillsList.length, 0, 'The skill was removed from the list');
   });
 });

--- a/tests/acceptance/task-comments-test.js
+++ b/tests/acceptance/task-comments-test.js
@@ -22,7 +22,7 @@ test('Task comments are displayed correctly', function(assert) {
   });
 
   andThen(() => {
-    assert.equal(taskPage.taskCommentList.comments().count, 4, 'The correct number of task comments is rendered');
+    assert.equal(taskPage.taskCommentList.comments.length, 4, 'The correct number of task comments is rendered');
   });
 });
 
@@ -50,7 +50,7 @@ test('A comment can be added to a task', function(assert) {
 
   andThen(() => {
     assert.equal(server.schema.comments.all().models.length, 1, 'A new comment was created');
-    assert.equal(taskPage.taskCommentList.comments().count, 1, 'The comment is being rendered');
+    assert.equal(taskPage.taskCommentList.comments.length, 1, 'The comment is being rendered');
     let [comment] = server.schema.comments.all().models;
 
     assert.equal(comment.markdown, 'Test markdown', 'New comment has the correct markdown');
@@ -170,7 +170,7 @@ test('When comment creation fails due to validation, validation errors are displ
   });
 
   andThen(() => {
-    assert.equal(taskPage.createCommentForm.errors().count, 2, 'Validation errors are rendered');
+    assert.equal(taskPage.createCommentForm.errors.length, 2, 'Validation errors are rendered');
   });
 });
 
@@ -210,8 +210,8 @@ test('When comment creation fails due to non-validation issues, the error is dis
   });
 
   andThen(() => {
-    assert.equal(taskPage.errors().count, 1);
-    assert.equal(taskPage.errors(0).text, 'An unknown error: Something happened', 'The  error is rendered');
+    assert.equal(taskPage.errors.length, 1);
+    assert.equal(taskPage.errors.objectAt(0).text, 'An unknown error: Something happened', 'The  error is rendered');
   });
 });
 

--- a/tests/acceptance/task-creation-test.js
+++ b/tests/acceptance/task-creation-test.js
@@ -190,7 +190,7 @@ test('When task creation fails due to validation, validation errors are displaye
     projectTasksNewPage.clickSubmit();
   });
 
-  andThen(() => assert.equal(projectTasksNewPage.errors().count, 2));
+  andThen(() => assert.equal(projectTasksNewPage.errors.length, 2));
 });
 
 test('When task creation fails due to non-validation issues, the error is displayed', function(assert) {
@@ -227,8 +227,8 @@ test('When task creation fails due to non-validation issues, the error is displa
   });
 
   andThen(() => {
-    assert.equal(projectTasksNewPage.errors().count, 1);
-    assert.ok(projectTasksNewPage.errors().contains('An unknown error: Something happened', 'The error is messaged'));
+    assert.equal(projectTasksNewPage.errors.length, 1);
+    assert.ok(projectTasksNewPage.errors.objectAt(0).contains('An unknown error: Something happened', 'The error is messaged'));
   });
 });
 
@@ -254,12 +254,12 @@ test('Navigating away from task route destroys task with prompt', function(asser
   });
 
   andThen(() => {
-    projectTasksNewPage.projectMenu.links(1).click();
+    projectTasksNewPage.projectMenu.links.objectAt(1).click();
   });
 
   andThen(() => {
     assert.equal(
-      projectTasksIndexPage.taskBoard.taskLists(0).taskCards().count,
+      projectTasksIndexPage.taskBoard.taskLists.objectAt(0).taskCards.length,
       0,
       'The task was removed from the list.'
     );
@@ -290,7 +290,7 @@ test('Navigation is aborted if user answers negatively to prompt', function(asse
   });
 
   andThen(() => {
-    projectTasksNewPage.projectMenu.links(1).click();
+    projectTasksNewPage.projectMenu.links.objectAt(1).click();
   });
 
   andThen(() => {
@@ -336,12 +336,12 @@ test('Skills can be assigned to task during creation', function(assert) {
 
   andThen(() => {
     // add skill
-    projectTasksNewPage.skillsTypeahead.dropdown.inputItems(0).click();
+    projectTasksNewPage.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
     // add skill from project skill list
-    projectTasksNewPage.projectSkillsList.skills(0).click();
+    projectTasksNewPage.projectSkillsList.skills.objectAt(0).click();
   });
 
   andThen(() => {

--- a/tests/acceptance/task-editing-test.js
+++ b/tests/acceptance/task-editing-test.js
@@ -287,19 +287,19 @@ test('Skills can be assigned or unassigned to/from task', function(assert) {
   });
 
   andThen(() => {
-    assert.equal(taskPage.skillsTypeahead.dropdown.inputItems().count, 1);
-    assert.equal(taskPage.skillsTypeahead.dropdown.inputItems(0).text, 'Ruby');
-    taskPage.skillsTypeahead.dropdown.inputItems(0).click();
+    assert.equal(taskPage.skillsTypeahead.dropdown.inputItems.length, 1);
+    assert.equal(taskPage.skillsTypeahead.dropdown.inputItems.objectAt(0).text, 'Ruby');
+    taskPage.skillsTypeahead.dropdown.inputItems.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(taskPage.taskSkillsList().count, 1);
-    assert.equal(taskPage.taskSkillsList(0).text, 'Ruby');
-    taskPage.taskSkillsList(0).click();
+    assert.equal(taskPage.taskSkillsList.length, 1);
+    assert.equal(taskPage.taskSkillsList.objectAt(0).text, 'Ruby');
+    taskPage.taskSkillsList.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(taskPage.taskSkillsList().count, 0);
+    assert.equal(taskPage.taskSkillsList.length, 0);
     done();
   });
 });

--- a/tests/acceptance/task-list-test.js
+++ b/tests/acceptance/task-list-test.js
@@ -46,7 +46,7 @@ test('member can assign/reassign/unassign tasks to user', function(assert) {
   });
 
   andThen(() => {
-    taskCard = page.taskBoard.taskLists(0).taskCards(0);
+    taskCard = page.taskBoard.taskLists.objectAt(0).taskCards.objectAt(0);
     assert.ok(taskCard.taskAssignment.select.trigger.unassigned, 'Task is rendered unassigned.');
     taskCard.mouseenter();
     taskCard.triggerKeyDown('Space');
@@ -62,7 +62,7 @@ test('member can assign/reassign/unassign tasks to user', function(assert) {
   });
 
   andThen(() => {
-    taskCard.taskAssignment.select.dropdown.options(1).select();
+    taskCard.taskAssignment.select.dropdown.options.objectAt(1).select();
   });
 
   andThen(() => {
@@ -74,7 +74,7 @@ test('member can assign/reassign/unassign tasks to user', function(assert) {
   });
 
   andThen(() => {
-    taskCard.taskAssignment.select.dropdown.options(1).select();
+    taskCard.taskAssignment.select.dropdown.options.objectAt(1).select();
   });
 
   andThen(() => {
@@ -118,6 +118,6 @@ test('clicking a task card is tracked', function(assert) {
   this.application.inject('route', 'metrics', 'service:stubMetrics');
 
   andThen(() => {
-    page.taskBoard.taskLists(0).taskCards(0).title.click();
+    page.taskBoard.taskLists.objectAt(0).taskCards.objectAt(0).title.click();
   });
 });

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -10,8 +10,8 @@ test('visiting /team', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), '/team');
     assert.equal(teamPage.company.header, 'Our Team');
-    assert.equal(teamPage.company.items().count, 3);
+    assert.equal(teamPage.company.items.length, 3);
     assert.equal(teamPage.contributors.header, 'Our Volunteers');
-    assert.equal(teamPage.contributors.items().count, 29);
+    assert.equal(teamPage.contributors.items.length, 29);
   });
 });

--- a/tests/acceptance/user-conversations-test.js
+++ b/tests/acceptance/user-conversations-test.js
@@ -37,11 +37,11 @@ test('User can view list of their own conversations', function(assert) {
   page.visit();
 
   andThen(() => {
-    assert.equal(page.conversations().count, 3, 'Conversations are rendered');
+    assert.equal(page.conversations.length, 3, 'Conversations are rendered');
     let renderedTimeStampOrder = [
-      page.conversations(0).updatedAt.text,
-      page.conversations(1).updatedAt.text,
-      page.conversations(2).updatedAt.text
+      page.conversations.objectAt(0).updatedAt.text,
+      page.conversations.objectAt(1).updatedAt.text,
+      page.conversations.objectAt(2).updatedAt.text
     ];
 
     let expectedTimeStampOrder = [
@@ -70,7 +70,7 @@ test('User can view single conversations', function(assert) {
   page.visit();
 
   andThen(() => {
-    page.conversations(0).click();
+    page.conversations.objectAt(0).click();
   });
 
   andThen(() => {
@@ -79,9 +79,9 @@ test('User can view single conversations', function(assert) {
     let conversation = store.peekRecord('conversation', server.db.conversations[0].id);
     let firstPart = conversation.get('sortedConversationParts').get('firstObject');
     let lastPart = conversation.get('sortedConversationParts').get('lastObject');
-    assert.equal(page.conversationThread.conversationParts().count, 11, 'Message head and conversation parts rendered');
-    assert.equal(page.conversationThread.conversationParts(1).body.text, firstPart.get('body'), 'first conversation part is rendered correctly');
-    assert.equal(page.conversationThread.conversationParts(10).body.text, lastPart.get('body'), 'last conversation part is rendered correctly');
+    assert.equal(page.conversationThread.conversationParts.length, 11, 'Message head and conversation parts rendered');
+    assert.equal(page.conversationThread.conversationParts.objectAt(1).body.text, firstPart.get('body'), 'first conversation part is rendered correctly');
+    assert.equal(page.conversationThread.conversationParts.objectAt(10).body.text, lastPart.get('body'), 'last conversation part is rendered correctly');
     assert.ok(firstPart.get('insertedAt') < lastPart.get('insertedAt'), 'conversations are sorted correctly');
   });
 });
@@ -97,16 +97,16 @@ test('System is notified of new conversation part', function(assert) {
   page.visit();
 
   andThen(() => {
-    page.conversations(0).click();
+    page.conversations.objectAt(0).click();
   });
 
   andThen(() => {
-    assert.equal(page.conversationThread.conversationParts().count, 1, 'Just the message head is rendered.');
+    assert.equal(page.conversationThread.conversationParts.length, 1, 'Just the message head is rendered.');
     server.create('conversation-part', { conversation });
   });
 
   andThen(() => {
-    assert.equal(page.conversationThread.conversationParts().count, 1, 'No notification yet, so new part was not rendered.');
+    assert.equal(page.conversationThread.conversationParts.length, 1, 'No notification yet, so new part was not rendered.');
     let conversationChannelService = this.application.__container__.lookup('service:conversation-channel');
     let socket = get(conversationChannelService, 'socket.socket');
     let [channel] = socket.channels;
@@ -114,7 +114,7 @@ test('System is notified of new conversation part', function(assert) {
   });
 
   andThen(() => {
-    assert.equal(page.conversationThread.conversationParts().count, 2, 'Notification was sent. New part is rendered.');
+    assert.equal(page.conversationThread.conversationParts.length, 2, 'Notification was sent. New part is rendered.');
   });
 });
 
@@ -129,7 +129,7 @@ test('User can post to a conversation', function(assert) {
   page.visit();
 
   andThen(() => {
-    page.conversations(0).click();
+    page.conversations.objectAt(0).click();
   });
 
   andThen(() => {

--- a/tests/integration/components/animated-high-five-test.js
+++ b/tests/integration/components/animated-high-five-test.js
@@ -16,7 +16,7 @@ moduleForComponent('animated-high-five', 'Integration | Component | animated hig
 });
 
 test('it changes the initial and follow on animation classes when clicked', function(assert) {
-  page.render(hbs`{{animated-high-five}}`);
+  this.render(hbs`{{animated-high-five}}`);
 
   assert.ok(page.isInitialAnimation);
   assert.notOk(page.isFollowOnAnimation);

--- a/tests/integration/components/categories-list-test.js
+++ b/tests/integration/components/categories-list-test.js
@@ -38,10 +38,10 @@ test('it renders the categories and sorts them by name', function(assert) {
   ];
 
   this.set('categories', categories);
-  page.render(hbs`{{categories-list categories=categories}}`);
+  this.render(hbs`{{categories-list categories=categories}}`);
 
-  assert.equal(page.items().count, 3);
-  assert.equal(page.items(0).name, 'Alphabets');
-  assert.equal(page.items(1).name, 'Society');
-  assert.equal(page.items(2).name, 'Zoology');
+  assert.equal(page.items.length, 3);
+  assert.equal(page.items.objectAt(0).name, 'Alphabets');
+  assert.equal(page.items.objectAt(1).name, 'Society');
+  assert.equal(page.items.objectAt(2).name, 'Zoology');
 });

--- a/tests/integration/components/category-checkboxes-test.js
+++ b/tests/integration/components/category-checkboxes-test.js
@@ -6,16 +6,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{category-checkboxes
-      options=options
-      selection=selection
-      updateCategories=updateCategories
-    }}
-  `);
-}
-
 moduleForComponent('category-checkboxes', 'Integration | Component | category checkboxes', {
   integration: true,
   beforeEach() {
@@ -39,12 +29,18 @@ test('it works for unselecting selected categories', function(assert) {
     assert.ok(true);
   });
 
-  renderPage();
+  this.render(hbs`
+    {{category-checkboxes
+      options=options
+      selection=selection
+      updateCategories=updateCategories
+    }}
+  `);
 
-  assert.equal(page.checkboxes(0).label.name, 'Test', 'Renders the name');
-  assert.ok(page.checkboxes(0).isChecked, 'Checkbox is checked');
-  page.checkboxes(0).label.click();
-  assert.notOk(page.checkboxes(0).isChecked, 'Checkbox is not checked');
+  assert.equal(page.checkboxes.objectAt(0).label.name, 'Test', 'Renders the name');
+  assert.ok(page.checkboxes.objectAt(0).isChecked, 'Checkbox is checked');
+  page.checkboxes.objectAt(0).label.click();
+  assert.notOk(page.checkboxes.objectAt(0).isChecked, 'Checkbox is not checked');
 });
 
 test('it works for selecting unselected categories', function(assert) {
@@ -60,10 +56,16 @@ test('it works for selecting unselected categories', function(assert) {
     assert.ok(true);
   });
 
-  renderPage();
+  this.render(hbs`
+    {{category-checkboxes
+      options=options
+      selection=selection
+      updateCategories=updateCategories
+    }}
+  `);
 
-  assert.equal(page.checkboxes(0).label.name, 'Test', 'Renders the name');
-  assert.notOk(page.checkboxes(0).isChecked, 'Checkbox is not checked');
-  page.checkboxes(0).label.click();
-  assert.ok(page.checkboxes(0).isChecked, 'Checkbox is checked');
+  assert.equal(page.checkboxes.objectAt(0).label.name, 'Test', 'Renders the name');
+  assert.notOk(page.checkboxes.objectAt(0).isChecked, 'Checkbox is not checked');
+  page.checkboxes.objectAt(0).label.click();
+  assert.ok(page.checkboxes.objectAt(0).isChecked, 'Checkbox is checked');
 });

--- a/tests/integration/components/category-item-test.js
+++ b/tests/integration/components/category-item-test.js
@@ -15,10 +15,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`{{category-item category=category}}`);
-}
-
 moduleForComponent('category-item', 'Integration | Component | category item', {
   integration: true,
   beforeEach() {
@@ -101,7 +97,7 @@ test('it works for selecting unselected categories', async function(assert) {
   stubService(this, 'user-categories', mockUserCategoriesService);
   set(this, 'category', unselectedCategory);
 
-  renderPage();
+  this.render(hbs`{{category-item category=category}}`);
 
   assert.ok(page.icon.classContains('technology'), 'renders the right icon');
   assert.notOk(page.icon.classContains('technology--selected'), 'is not selected');
@@ -119,7 +115,7 @@ test('it works for removing selected categories', function(assert) {
   stubService(this, 'user-categories', mockUserCategoriesService);
   this.set('category', selectedCategory);
 
-  renderPage();
+  this.render(hbs`{{category-item category=category}}`);
 
   assert.ok(page.icon.classContains('society--selected'), 'is selected');
   assert.equal(page.button.text, 'Society', 'Button text is rendered correctly.');
@@ -135,7 +131,7 @@ test('it creates a flash message on an error when adding', function(assert) {
   stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
   this.set('category', unselectedCategory);
 
-  renderPage();
+  this.render(hbs`{{category-item category=category}}`);
 
   page.button.click();
 
@@ -155,7 +151,7 @@ test('it creates a flash message on an error when removing', function(assert) {
   stubService(this, 'user-categories', mockUserCategoriesServiceForErrors);
   this.set('category', selectedCategory);
 
-  renderPage();
+  this.render(hbs`{{category-item category=category}}`);
 
   page.button.click();
 
@@ -175,7 +171,7 @@ test('it sets and unsets loading state when adding', async function(assert) {
   stubService(this, 'user-categories', mockUserCategoriesService);
   this.set('category', unselectedCategory);
 
-  renderPage();
+  this.render(hbs`{{category-item category=category}}`);
 
   let result = page.button.click();
 
@@ -192,7 +188,7 @@ test('it sets and unsets loading state when removing', async function(assert) {
   stubService(this, 'user-categories', mockUserCategoriesService);
   this.set('category', selectedCategory);
 
-  renderPage();
+  this.render(hbs`{{category-item category=category}}`);
 
   let result = page.button.click();
 

--- a/tests/integration/components/code-theme-selector-test.js
+++ b/tests/integration/components/code-theme-selector-test.js
@@ -24,7 +24,8 @@ test('it toggles code theme service when clicked', function(assert) {
       assert.ok(true, 'Code theme service was called');
     }
   });
-  page.render(hbs`{{code-theme-selector}}`);
+
+  this.render(hbs`{{code-theme-selector}}`);
 
   page.click();
 });
@@ -35,7 +36,8 @@ test('it has the class name from the service', function(assert) {
   stubService(this, 'code-theme', {
     className: 'light'
   });
-  page.render(hbs`{{code-theme-selector}}`);
+
+  this.render(hbs`{{code-theme-selector}}`);
 
   assert.ok(page.isLight);
 });

--- a/tests/integration/components/comment-item-test.js
+++ b/tests/integration/components/comment-item-test.js
@@ -9,10 +9,6 @@ import commentItemComponent from 'code-corps-ember/tests/pages/components/commen
 
 let page = PageObject.create(commentItemComponent);
 
-function renderPage() {
-  page.render(hbs`{{comment-item comment=comment}}`);
-}
-
 moduleForComponent('comment-item', 'Integration | Component | comment item', {
   integration: true,
   beforeEach() {
@@ -30,7 +26,7 @@ test('it renders all required comment elements properly', function(assert) {
 
   set(this, 'comment', comment);
 
-  renderPage();
+  this.render(hbs`{{comment-item comment=comment}}`);
 
   assert.equal(page.commentBody.text, '', 'The body is not initially rendered, since the comment has not loaded');
   assert.notOk(page.username.isVisible, 'The username of the comment author is not rendered, since the comment is not loaded yet');
@@ -66,7 +62,8 @@ test('it switches between editing and viewing mode', function(assert) {
   };
 
   set(this, 'comment', comment);
-  renderPage();
+
+  this.render(hbs`{{comment-item comment=comment}}`);
 
   page.clickEdit();
 
@@ -93,7 +90,7 @@ test('if the comment body is empty render null comment element', function(assert
 
   set(this, 'comment', comment);
 
-  renderPage();
+  this.render(hbs`{{comment-item comment=comment}}`);
 
   // this will trigger some promise resolving, so we wrap it in a loop
   run(this, () => {

--- a/tests/integration/components/common/busy-model-wrapper-test.js
+++ b/tests/integration/components/common/busy-model-wrapper-test.js
@@ -11,16 +11,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create({ scope: '.test-container' });
 
-function renderPage() {
-  page.render(hbs`
-    <div class="test-container">
-      {{#common/busy-model-wrapper model=model}}
-        Yielded
-      {{/common/busy-model-wrapper}}
-    </div>
-  `);
-}
-
 moduleForComponent('common/busy-model-wrapper', 'Integration | Component | common/busy model wrapper', {
   integration: true,
   beforeEach() {
@@ -35,7 +25,14 @@ test('it shows "Deleting" if model is saving and is deleted', function(assert) {
   let model = { isSaving: true, isDeleted: true };
   set(this, 'model', model);
 
-  renderPage();
+  this.render(hbs`
+    <div class="test-container">
+      {{#common/busy-model-wrapper model=model}}
+        Yielded
+      {{/common/busy-model-wrapper}}
+    </div>
+  `);
+
   assert.equal(page.text, 'Deleting...', 'A deletion indicator is rendered in place of the yielded block.');
 });
 
@@ -43,7 +40,14 @@ test('it shows "Saving" if model is saving and not deleted', function(assert) {
   let model = { isSaving: true, isDeleted: false };
   set(this, 'model', model);
 
-  renderPage();
+  this.render(hbs`
+    <div class="test-container">
+      {{#common/busy-model-wrapper model=model}}
+        Yielded
+      {{/common/busy-model-wrapper}}
+    </div>
+  `);
+
   assert.equal(page.text, 'Saving...', 'A deletion indicator is rendered in place of the yielded block.');
 });
 
@@ -51,6 +55,13 @@ test('it shows yield if model is neither saving or deleted', function(assert) {
   let model = { isSaving: false, isDeleted: false };
   set(this, 'model', model);
 
-  renderPage();
+  this.render(hbs`
+    <div class="test-container">
+      {{#common/busy-model-wrapper model=model}}
+        Yielded
+      {{/common/busy-model-wrapper}}
+    </div>
+  `);
+
   assert.equal(page.text, 'Yielded', 'The yielded block is rendered.');
 });

--- a/tests/integration/components/conversations/conversation-composer-test.js
+++ b/tests/integration/components/conversations/conversation-composer-test.js
@@ -8,12 +8,6 @@ import { reject, resolve } from 'rsvp';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-composer body=body onSend=onSend}}
-  `);
-}
-
 moduleForComponent('conversations/conversation-composer', 'Integration | Component | conversations/conversation composer', {
   integration: true,
   beforeEach() {
@@ -31,7 +25,9 @@ test('disables submit when body is blank', function(assert) {
   assert.expect(3);
   set(this, 'body', null);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-composer body=body onSend=onSend}}
+  `);
 
   assert.ok(page.submitButton.isDisabled, 'Submit is disabled if null');
   run(() => set(this, 'body', 'foo'));
@@ -49,7 +45,10 @@ test('sends out action and blanks out body when clicking submit', function(asser
     return resolve();
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-composer body=body onSend=onSend}}
+  `);
+
   assert.equal(page.submittableTextarea.value, 'foo', 'Body is rendered correctly.');
   page.submitButton.click();
   assert.equal(page.submittableTextarea.value, '', 'Body was blanked out.');
@@ -64,7 +63,10 @@ test('resets the body when promise rejects on clicking submit', async function(a
     return reject({ body });
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-composer body=body onSend=onSend}}
+  `);
+
   assert.equal(page.submittableTextarea.value, 'foo', 'Body is rendered correctly.');
   await page.submitButton.click();
   assert.equal(page.submittableTextarea.value, 'foo', 'Body was reset.');
@@ -79,7 +81,10 @@ test('sends out action and blanks out body when hitting enter key', function(ass
     return resolve();
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-composer body=body onSend=onSend}}
+  `);
+
   assert.equal(page.submittableTextarea.value, 'foo', 'Body is rendered correctly.');
   page.submittableTextarea.keySubmit();
   assert.equal(page.submittableTextarea.value, '', 'Body was blanked out.');

--- a/tests/integration/components/conversations/conversation-list-item-with-project-test.js
+++ b/tests/integration/components/conversations/conversation-list-item-with-project-test.js
@@ -7,14 +7,6 @@ import moment from 'moment';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-list-item-with-project
-      conversation=conversation
-    }}
-  `);
-}
-
 moduleForComponent('conversations/conversation-list-item-with-project', 'Integration | Component | conversations/conversation list item with project', {
   integration: true,
   beforeEach() {
@@ -44,7 +36,11 @@ test('it renders the conversation details', function(assert) {
 
   set(this, 'conversation', conversation);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-list-item-with-project
+      conversation=conversation
+    }}
+  `);
 
   assert.equal(page.project.photo.url, project.iconThumbUrl, 'The project icon renders');
   assert.equal(page.project.title.text, project.title, 'The project title renders');

--- a/tests/integration/components/conversations/conversation-list-item-with-user-test.js
+++ b/tests/integration/components/conversations/conversation-list-item-with-user-test.js
@@ -7,16 +7,6 @@ import moment from 'moment';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-list-item-with-user
-      close=onClose
-      reopen=onReopen
-      conversation=conversation
-    }}
-  `);
-}
-
 moduleForComponent('conversations/conversation-list-item-with-user', 'Integration | Component | conversations/conversation list item with user', {
   integration: true,
   beforeEach() {
@@ -46,7 +36,13 @@ test('it renders the conversation details', function(assert) {
 
   set(this, 'conversation', conversation);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-list-item-with-user
+      close=onClose
+      reopen=onReopen
+      conversation=conversation
+    }}
+  `);
 
   assert.equal(page.target.photo.url, user.photoThumbUrl, 'The target user photo renders');
   assert.equal(page.target.name.text, user.name, 'The target user name renders');
@@ -69,7 +65,13 @@ test('it renders close button when conversation is open', function(assert) {
 
   set(this, 'conversation', conversation);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-list-item-with-user
+      close=onClose
+      reopen=onReopen
+      conversation=conversation
+    }}
+  `);
 
   // we use isPresent because the buttons only display on hover and are
   // otherwise set to `display: none;`
@@ -92,7 +94,13 @@ test('it renders reopen button when conversation is closed', function(assert) {
 
   set(this, 'conversation', conversation);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-list-item-with-user
+      close=onClose
+      reopen=onReopen
+      conversation=conversation
+    }}
+  `);
 
   // we use isPresent because the buttons only display on hover and are
   // otherwise set to `display: none;`
@@ -120,7 +128,13 @@ test('it calls bound action when clicking close button', function(assert) {
     assert.equal(c, conversation, 'Action was called with correct argument');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-list-item-with-user
+      close=onClose
+      reopen=onReopen
+      conversation=conversation
+    }}
+  `);
 
   page.closeButton.click();
 });
@@ -144,7 +158,13 @@ test('it calls bound action when clicking reopen button', function(assert) {
     assert.equal(c, conversation, 'Action was called with correct argument');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-list-item-with-user
+      close=onClose
+      reopen=onReopen
+      conversation=conversation
+    }}
+  `);
 
   page.reopenButton.click();
 });

--- a/tests/integration/components/conversations/conversation-part-closed-test.js
+++ b/tests/integration/components/conversations/conversation-part-closed-test.js
@@ -8,15 +8,6 @@ import moment from 'moment';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-part-closed
-      author=author
-      closedAt=closedAt
-    }}
-  `);
-}
-
 moduleForComponent('conversations/conversation-part-closed', 'Integration | Component | conversations/conversation part closed', {
   integration: true,
   beforeEach() {
@@ -41,7 +32,12 @@ test('if current user closes message, "You closed this" is rendered', function(a
   let twoMinutesAgoFriendly = twoMinutesAgo.from();
   set(this, 'closedAt', twoMinutesAgo);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-closed
+      author=author
+      closedAt=closedAt
+    }}
+  `);
 
   let expectedText = `You closed this ${twoMinutesAgoFriendly}`;
   assert.equal(page.closedAt.text, expectedText, 'The closed at timestamp is rendered');
@@ -66,7 +62,12 @@ test('if someone other than the current user closes the message, "Author.usernam
   let twoMinutesAgoFriendly = twoMinutesAgo.from();
   set(this, 'closedAt', twoMinutesAgo);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-closed
+      author=author
+      closedAt=closedAt
+    }}
+  `);
 
   let expectedText = `${author.username} closed this ${twoMinutesAgoFriendly}`;
   assert.equal(page.closedAt.text, expectedText, 'The closed at timestamp is rendered');

--- a/tests/integration/components/conversations/conversation-part-comment-test.js
+++ b/tests/integration/components/conversations/conversation-part-comment-test.js
@@ -14,16 +14,6 @@ import {
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-part-comment
-      author=author
-      body=body
-      sentAt=sentAt
-    }}
-  `);
-}
-
 moduleForComponent('conversations/conversation-part-comment', 'Integration | Component | conversations/conversation part comment', {
   integration: true,
   beforeEach() {
@@ -49,7 +39,13 @@ test('it renders all the details', function(assert) {
   set(this, 'sentAt', moment().subtract(2, 'days'));
   stubService(this, 'current-user', { user: { id: 2 } });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-comment
+      author=author
+      body=body
+      sentAt=sentAt
+    }}
+  `);
 
   assert.equal(page.body.text, body, 'The body renders in the chat bubble');
   assert.equal(page.sentAt.text, '2 days ago', 'The sent at timestamp renders');
@@ -69,7 +65,13 @@ test('when the message has not been sent yet', function(assert) {
 
   set(this, 'sentAt', null);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-comment
+      author=author
+      body=body
+      sentAt=sentAt
+    }}
+  `);
 
   assert.equal(page.sentAt.text, 'Sending...', 'The message says sending');
 });
@@ -80,7 +82,13 @@ test('when the current user did not send the message', function(assert) {
   set(this, 'author', { id: 1 });
   stubService(this, 'current-user', { user: { id: 2 } });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-comment
+      author=author
+      body=body
+      sentAt=sentAt
+    }}
+  `);
 
   assert.notOk(page.isByCurrentUser, 'Does not have the current user styles');
 });
@@ -91,7 +99,13 @@ test('when the current user sent the message', function(assert) {
   set(this, 'author', { id: 1 });
   stubService(this, 'current-user', { user: { id: 1 } });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-comment
+      author=author
+      body=body
+      sentAt=sentAt
+    }}
+  `);
 
   assert.ok(page.isByCurrentUser, 'Has the current user styles');
 });

--- a/tests/integration/components/conversations/conversation-part-reopened-test.js
+++ b/tests/integration/components/conversations/conversation-part-reopened-test.js
@@ -8,15 +8,6 @@ import moment from 'moment';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-part-reopened
-      author=author
-      reopenedAt=reopenedAt
-    }}
-  `);
-}
-
 moduleForComponent('conversations/conversation-part-reopened', 'Integration | Component | conversations/conversation part reopened', {
   integration: true,
   beforeEach() {
@@ -41,7 +32,12 @@ test('if current user reopens message, "You reopened this" is rendered', functio
   let twoMinutesAgoFriendly = twoMinutesAgo.from();
   set(this, 'reopenedAt', twoMinutesAgo);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-reopened
+      author=author
+      reopenedAt=reopenedAt
+    }}
+  `);
 
   let expectedText = `You reopened this ${twoMinutesAgoFriendly}`;
   assert.equal(page.reopenedAt.text, expectedText, 'The reopened at timestamp is rendered');
@@ -66,7 +62,12 @@ test('if someone other than the current user reopens the message, "Author.userna
   let twoMinutesAgoFriendly = twoMinutesAgo.from();
   set(this, 'reopenedAt', twoMinutesAgo);
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-part-reopened
+      author=author
+      reopenedAt=reopenedAt
+    }}
+  `);
 
   let expectedText = `${author.username} reopened this ${twoMinutesAgoFriendly}`;
   assert.equal(page.reopenedAt.text, expectedText, 'The reopened at timestamp is rendered');

--- a/tests/integration/components/conversations/conversation-thread-test.js
+++ b/tests/integration/components/conversations/conversation-thread-test.js
@@ -7,16 +7,6 @@ import { resolve } from 'rsvp';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/conversation-thread
-      sortedConversationParts=conversation.sortedConversationParts
-      conversation=conversation
-      send=send
-    }}
-  `);
-}
-
 moduleForComponent('conversations/conversation-thread', 'Integration | Component | conversations/conversation thread', {
   integration: true,
   beforeEach() {
@@ -32,7 +22,15 @@ moduleForComponent('conversations/conversation-thread', 'Integration | Component
 
 test('it renders composer', function(assert) {
   assert.expect(1);
-  renderPage();
+
+  this.render(hbs`
+    {{conversations/conversation-thread
+      sortedConversationParts=conversation.sortedConversationParts
+      conversation=conversation
+      send=send
+    }}
+  `);
+
   assert.ok(page.conversationComposer.isVisible, 'Composer is rendered');
 });
 
@@ -42,10 +40,16 @@ test('it renders head as conversation part', function(assert) {
   let message = { body: 'foo', isLoaded: true };
   set(this, 'conversation', { message });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-thread
+      sortedConversationParts=conversation.sortedConversationParts
+      conversation=conversation
+      send=send
+    }}
+  `);
 
-  assert.equal(page.conversationParts().count, 1, 'A part is rendered for the head.');
-  page.conversationParts(0).as((head) => {
+  assert.equal(page.conversationParts.length, 1, 'A part is rendered for the head.');
+  page.conversationParts.objectAt(0).as((head) => {
     assert.equal(head.body.text, 'foo', 'Message body is rendered.');
   });
 });
@@ -56,9 +60,15 @@ test('it delays rendering head until loaded', function(assert) {
   let message = { body: 'foo', isLoaded: false };
   set(this, 'conversation', { message });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-thread
+      sortedConversationParts=conversation.sortedConversationParts
+      conversation=conversation
+      send=send
+    }}
+  `);
 
-  assert.equal(page.conversationParts().count, 0, 'No part is rendered.');
+  assert.equal(page.conversationParts.length, 0, 'No part is rendered.');
 });
 
 test('it renders each conversation part', function(assert) {
@@ -70,12 +80,19 @@ test('it renders each conversation part', function(assert) {
     { isLoaded: true, body: 'foo 3', insertedAt: new Date('2017-10-01') }
   ];
   set(this, 'conversation', { sortedConversationParts });
-  renderPage();
 
-  assert.equal(page.conversationParts().count, 3, 'Each part is rendered.');
-  assert.equal(page.conversationParts(0).body.text, 'foo 1', 'Part 1 is rendered first');
-  assert.equal(page.conversationParts(1).body.text, 'foo 2', 'Part 2 is rendered second');
-  assert.equal(page.conversationParts(2).body.text, 'foo 3', 'Part 3 is rendered last');
+  this.render(hbs`
+    {{conversations/conversation-thread
+      sortedConversationParts=conversation.sortedConversationParts
+      conversation=conversation
+      send=send
+    }}
+  `);
+
+  assert.equal(page.conversationParts.length, 3, 'Each part is rendered.');
+  assert.equal(page.conversationParts.objectAt(0).body.text, 'foo 1', 'Part 1 is rendered first');
+  assert.equal(page.conversationParts.objectAt(1).body.text, 'foo 2', 'Part 2 is rendered second');
+  assert.equal(page.conversationParts.objectAt(2).body.text, 'foo 3', 'Part 3 is rendered last');
 });
 
 test('it delays rendering conversation parts not yet loaded', function(assert) {
@@ -87,9 +104,16 @@ test('it delays rendering conversation parts not yet loaded', function(assert) {
     { isLoaded: false, body: 'foo 3' }
   ];
   set(this, 'conversation', { sortedConversationParts });
-  renderPage();
 
-  assert.equal(page.conversationParts().count, 1, 'Only loaded parts are rendered.');
+  this.render(hbs`
+    {{conversations/conversation-thread
+      sortedConversationParts=conversation.sortedConversationParts
+      conversation=conversation
+      send=send
+    }}
+  `);
+
+  assert.equal(page.conversationParts.length, 1, 'Only loaded parts are rendered.');
 });
 
 test('it delegates send action from composer', function(assert) {
@@ -100,7 +124,13 @@ test('it delegates send action from composer', function(assert) {
     return resolve();
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/conversation-thread
+      sortedConversationParts=conversation.sortedConversationParts
+      conversation=conversation
+      send=send
+    }}
+  `);
 
   page.conversationComposer.submittableTextarea.fillIn('foo');
   page.conversationComposer.submitButton.click();

--- a/tests/integration/components/conversations/new-conversation-modal-test.js
+++ b/tests/integration/components/conversations/new-conversation-modal-test.js
@@ -10,16 +10,6 @@ import { getOwner } from '@ember/application';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/new-conversation-modal
-      initiatedBy=initiatedBy
-      project=project
-      user=user
-    }}
-  `);
-}
-
 moduleForComponent('conversations/new-conversation-modal', 'Integration | Component | conversations/new conversation modal', {
   integration: true,
   beforeEach() {
@@ -45,7 +35,13 @@ test('it initiates a conversation and opens the modal when open button is clicke
     set(this, 'currentUser.user', store.createRecord('user', { id: 'baz' }));
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/new-conversation-modal
+      initiatedBy=initiatedBy
+      project=project
+      user=user
+    }}
+  `);
 
   assert.notOk(page.modal.isVisible, 'Modal is initially hidden.');
   page.openButton.click();
@@ -75,7 +71,13 @@ test('it keeps the modal open and retains the records when close button is click
   let messages = store.peekAll('message');
   let conversations = store.peekAll('conversation');
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/new-conversation-modal
+      initiatedBy=initiatedBy
+      project=project
+      user=user
+    }}
+  `);
 
   page.openButton.click();
 
@@ -114,7 +116,13 @@ test('it does not prompt when close button is clicked and the form has no data',
   let messages = store.peekAll('message');
   let conversations = store.peekAll('conversation');
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/new-conversation-modal
+      initiatedBy=initiatedBy
+      project=project
+      user=user
+    }}
+  `);
 
   page.openButton.click();
 
@@ -140,7 +148,13 @@ test('it discards the conversation and closes the modal when close button is cli
     set(this, 'currentUser.user', store.createRecord('user', { id: 'baz' }));
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/new-conversation-modal
+      initiatedBy=initiatedBy
+      project=project
+      user=user
+    }}
+  `);
 
   let messages = store.peekAll('message');
   let conversations = store.peekAll('conversation');
@@ -179,7 +193,13 @@ test('it saves the conversation and closes the modal when send button is clicked
     set(this, 'currentUser.user', store.createRecord('user', { id: 'baz' }));
   });
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/new-conversation-modal
+      initiatedBy=initiatedBy
+      project=project
+      user=user
+    }}
+  `);
 
   let messages = store.peekAll('message');
   let conversations = store.peekAll('conversation');
@@ -216,7 +236,13 @@ test('it renders validation errors', function(assert) {
 
   let messages = store.peekAll('message');
 
-  renderPage();
+  this.render(hbs`
+    {{conversations/new-conversation-modal
+      initiatedBy=initiatedBy
+      project=project
+      user=user
+    }}
+  `);
 
   page.openButton.click();
 
@@ -227,10 +253,10 @@ test('it renders validation errors', function(assert) {
   });
 
   assert.ok(page.modal.subject.isErrored, 'Subject renders as errored');
-  assert.equal(page.modal.subject.errors().count, 1, 'Correct number of errors is rendered');
-  assert.equal(page.modal.subject.errors(0).text, 'Foo', 'Error is correctly rendered');
+  assert.equal(page.modal.subject.errors.length, 1, 'Correct number of errors is rendered');
+  assert.equal(page.modal.subject.errors.objectAt(0).text, 'Foo', 'Error is correctly rendered');
   assert.ok(page.modal.body.isErrored, 'Body renders as errored');
-  assert.equal(page.modal.body.errors().count, 2, 'Correct number of errors is rendered');
-  assert.equal(page.modal.body.errors(0).text, 'Bar', 'Error is correctly rendered');
-  assert.equal(page.modal.body.errors(1).text, 'Baz', 'Error is correctly rendered');
+  assert.equal(page.modal.body.errors.length, 2, 'Correct number of errors is rendered');
+  assert.equal(page.modal.body.errors.objectAt(0).text, 'Bar', 'Error is correctly rendered');
+  assert.equal(page.modal.body.errors.objectAt(1).text, 'Baz', 'Error is correctly rendered');
 });

--- a/tests/integration/components/conversations/project-details-test.js
+++ b/tests/integration/components/conversations/project-details-test.js
@@ -6,14 +6,6 @@ import component from 'code-corps-ember/tests/pages/components/conversations/pro
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/project-details
-      project=project
-    }}
-  `);
-}
-
 moduleForComponent('conversations/project-details', 'Integration | Component | conversations/project details', {
   integration: true,
   beforeEach() {
@@ -37,12 +29,12 @@ test('it renders the project details', function(assert) {
 
   set(this, 'project', project);
 
-  renderPage();
+  this.render(hbs`{{conversations/project-details project=project}}`);
 
   assert.equal(page.icon.url, project.iconThumbUrl, 'The icon renders');
   assert.equal(page.title.text, project.title, 'The title renders');
   assert.equal(page.description.text, project.description, 'The description renders');
-  page.projectCategoriesList.projectCategoryItems(0).mouseenter();
-  assert.equal(page.projectCategoriesList.projectCategoryItems(0).tooltip.text, project.categories[0].name, 'The categories render');
-  assert.equal(page.relatedSkills.skillListItems.listItems(0).text, project.skills[0].title, 'The skills render');
+  page.projectCategoriesList.projectCategoryItems.objectAt(0).mouseenter();
+  assert.equal(page.projectCategoriesList.projectCategoryItems.objectAt(0).tooltip.text, project.categories[0].name, 'The categories render');
+  assert.equal(page.relatedSkills.skillListItems.listItems.objectAt(0).text, project.skills[0].title, 'The skills render');
 });

--- a/tests/integration/components/conversations/status-select-test.js
+++ b/tests/integration/components/conversations/status-select-test.js
@@ -6,14 +6,6 @@ import component from 'code-corps-ember/tests/pages/components/conversations/sta
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/status-select
-      status=status
-    }}
-  `);
-}
-
 moduleForComponent('conversations/status-select', 'Integration | Component | conversations/status select', {
   integration: true,
   beforeEach() {
@@ -29,7 +21,7 @@ test('it opens, closes, and renders the correct states', async function(assert) 
 
   set(this, 'status', 'open');
 
-  renderPage();
+  this.render(hbs`{{conversations/status-select status=status}}`);
 
   assert.ok(page.openButton.isVisible, 'The open button is visible');
 

--- a/tests/integration/components/conversations/user-details-test.js
+++ b/tests/integration/components/conversations/user-details-test.js
@@ -6,14 +6,6 @@ import component from 'code-corps-ember/tests/pages/components/conversations/use
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{conversations/user-details
-      user=user
-    }}
-  `);
-}
-
 moduleForComponent('conversations/user-details', 'Integration | Component | conversations/user details', {
   integration: true,
   beforeEach() {
@@ -31,33 +23,25 @@ test('it renders the user details', function(assert) {
     name: 'Test User',
     photoThumbUrl: 'http://lorempixel.com/25/25/',
     username: 'testuser',
-    userSkills: [
-      {
-        skill: {
-          title: 'Ember.js'
-        }
-      }
-    ]
+    userSkills: [{ skill: { title: 'Ember.js' } }]
   };
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{conversations/user-details user=user}}`);
 
   assert.equal(page.photo.url, user.photoThumbUrl, 'Their photo renders');
   assert.equal(page.name.text, user.name, 'Their name renders');
   assert.equal(page.username.text, user.username, 'Their username renders');
-  assert.equal(page.userSkillsList.skills(0).text, 'Ember.js');
+  assert.equal(page.userSkillsList.skills.objectAt(0).text, 'Ember.js');
 });
 
 test('it sets the name to username if name is blank', function(assert) {
   assert.expect(1);
 
-  let user = {
-    username: 'testuser'
-  };
+  let user = { username: 'testuser' };
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{conversations/user-details user=user}}`);
 
   assert.equal(page.name.text, 'testuser');
 });

--- a/tests/integration/components/create-comment-form-test.js
+++ b/tests/integration/components/create-comment-form-test.js
@@ -11,21 +11,12 @@ let page = PageObject.create(createCommentForm);
 
 let mockSession = { isAuthenticated: true };
 
-function renderPage() {
-  page.render(hbs`{{create-comment-form comment=comment save=saveHandler}}`);
-}
-
-function setHandler(context, saveHandler = function() {}) {
-  set(context, 'saveHandler', saveHandler);
-}
-
 moduleForComponent('create-comment-form', 'Integration | Component | create comment form', {
   integration: true,
   setup() {
     mockRouting(this);
   },
   beforeEach() {
-    setHandler(this);
     page.setContext(this);
   },
   afterEach() {
@@ -37,8 +28,14 @@ test('it yields to content', function(assert) {
   assert.expect(1);
 
   stubService(this, 'session', mockSession);
+  set(this, 'onSave', () => {});
 
-  page.render(hbs`{{#create-comment-form comment=comment save=saveHandler}}Random content{{/create-comment-form}}`);
+  this.render(hbs`
+    {{#create-comment-form comment=comment save=onSave}}
+      Random content
+    {{/create-comment-form}}
+  `);
+
   assert.ok(page.contains('Random content'), 'The provided content is yielded to');
 });
 
@@ -48,8 +45,10 @@ test('it renders the proper elements', function(assert) {
   stubService(this, 'session', mockSession);
 
   set(this, 'comment', {});
+  set(this, 'onSave', () => {});
 
-  renderPage();
+  this.render(hbs`{{create-comment-form comment=comment save=onSave}}`);
+
   assert.ok(page.rendersMarkdown, 'The markdown input is rendered');
   assert.ok(page.rendersSaveButton, 'The save button is rendered');
 });
@@ -60,18 +59,21 @@ test('it calls action when user clicks submit', function(assert) {
   stubService(this, 'session', mockSession);
 
   set(this, 'comment', { markdown: 'Test markdown' });
-  setHandler(this, (markdown) => {
+  set(this, 'onSave', (markdown) => {
     assert.equal(markdown, 'Test markdown', 'Action was called with proper parameter');
   });
 
-  renderPage();
+  this.render(hbs`{{create-comment-form comment=comment save=onSave}}`);
+
   page.clickSave();
 });
 
 test('it renders a sign up button and sign in link when not authenticated', function(assert) {
   assert.expect(2);
 
-  renderPage();
+  set(this, 'onSave', () => {});
+
+  this.render(hbs`{{create-comment-form comment=comment save=onSave}}`);
 
   assert.ok(page.rendersSignup, 'Sign up link is rendered');
   assert.ok(page.rendersLogin, 'Login ink is rendered');

--- a/tests/integration/components/donation-goal-edit-test.js
+++ b/tests/integration/components/donation-goal-edit-test.js
@@ -28,7 +28,7 @@ moduleForComponent('donation-goal-edit', 'Integration | Component | donation goa
 test('it renders cancel button, when canCancel is true', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=true cancel=cancelHandler save=saveHandler}}`);
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=true cancel=cancelHandler save=saveHandler}}`);
 
   assert.ok(page.cancelButtonIsVisible);
 });
@@ -36,7 +36,7 @@ test('it renders cancel button, when canCancel is true', function(assert) {
 test('it does not render cancel button, when canCancel is false', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=false save=saveHandler}}`);
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=false save=saveHandler}}`);
 
   assert.notOk(page.cancelButtonIsVisible);
 });
@@ -52,7 +52,7 @@ test('it sends save action, with user input properties as argument, when save bu
 
   setHandlers(this, { saveHandler });
 
-  page.render(hbs`{{donation-goal-edit donationGoal=donationGoal save=(action saveHandler donationGoal)}}`);
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal save=(action saveHandler donationGoal)}}`);
 
   page.fillInAmount(mockProperties.amount)
     .fillInDescription(mockProperties.description)
@@ -68,7 +68,7 @@ test('it sends cancel action, when cancel button is clicked', function(assert) {
 
   setHandlers(this, { cancelHandler });
 
-  page.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=true cancel=(action cancelHandler donationGoal) save=saveHandler}}`);
+  this.render(hbs`{{donation-goal-edit donationGoal=donationGoal canCancel=true cancel=(action cancelHandler donationGoal) save=saveHandler}}`);
 
   page.clickCancel();
 });

--- a/tests/integration/components/donation-goal-test.js
+++ b/tests/integration/components/donation-goal-test.js
@@ -30,7 +30,7 @@ moduleForComponent('donation-goal', 'Integration | Component | donation goal', {
 test('it displays the donation goal info', function(assert) {
   assert.expect(2);
 
-  page.render(hbs`{{donation-goal donationGoal=donationGoal}}`);
+  this.render(hbs`{{donation-goal donationGoal=donationGoal}}`);
 
   assert.equal(page.amount.text, '$500.00', 'Correct amount is rendered');
   assert.equal(page.description.text, 'A test goal', 'Correct description is rendered');
@@ -39,7 +39,7 @@ test('it displays the donation goal info', function(assert) {
 test('it renders the edit link, if canEdit flag is set to true', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{donation-goal canEdit=true edit=editHandler donationGoal=donationGoal}}`);
+  this.render(hbs`{{donation-goal canEdit=true edit=editHandler donationGoal=donationGoal}}`);
 
   assert.ok(page.editButton.isVisible);
 });
@@ -47,7 +47,7 @@ test('it renders the edit link, if canEdit flag is set to true', function(assert
 test('it does not render the edit link, if canEdit flag is set to false', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{donation-goal canEdit=false donationGoal=donationGoal}}`);
+  this.render(hbs`{{donation-goal canEdit=false donationGoal=donationGoal}}`);
 
   assert.notOk(page.editButton.isVisible);
 });

--- a/tests/integration/components/donation-goals-activation-test.js
+++ b/tests/integration/components/donation-goals-activation-test.js
@@ -6,15 +6,6 @@ import donationGoalsActivation from 'code-corps-ember/tests/pages/component/dona
 
 let page = PageObject.create(donationGoalsActivation);
 
-function renderPage() {
-  page.render(hbs`
-    {{donation-goals-activation
-      activateDonations=activateDonationsHandler
-      canActivateDonations=canActivateDonations
-    }}
-  `);
-}
-
 function setHandlers(context, { activateDonationsHandler = function() {} } = {}) {
   set(context, 'activateDonationsHandler', activateDonationsHandler);
 }
@@ -40,7 +31,12 @@ test('it allows activating donations if canActivateDonations is true', function(
   setHandlers(this, { activateDonationsHandler });
   set(this, 'canActivateDonations', true);
 
-  renderPage();
+  this.render(hbs`
+    {{donation-goals-activation
+      activateDonations=activateDonationsHandler
+      canActivateDonations=canActivateDonations
+    }}
+  `);
 
   assert.ok(page.activateDonationsButton.isVisible, 'The "activate donations" button is rendered');
 
@@ -52,7 +48,12 @@ test('it prevents activating donations if canActivateDonations is false', functi
 
   set(this, 'canActivateDonations', false);
 
-  renderPage();
+  this.render(hbs`
+    {{donation-goals-activation
+      activateDonations=activateDonationsHandler
+      canActivateDonations=canActivateDonations
+    }}
+  `);
 
   assert.notOk(page.activateDonationsButton.isVisible, 'The "activate donations" button is not rendered');
 });

--- a/tests/integration/components/donation-goals-test.js
+++ b/tests/integration/components/donation-goals-test.js
@@ -31,9 +31,9 @@ test('it renders loading goals when not loaded', function(assert) {
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
 
-  assert.equal(page.donationGoalLoadings().count, 1, 'Renders correct number of donation-goal-loading elements');
+  assert.equal(page.donationGoalLoadings.length, 1, 'Renders correct number of donation-goal-loading elements');
 });
 
 test('it renders the correct number of subcomponents', function(assert) {
@@ -47,9 +47,9 @@ test('it renders the correct number of subcomponents', function(assert) {
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
 
-  assert.equal(page.donationGoals().count, 3, 'Renders correct number of donation-goal components');
+  assert.equal(page.donationGoals.length, 3, 'Renders correct number of donation-goal components');
 });
 
 test('it renders the correct number of subcomponents in view or edit mode', function(assert) {
@@ -63,10 +63,10 @@ test('it renders the correct number of subcomponents in view or edit mode', func
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
 
-  assert.equal(page.donationGoals().count, 2, 'Renders correct number of donation-goal components');
-  assert.equal(page.donationGoalEdits().count, 1, 'Renders correct number of donation-goal-edit components');
+  assert.equal(page.donationGoals.length, 2, 'Renders correct number of donation-goal components');
+  assert.equal(page.donationGoalEdits.length, 1, 'Renders correct number of donation-goal-edit components');
 });
 
 test('it sends "cancel" action with donation goal as parameter when cancel button is clicked', function(assert) {
@@ -84,7 +84,7 @@ test('it sends "cancel" action with donation goal as parameter when cancel butto
 
   setHandlers(this, { cancelHandler });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
 
   page.cancel.click();
 });
@@ -103,9 +103,9 @@ test('it sends "edit" action with donation goal as parameter when clicked', func
   };
   setHandlers(this, { editHandler });
 
-  page.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
 
-  page.donationGoals(0).click();
+  page.donationGoals.objectAt(0).click();
 });
 
 test('it sends "save" action with donation goal curried first, and values second when save button is clicked', function(assert) {
@@ -123,7 +123,7 @@ test('it sends "save" action with donation goal curried first, and values second
   };
   setHandlers(this, { saveHandler });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
 
   page.save.click();
 });
@@ -137,7 +137,7 @@ test('it does not allow cancelling an edited record if that record is the only o
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler project=project}}`);
 
   assert.notOk(page.cancel.isVisible);
 });
@@ -151,7 +151,7 @@ test('it allows cancelling an edited record if that record is the only one and n
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler edit=editHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler save=saveHandler edit=editHandler project=project}}`);
 
   assert.ok(page.cancel.isVisible);
 });
@@ -166,7 +166,7 @@ test('it allows cancelling an edited record if that record is new, but there are
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
 
   assert.ok(page.cancel.isVisible);
 });
@@ -181,7 +181,7 @@ test('it only allows editing a single record at a time', function(assert) {
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
 
   assert.notOk(page.edit.isVisible);
 });
@@ -193,7 +193,7 @@ test('it does not allow adding a record if a record is being edited', function(a
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
 
   assert.notOk(page.add.isVisible);
 });
@@ -205,7 +205,7 @@ test('it does not allow adding a record if a record is being added', function(as
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
+  this.render(hbs`{{donation-goals cancel=cancelHandler edit=editHandler save=saveHandler project=project}}`);
 
   assert.notOk(page.add.isVisible);
 });
@@ -217,7 +217,7 @@ test('it allows adding a record if no record is being added or edited', function
 
   set(this, 'project', { donationGoals: mockGoals });
 
-  page.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
 
   assert.ok(page.add.isVisible);
 });
@@ -235,7 +235,7 @@ test('it calls provided "add" action with project as parameter when add button i
   };
   setHandlers(this, { addHandler });
 
-  page.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
+  this.render(hbs`{{donation-goals add=addHandler edit=editHandler project=project}}`);
 
   page.add.click();
 });

--- a/tests/integration/components/donation/card-item-test.js
+++ b/tests/integration/components/donation/card-item-test.js
@@ -21,7 +21,7 @@ test('it renders proper information', function(assert) {
 
   this.set('card', { id: 1, brand: 'Visa', last4: 4242, expMonth: '01', expYear: '2022' });
 
-  page.render(hbs`{{donation/card-item card=card}}`);
+  this.render(hbs`{{donation/card-item card=card}}`);
 
   assert.equal(page.cardDescription, 'Visa ending in 4242 01/2022', 'Card description is correct');
 });

--- a/tests/integration/components/donation/card-logo-test.js
+++ b/tests/integration/components/donation/card-logo-test.js
@@ -17,36 +17,36 @@ moduleForComponent('donation/card-logo', 'Integration | Component | donation/car
 });
 
 test('it renders for American Express', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="American Express"}}`);
+  this.render(hbs`{{donation/card-logo brand="American Express"}}`);
   assert.ok(page.isAmex);
 });
 
 test('it renders for Diners Club', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="Diners Club"}}`);
+  this.render(hbs`{{donation/card-logo brand="Diners Club"}}`);
   assert.ok(page.isDiners);
 });
 
 test('it renders for Discover', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="Discover"}}`);
+  this.render(hbs`{{donation/card-logo brand="Discover"}}`);
   assert.ok(page.isDiscover);
 });
 
 test('it renders for JCB', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="JCB"}}`);
+  this.render(hbs`{{donation/card-logo brand="JCB"}}`);
   assert.ok(page.isJCB);
 });
 
 test('it renders for MasterCard', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="MasterCard"}}`);
+  this.render(hbs`{{donation/card-logo brand="MasterCard"}}`);
   assert.ok(page.isMasterCard);
 });
 
 test('it renders for Visa', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="Visa"}}`);
+  this.render(hbs`{{donation/card-logo brand="Visa"}}`);
   assert.ok(page.isVisa);
 });
 
 test('it renders for Unknown', function(assert) {
-  page.render(hbs`{{donation/card-logo brand="Unknown"}}`);
+  this.render(hbs`{{donation/card-logo brand="Unknown"}}`);
   assert.ok(page.isUnknown);
 });

--- a/tests/integration/components/donation/donation-container-test.js
+++ b/tests/integration/components/donation/donation-container-test.js
@@ -34,14 +34,14 @@ test('it renders new card form when there is no card to begin with', function(as
   this.set('projectTitle', 'CodeCorps');
   this.set('card', { content: null, isFulfilled: true });
 
-  page.render(hbs`
+  this.render(hbs`
     {{donation/donation-container
       card=card donate=donateHandler donationAmount=amount
       isProcessing=isProcessing projectTitle=projectTitle saveAndDonate=saveAndDonateHandler }}
   `);
 
   assert.ok(page.cardFormIsVisible, 'The new card form is rendered automatically.');
-  assert.notOk(page.cards(0).isVisible, 'The card item is not visible.');
+  assert.notOk(page.cards.objectAt(0).isVisible, 'The card item is not visible.');
 });
 
 test('it renders new card form when the card is added and is processing', function(assert) {
@@ -52,7 +52,7 @@ test('it renders new card form when the card is added and is processing', functi
   this.set('projectTitle', 'CodeCorps');
   this.set('card', { content: null, isFulfilled: true });
 
-  page.render(hbs`
+  this.render(hbs`
     {{donation/donation-container
       card=card
       donate=donateHandler
@@ -65,7 +65,7 @@ test('it renders new card form when the card is added and is processing', functi
   this.set('isProcessing', true);
 
   assert.ok(page.cardFormIsVisible, 'The new card form is rendered.');
-  assert.notOk(page.cards(0).isVisible, 'The card item is not visible.');
+  assert.notOk(page.cards.objectAt(0).isVisible, 'The card item is not visible.');
 });
 
 test('it renders the card item if there is a card and the form is processing', function(assert) {
@@ -74,7 +74,7 @@ test('it renders the card item if there is a card and the form is processing', f
   this.set('card', visa);
   this.set('isProcessing', true);
 
-  page.render(hbs`
+  this.render(hbs`
     {{donation/donation-container
       card=card
       donate=donateHandler
@@ -85,7 +85,7 @@ test('it renders the card item if there is a card and the form is processing', f
 
   assert.notOk(page.cardFormIsVisible, 'The new card form is not rendered.');
   assert.ok(page.donationButtonIsVisible, 'Donation button is rendered.');
-  assert.ok(page.cards(0).isVisible, 'The card item is visible.');
+  assert.ok(page.cards.objectAt(0).isVisible, 'The card item is visible.');
 });
 
 test('it renders the card item and the "donate" button when a card exists', function(assert) {
@@ -93,13 +93,13 @@ test('it renders the card item and the "donate" button when a card exists', func
 
   this.set('card', visa);
 
-  page.render(hbs`
+  this.render(hbs`
     {{donation/donation-container
       card=card donate=donateHandler donationAmount=amount projectTitle=projectTitle saveAndDonate=saveAndDonateHandler }}
   `);
 
   assert.notOk(page.cardFormIsVisible, 'Credit card form component is not rendered.');
-  assert.ok(page.cards(0).isVisible, 'Credit card item is rendered.');
+  assert.ok(page.cards.objectAt(0).isVisible, 'Credit card item is rendered.');
   assert.ok(page.donationButtonIsVisible, 'Donation button is rendered.');
 });
 
@@ -115,7 +115,7 @@ test('it handles adding a card correctly', function(assert) {
 
   this.set('card', null);
 
-  page.render(hbs`
+  this.render(hbs`
     {{donation/donation-container
       card=card donate=donateHandler donationAmount=amount projectTitle=projectTitle saveAndDonate=saveAndDonateHandler }}
   `);
@@ -135,7 +135,7 @@ test('it handles donating correctly', function(assert) {
 
   setHandlers(this, { donateHandler });
 
-  page.render(hbs`
+  this.render(hbs`
     {{donation/donation-container
       card=card donate=donateHandler donationAmount=amount projectTitle=projectTitle saveAndDonate=saveAndDonateHandler }}
   `);

--- a/tests/integration/components/donation/project-header-test.js
+++ b/tests/integration/components/donation/project-header-test.js
@@ -25,7 +25,7 @@ test('it displays the right title, icon, description', function(assert) {
   };
   this.set('project', project);
 
-  page.render(hbs`{{donation/project-header project=project}}`);
+  this.render(hbs`{{donation/project-header project=project}}`);
 
   assert.equal(page.icon.src, project.iconThumbUrl, 'Icon is rendered');
   assert.equal(page.title.text, project.title, 'Title is rendered');

--- a/tests/integration/components/donations/create-donation-test.js
+++ b/tests/integration/components/donations/create-donation-test.js
@@ -7,12 +7,6 @@ import createDonationComponent from '../../../pages/components/donations/create-
 
 let page = PageObject.create(createDonationComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
-  `);
-}
-
 moduleForComponent('donations/create-donation', 'Integration | Component | donations/create donation', {
   integration: true,
   beforeEach() {
@@ -28,7 +22,9 @@ moduleForComponent('donations/create-donation', 'Integration | Component | donat
 test('it renders properly', function(assert) {
   assert.expect(6);
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   assert.ok(page.setTo10.isRendered, 'Button for preset amount of 10 is rendered.');
   assert.ok(page.setTo15.isRendered, 'Button for preset amount of 15 is rendered.');
@@ -41,7 +37,9 @@ test('it renders properly', function(assert) {
 test('unsetting the input value resets to the fallback amount', function(assert) {
   assert.expect(2);
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   page.setTo10.clickButton();
   page.customAmount(12.5);
@@ -55,7 +53,9 @@ test('unsetting the input value resets to the fallback amount', function(assert)
 test('preset amount buttons unset the input value', function(assert) {
   assert.expect(1);
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   page.setTo10.clickButton();
   assert.equal(page.customAmountValue, '', 'The custom value was unset.');
@@ -68,7 +68,9 @@ test('clicking "continue" calls action with preset amount as argument', function
     assert.equal(amount, 15, 'Proper amount was sent via action.');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   page.setTo15.clickButton();
   page.clickContinue();
@@ -81,7 +83,9 @@ test('clicking "continue" calls action with custom amount as argument', function
     assert.equal(amount, 22, 'Proper amount was sent via action.');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   page.customAmount(22);
   page.clickContinue();
@@ -90,7 +94,9 @@ test('clicking "continue" calls action with custom amount as argument', function
 test('buttons do not activate when custom amount is set to preset value', function(assert) {
   assert.expect(1);
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   page.customAmount(50);
   assert.ok(page.setTo50.isActive, 'Related button should be active.');
@@ -105,7 +111,7 @@ test('calls action when custom amount changes', function(assert) {
     assert.equal(changedAmount, filledInAmount, 'The correct amount was sent.');
   });
 
-  page.render(hbs`
+  this.render(hbs`
     {{donations/create-donation amount=amount continue=onContinue onAmountChanged=onAmountChanged}}
   `);
 
@@ -115,7 +121,9 @@ test('calls action when custom amount changes', function(assert) {
 test('preselects one of the buttons if amount is externally set to appropriate value.', function(assert) {
   assert.expect(16);
 
-  renderPage();
+  this.render(hbs`
+    {{donations/create-donation amount=amount continue=onContinue onAmountChanged=(action (mut amount))}}
+  `);
 
   [10, '10', 10.0, '10.0'].forEach((amount) => {
     run(() => set(this, 'amount', amount));

--- a/tests/integration/components/donations/donation-amount-button-test.js
+++ b/tests/integration/components/donations/donation-amount-button-test.js
@@ -6,12 +6,6 @@ import donationAmountButtonComponent from '../../../pages/components/donations/d
 
 let page = PageObject.create(donationAmountButtonComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{donations/donation-amount-button presetAmount=presetAmount selected=selected}}
-  `);
-}
-
 moduleForComponent('donations/donation-amount-button', 'Integration | Component | donations/donation amount button', {
   integration: true,
   beforeEach() {
@@ -27,7 +21,7 @@ test('it renders preset value as part of button text', function(assert) {
 
   set(this, 'presetAmount', 5);
 
-  renderPage();
+  this.render(hbs`{{donations/donation-amount-button presetAmount=presetAmount selected=selected}}`);
 
   assert.equal(page.text, 'Donate $5', 'Value is rendered properly.');
 });
@@ -37,7 +31,7 @@ test('it shows as active if button is selected', function(assert) {
 
   set(this, 'selected', true);
 
-  renderPage();
+  this.render(hbs`{{donations/donation-amount-button presetAmount=presetAmount selected=selected}}`);
 
   assert.ok(page.isActive, 'Button is rendered as active');
 });
@@ -47,7 +41,7 @@ test('it shows as inactive if button is not selected', function(assert) {
 
   set(this, 'selected', false);
 
-  renderPage();
+  this.render(hbs`{{donations/donation-amount-button presetAmount=presetAmount selected=selected}}`);
 
   assert.ok(page.isInactive, 'Button is rendered as inActive');
 });

--- a/tests/integration/components/donations/donation-progress-test.js
+++ b/tests/integration/components/donations/donation-progress-test.js
@@ -23,7 +23,7 @@ test('it renders proper information', function(assert) {
 
   this.set('donationGoal', mockGoal);
 
-  page.render(hbs`{{donations/donation-progress donationGoal=donationGoal amountDonated=500}}`);
+  this.render(hbs`{{donations/donation-progress donationGoal=donationGoal amountDonated=500}}`);
 
   assert.equal(page.amountValue, '$500', 'Correct amount value is rendered');
   assert.equal(page.percentageLabel, 'of $1,000 goal', 'Correct percentage label is rendered');
@@ -39,7 +39,7 @@ test('it renders decimal values if there are any', function(assert) {
 
   this.set('donationGoal', mockGoal);
 
-  page.render(hbs`{{donations/donation-progress donationGoal=donationGoal amountDonated=505.50}}`);
+  this.render(hbs`{{donations/donation-progress donationGoal=donationGoal amountDonated=505.50}}`);
 
   assert.equal(page.amountValue, '$505.50', 'Correct amount is rendered');
   assert.equal(page.percentageLabel, 'of $1,000 goal', 'Correct percentage label is rendered');

--- a/tests/integration/components/donations/donation-status-test.js
+++ b/tests/integration/components/donations/donation-status-test.js
@@ -24,7 +24,7 @@ moduleForComponent('donations/donation-status', 'Integration | Component | donat
 test('it renders the become a donor link initially', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{donations/donation-status}}`);
+  this.render(hbs`{{donations/donation-status}}`);
 
   assert.ok(page.rendersLink, 'The link is rendered.');
 });
@@ -33,7 +33,7 @@ test('it renders show-donation if a subscription record is present and assigned'
   assert.expect(2);
 
   this.set('subscription', { quantity: 1.50 });
-  page.render(hbs`{{donations/donation-status subscription=subscription}}`);
+  this.render(hbs`{{donations/donation-status subscription=subscription}}`);
 
   assert.ok(page.rendersShowDonation, 'show-donation subcomponent is rendered.');
   assert.equal(page.showDonation.infoText, 'You pledged $1.50 each month.', 'Info text is properly rendered. Binding is correct.');

--- a/tests/integration/components/donations/show-donation-test.js
+++ b/tests/integration/components/donations/show-donation-test.js
@@ -21,7 +21,7 @@ test('it renders proper information', function(assert) {
 
   this.set('amount', 22.500);
 
-  page.render(hbs`{{donations/show-donation amount=amount}}`);
+  this.render(hbs`{{donations/show-donation amount=amount}}`);
 
   assert.equal(page.infoText, 'You pledged $22.50 each month.', 'Proper text is rendered.');
 });

--- a/tests/integration/components/editor-with-preview-test.js
+++ b/tests/integration/components/editor-with-preview-test.js
@@ -43,13 +43,13 @@ moduleForComponent('editor-with-preview', 'Integration | Component | editor with
 
 test('it binds to the editor text correctly', function(assert) {
   assert.expect(1);
-  page.render(hbs`{{editor-with-preview input='Random input'}}`);
+  this.render(hbs`{{editor-with-preview input='Random input'}}`);
   assert.equal(page.textarea.value, 'Random input', 'The text area is rendered with correct content');
 });
 
 test('user can switch between editing and preview mode', function(assert) {
   assert.expect(3);
-  page.render(hbs`{{editor-with-preview}}`);
+  this.render(hbs`{{editor-with-preview}}`);
   assert.ok(page.isEditing, 'The component is rendered in editing mode initially');
   page.clickPreview();
   assert.ok(page.isPreviewing, 'The component switches to preview mode');
@@ -59,14 +59,14 @@ test('user can switch between editing and preview mode', function(assert) {
 
 test('It renders the preview tab with proper content when clicking the preview button', function(assert) {
   assert.expect(1);
-  page.render(hbs`{{editor-with-preview input='test' generatePreview='generatePreview'}}`);
+  this.render(hbs`{{editor-with-preview input='test' generatePreview='generatePreview'}}`);
   page.clickPreview();
   assert.equal(page.bodyPreview.text, 'Lorem ipsum bla');
 });
 
 test('it renders the preview tab with no content message when input is blank when clicking the preview button', function(assert) {
   assert.expect(1);
-  page.render(hbs`{{editor-with-preview input='' generatePreview='generatePreview'}}`);
+  this.render(hbs`{{editor-with-preview input='' generatePreview='generatePreview'}}`);
   page.clickPreview();
   assert.equal(page.bodyPreview.text, 'Nothing to preview.');
 });
@@ -75,7 +75,7 @@ test('it has a spinner when loading', function(assert) {
   assert.expect(1);
 
   this.set('isLoading', true);
-  page.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
+  this.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
 
   assert.ok(page.spinnerIsVisible);
 });
@@ -84,7 +84,7 @@ test('it has no spinner when not loading', function(assert) {
   assert.expect(1);
 
   this.set('isLoading', false);
-  page.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
+  this.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
 
   assert.notOk(page.spinnerIsVisible);
 });
@@ -92,7 +92,7 @@ test('it has no spinner when not loading', function(assert) {
 test('it sets the edit button class when editing', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{editor-with-preview}}`);
+  this.render(hbs`{{editor-with-preview}}`);
   this.set('editing', true);
 
   assert.ok(page.editButton.isActive);
@@ -101,7 +101,7 @@ test('it sets the edit button class when editing', function(assert) {
 test('it has the code theme selector', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{editor-with-preview}}`);
+  this.render(hbs`{{editor-with-preview}}`);
 
   assert.ok(page.codeThemeSelector.isVisible);
 });
@@ -110,7 +110,7 @@ test('it has a placeholder when provided', function(assert) {
   assert.expect(1);
 
   this.set('placeholder', 'Placeholder text');
-  page.render(hbs`{{editor-with-preview placeholder=placeholder}}`);
+  this.render(hbs`{{editor-with-preview placeholder=placeholder}}`);
 
   assert.equal(page.textarea.placeholder, 'Placeholder text');
 });
@@ -118,7 +118,7 @@ test('it has a placeholder when provided', function(assert) {
 test('it does not autofocus on first load if not provided', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{editor-with-preview}}`);
+  this.render(hbs`{{editor-with-preview}}`);
 
   assert.notOk(page.textarea.isFocused);
 });
@@ -126,7 +126,7 @@ test('it does not autofocus on first load if not provided', function(assert) {
 test('it autofocuses on second render if not provided', function(assert) {
   assert.expect(1);
 
-  page.render(hbs`{{editor-with-preview}}`);
+  this.render(hbs`{{editor-with-preview}}`);
   page.clickPreview();
   page.clickEdit();
 
@@ -137,7 +137,7 @@ test('it autofocuses on first load if provided', function(assert) {
   assert.expect(1);
 
   this.set('autofocus', true);
-  page.render(hbs`{{editor-with-preview autofocus=autofocus}}`);
+  this.render(hbs`{{editor-with-preview autofocus=autofocus}}`);
 
   assert.ok(page.textarea.isFocused);
 });
@@ -146,7 +146,7 @@ test('it sets the editor min-height to the editor height when previewing and sti
   assert.expect(1);
 
   this.set('isLoading', true);
-  page.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
+  this.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
 
   let height = this.$('.editor-with-preview').css('height');
 
@@ -159,7 +159,7 @@ test('it clears the editor style when previewing and done loading', function(ass
   assert.expect(2);
 
   this.set('isLoading', true);
-  page.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
+  this.render(hbs`{{editor-with-preview isLoading=isLoading}}`);
 
   page.clickPreview();
   assert.ok(page.style);
@@ -175,7 +175,7 @@ test('it sends the modifiedSubmit action with ctrl/cmd + enter', function(assert
     assert.equal(page.textarea.value, '', 'Action was called, input is unchanged.');
   });
 
-  page.render(hbs`{{editor-with-preview modifiedSubmit="modifiedSubmit"}}`);
+  this.render(hbs`{{editor-with-preview modifiedSubmit="modifiedSubmit"}}`);
 
   page.textarea.keySubmit();
 });

--- a/tests/integration/components/error-formatter-test.js
+++ b/tests/integration/components/error-formatter-test.js
@@ -37,10 +37,10 @@ test('it formats adapter error properly', function(assert) {
   ]);
 
   this.set('error', adapterError);
-  page.render(hbs`{{error-formatter error=error}}`);
-  assert.equal(page.errors().count, 2, 'Each error message is rendered');
-  assert.equal(page.errors(0).text, 'First: error', 'First message is rendered');
-  assert.equal(page.errors(1).text, 'Second: error', 'Second message is rendered');
+  this.render(hbs`{{error-formatter error=error}}`);
+  assert.equal(page.errors.length, 2, 'Each error message is rendered');
+  assert.equal(page.errors.objectAt(0).text, 'First: error', 'First message is rendered');
+  assert.equal(page.errors.objectAt(1).text, 'Second: error', 'Second message is rendered');
 });
 
 test('it formats friendly errors properly', function(assert) {
@@ -49,24 +49,24 @@ test('it formats friendly errors properly', function(assert) {
   let friendlyError = new FriendlyError('A friendly error');
 
   this.set('error', friendlyError);
-  page.render(hbs`{{error-formatter error=error}}`);
-  assert.equal(page.errors().count, 1, 'Error message is rendered');
-  assert.equal(page.errors(0).text, 'A friendly error', 'Message text is rendered');
+  this.render(hbs`{{error-formatter error=error}}`);
+  assert.equal(page.errors.length, 1, 'Error message is rendered');
+  assert.equal(page.errors.objectAt(0).text, 'A friendly error', 'Message text is rendered');
 });
 
 test('it formats stripe card error properly', function(assert) {
   assert.expect(1);
 
   this.set('error', mockStripeError);
-  page.render(hbs`{{error-formatter error=error}}`);
-  assert.equal(page.errors(0).text, mockStripeError.error.message, 'Message is rendered');
+  this.render(hbs`{{error-formatter error=error}}`);
+  assert.equal(page.errors.objectAt(0).text, mockStripeError.error.message, 'Message is rendered');
 });
 
 test('it displays a default message if the error structure is not supported', function(assert) {
   assert.expect(2);
 
   this.set('error', {});
-  page.render(hbs`{{error-formatter error=error}}`);
-  assert.equal(page.errors().count, 1, 'Each error message is rendered');
-  assert.equal(page.errors(0).text, 'An unexpected error has occured', 'Default message is rendered');
+  this.render(hbs`{{error-formatter error=error}}`);
+  assert.equal(page.errors.length, 1, 'Each error message is rendered');
+  assert.equal(page.errors.objectAt(0).text, 'An unexpected error has occured', 'Default message is rendered');
 });

--- a/tests/integration/components/error-wrapper-test.js
+++ b/tests/integration/components/error-wrapper-test.js
@@ -25,7 +25,7 @@ test('it renders all required elements for the 404 case', function(assert) {
   };
 
   this.set('model', error);
-  page.render(hbs`{{error-wrapper error=model}}`);
+  this.render(hbs`{{error-wrapper error=model}}`);
 
   assert.ok(page.has404Image, 'The 404 image renders');
   assert.equal(page.title, '404 Error', 'The title renders');
@@ -45,7 +45,7 @@ test('it renders all required elements for the 503 case', function(assert) {
   };
 
   this.set('model', error);
-  page.render(hbs`{{error-wrapper error=model}}`);
+  this.render(hbs`{{error-wrapper error=model}}`);
 
   assert.ok(page.hasMaintenanceIcon, 'The maintenance icon renders');
   assert.equal(page.title, 'Down for maintenance', 'The title renders');
@@ -65,7 +65,7 @@ test('it renders all required elements for the general error case', function(ass
   };
 
   this.set('model', error);
-  page.render(hbs`{{error-wrapper error=model}}`);
+  this.render(hbs`{{error-wrapper error=model}}`);
 
   assert.ok(page.hasServerErrorImage, 'The general error image renders');
   assert.equal(page.title, 'Server Error', 'The title renders');

--- a/tests/integration/components/flash-messages/fixed-position-test.js
+++ b/tests/integration/components/flash-messages/fixed-position-test.js
@@ -18,7 +18,7 @@ moduleForComponent('flash-messages/fixed-position', 'Integration | Component | f
 });
 
 test('it renders a fixed error message', function(assert) {
-  page.render(hbs`{{flash-messages/fixed-position}}`);
+  this.render(hbs`{{flash-messages/fixed-position}}`);
 
   run(() => {
     getOwner(this).lookup('service:flash-messages').add({

--- a/tests/integration/components/flash-messages/full-width-test.js
+++ b/tests/integration/components/flash-messages/full-width-test.js
@@ -18,7 +18,7 @@ moduleForComponent('flash-messages/full-width', 'Integration | Component | flash
 });
 
 test('it renders a normal success message', function(assert) {
-  page.render(hbs`{{flash-messages/full-width}}`);
+  this.render(hbs`{{flash-messages/full-width}}`);
 
   run(() => {
     getOwner(this).lookup('service:flash-messages').add({

--- a/tests/integration/components/github-connect-state-test.js
+++ b/tests/integration/components/github-connect-state-test.js
@@ -21,15 +21,12 @@ moduleForComponent('github-connect-state', 'Integration | Component | github con
   }
 });
 
-function renderPage() {
-  page.render(hbs`{{github-connect-state githubId=githubId githubAvatarUrl=githubAvatarUrl}}`);
-}
-
 test('it renders github user info if user is connected', function(assert) {
   assert.expect(2);
 
   set(this, 'githubId', 'foo');
-  renderPage();
+
+  this.render(hbs`{{github-connect-state githubId=githubId githubAvatarUrl=githubAvatarUrl}}`);
 
   assert.ok(page.githubUserInfo.isVisible, 'Github user info is rendered.');
   assert.notOk(page.githubConnect.isVisible, 'Github connect component is not rendered.');
@@ -39,7 +36,8 @@ test('it renders github connect component if user is not connected', function(as
   assert.expect(2);
 
   set(this, 'githubId', null);
-  renderPage();
+
+  this.render(hbs`{{github-connect-state githubId=githubId githubAvatarUrl=githubAvatarUrl}}`);
 
   assert.notOk(page.githubUserInfo.isVisible, 'Github user info is not rendered.');
   assert.ok(page.githubConnect.isVisible, 'Github connect component is rendered.');
@@ -50,7 +48,8 @@ test('it renders github resized github avatar url if user is connected', functio
 
   set(this, 'githubId', 'foo');
   set(this, 'githubAvatarUrl', 'bar');
-  renderPage();
+
+  this.render(hbs`{{github-connect-state githubId=githubId githubAvatarUrl=githubAvatarUrl}}`);
 
   assert.equal(page.githubUserInfo.avatar.url, 'bar&size=100', 'Resized avatar url is rendered.');
 });

--- a/tests/integration/components/github-connect-test.js
+++ b/tests/integration/components/github-connect-test.js
@@ -27,7 +27,7 @@ test('binds href correctly', function(assert) {
   set(this, 'scope', '3098379083');
   set(this, 'clientId', 'ace');
   set(this, 'redirectUri', 'ace.com');
-  page.render(hbs`{{github-connect scope=scope clientId=clientId state=state redirectUri=redirectUri}}`);
+  this.render(hbs`{{github-connect scope=scope clientId=clientId state=state redirectUri=redirectUri}}`);
 
   let session = this.container.lookup('service:session');
   let { githubState } = get(session, 'data');
@@ -44,6 +44,6 @@ test('tracks click event', function(assert) {
   };
   stubService(this, 'metrics', mockMetrics);
 
-  page.render(hbs`{{github-connect}}`);
+  this.render(hbs`{{github-connect}}`);
   page.click();
 });

--- a/tests/integration/components/github-repo-test.js
+++ b/tests/integration/components/github-repo-test.js
@@ -7,17 +7,6 @@ import githubRepoComponent from 'code-corps-ember/tests/pages/components/github-
 
 let page = PageObject.create(githubRepoComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{github-repo
-      connectRepo=connectRepoHandler
-      disconnectRepo=disconnectRepoHandler
-      githubRepo=githubRepo
-      project=project
-    }}
-  `);
-}
-
 moduleForComponent('github-repo', 'Integration | Component | github repo', {
   integration: true,
   beforeEach() {
@@ -32,7 +21,16 @@ test('it renders the github repo name', function(assert) {
   assert.expect(1);
   let githubRepo = { name: 'code-corps-ember', isLoaded: true };
   set(this, 'githubRepo', githubRepo);
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
+
   assert.equal(page.name.text, 'code-corps-ember');
 });
 
@@ -41,7 +39,14 @@ test('it changes state based on loading, presence of record', function(assert) {
 
   set(this, 'githubRepo', {});
 
-  renderPage();
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   run(() => set(this, 'githubRepo', { isLoaded: false }));
   assert.ok(page.loading.isVisible, 'With github repo loading, state should be loading.');
@@ -57,7 +62,15 @@ test('it changes actions based on sync state and settings', function(assert) {
   let project = { id: 1, isLoaded: true };
   set(this, 'githubRepo', githubRepo);
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   assert.equal(page.actions.connect.text, 'Connect', 'Connect link renders.');
 
@@ -91,7 +104,15 @@ test('it allows disconnecting', function(assert) {
   set(this, 'disconnectRepoHandler', function(passedRepo) {
     assert.deepEqual(githubRepo, passedRepo);
   });
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   page.click();
   page.callout.repoDisconnectConfirmModal.openButton.click();
@@ -109,7 +130,15 @@ test('it allows connecting', function(assert) {
   set(this, 'connectRepoHandler', function(passedRepo) {
     assert.deepEqual(githubRepo, passedRepo);
   });
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   page.click();
   assert.equal(page.callout.title.text, `Connect to ${githubRepo.name}`, 'Renders the callout title.');
@@ -131,7 +160,14 @@ test('it works with repos connected to other projects properly', function(assert
   set(this, 'githubRepo', githubRepo);
   set(this, 'project', project);
 
-  renderPage();
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   assert.notOk(page.actions.close.isVisible, 'Close link does not render for repo connected to other project.');
   assert.notOk(page.actions.connect.isVisible, 'Connect link does not render for repo connected to other project.');
@@ -155,7 +191,16 @@ test('clicking disconnected repo expands the UI', function(assert) {
 
   set(this, 'githubRepo', githubRepo);
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
+
   run(() => page.click());
 
   assert.ok(page.callout.isVisible, 'Page did expand');
@@ -173,7 +218,15 @@ test('clicking fully synced repo connected to current project expands the UI', f
 
   set(this, 'githubRepo', githubRepo);
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   run(() => page.click());
 
@@ -191,7 +244,15 @@ test('clicking repo connected to different project does nothing', function(asser
 
   set(this, 'githubRepo', githubRepo);
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   run(() => page.click());
 
@@ -210,7 +271,15 @@ test('clicking repo while syncing does nothing', function(assert) {
 
   set(this, 'githubRepo', githubRepo);
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`
+    {{github-repo
+      connectRepo=connectRepoHandler
+      disconnectRepo=disconnectRepoHandler
+      githubRepo=githubRepo
+      project=project
+    }}
+  `);
 
   run(() => page.click());
 

--- a/tests/integration/components/github/connected-installation-test.js
+++ b/tests/integration/components/github/connected-installation-test.js
@@ -6,18 +6,6 @@ import component from 'code-corps-ember/tests/pages/components/github/connected-
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{github/connected-installation
-      disconnect=(action disconnect)
-      connectRepo=(action connectRepo)
-      disconnectRepo=(action disconnectRepo)
-      organizationGithubAppInstallation=organizationGithubAppInstallation
-      project=project
-    }}
-  `);
-}
-
 function setHandlers(context, {
   disconnect = () => {},
   connectRepo = () => {},
@@ -64,17 +52,26 @@ test('renders correct elements for provided github app installation', function(a
   assert.expect(7);
 
   setProperties(this, { organizationGithubAppInstallation, project });
-  renderPage();
+
+  this.render(hbs`
+    {{github/connected-installation
+      disconnect=(action disconnect)
+      connectRepo=(action connectRepo)
+      disconnectRepo=(action disconnectRepo)
+      organizationGithubAppInstallation=organizationGithubAppInstallation
+      project=project
+    }}
+  `);
 
   assert.ok(page.avatar.url.indexOf('foo-url') > -1, 'Avatar url is rendered.');
   assert.equal(page.login.text, 'foo-login', 'Account login is rendered.');
   assert.ok(page.disconnect.text.indexOf(organization.name, 'Organization name is rendered on button.') > -1);
 
-  assert.equal(page.githubRepos().count, 3, 'All repos are rendered.');
+  assert.equal(page.githubRepos.length, 3, 'All repos are rendered.');
 
-  assert.equal(page.githubRepos(0).name.text, 'Connected Repo');
-  assert.equal(page.githubRepos(1).name.text, 'Unconnected Repo');
-  assert.ok(page.githubRepos(2).loading.isVisible, 'Repo is in loading state.');
+  assert.equal(page.githubRepos.objectAt(0).name.text, 'Connected Repo');
+  assert.equal(page.githubRepos.objectAt(1).name.text, 'Unconnected Repo');
+  assert.ok(page.githubRepos.objectAt(2).loading.isVisible, 'Repo is in loading state.');
 });
 
 test('triggers/passes out all actions', function(assert) {
@@ -95,13 +92,21 @@ test('triggers/passes out all actions', function(assert) {
     }
   });
 
-  renderPage();
+  this.render(hbs`
+    {{github/connected-installation
+      disconnect=(action disconnect)
+      connectRepo=(action connectRepo)
+      disconnectRepo=(action disconnectRepo)
+      organizationGithubAppInstallation=organizationGithubAppInstallation
+      project=project
+    }}
+  `);
 
-  page.githubRepos(0).click();
-  page.githubRepos(0).callout.repoDisconnectConfirmModal.openButton.click();
-  page.githubRepos(0).callout.repoDisconnectConfirmModal.modal.input.fillIn(connectedRepo.name);
-  page.githubRepos(0).callout.repoDisconnectConfirmModal.modal.disconnectButton.click();
-  page.githubRepos(1).click();
-  page.githubRepos(1).callout.button.click();
+  page.githubRepos.objectAt(0).click();
+  page.githubRepos.objectAt(0).callout.repoDisconnectConfirmModal.openButton.click();
+  page.githubRepos.objectAt(0).callout.repoDisconnectConfirmModal.modal.input.fillIn(connectedRepo.name);
+  page.githubRepos.objectAt(0).callout.repoDisconnectConfirmModal.modal.disconnectButton.click();
+  page.githubRepos.objectAt(1).click();
+  page.githubRepos.objectAt(1).callout.button.click();
   page.disconnect.click();
 });

--- a/tests/integration/components/github/install-link-test.js
+++ b/tests/integration/components/github/install-link-test.js
@@ -7,15 +7,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{github/install-link
-      organization=organization
-      project=project
-    }}
-  `);
-}
-
 moduleForComponent('github/install-link', 'Integration | Component | github/install link', {
   integration: true,
   beforeEach() {
@@ -48,7 +39,7 @@ test('it tracks clicking the link', function(assert) {
   set(this, 'organization', organization);
   set(this, 'project', project);
 
-  renderPage();
+  this.render(hbs`{{github/install-link organization=organization project=project}}`);
 
   page.click();
 });

--- a/tests/integration/components/github/issue-link-test.js
+++ b/tests/integration/components/github/issue-link-test.js
@@ -8,16 +8,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{github/issue-link
-      githubIssue=githubIssue
-      githubRepo=githubRepo
-      size=size
-    }}
-  `);
-}
-
 moduleForComponent('github/issue-link', 'Integration | Component | github/issue link', {
   integration: true,
   beforeEach() {
@@ -46,7 +36,7 @@ test('it renders with text and no tooltip when large', function(assert) {
   set(this, 'githubRepo', githubRepo);
   set(this, 'size', 'large');
 
-  renderPage();
+  this.render(hbs`{{github/issue-link githubIssue=githubIssue githubRepo=githubRepo size=size}}`);
 
   assert.equal(page.repoName.text, 'code-corps/code-corps-ember', 'The full repo name renders.');
   assert.equal(page.issueNumber.text, '#123', 'The issue number renders.');
@@ -60,7 +50,7 @@ test('it renders with no text and a tooltip when small', function(assert) {
   set(this, 'githubRepo', githubRepo);
   set(this, 'size', 'small');
 
-  renderPage();
+  this.render(hbs`{{github/issue-link githubIssue=githubIssue githubRepo=githubRepo size=size}}`);
 
   assert.notOk(page.repoName.isVisible, 'The repo name does not render.');
   assert.notOk(page.issueNumber.isVisible, 'The issue number does not render.');
@@ -84,7 +74,7 @@ test('it renders with loading when large', function(assert) {
   set(this, 'githubRepo', { isLoaded: false });
   set(this, 'size', 'large');
 
-  renderPage();
+  this.render(hbs`{{github/issue-link githubIssue=githubIssue githubRepo=githubRepo size=size}}`);
 
   assert.ok(page.loadingLarge.isVisible, 'The large loading state renders.');
 });
@@ -96,7 +86,7 @@ test('it renders with loading when small', function(assert) {
   set(this, 'githubRepo', { isLoaded: false });
   set(this, 'size', 'small');
 
-  renderPage();
+  this.render(hbs`{{github/issue-link githubIssue=githubIssue githubRepo=githubRepo size=size}}`);
 
   assert.ok(page.loadingSmall.isVisible, 'The small loading state renders.');
 });
@@ -115,7 +105,7 @@ test('it tracks clicking the link', function(assert) {
   set(this, 'githubIssue', githubIssue);
   set(this, 'githubRepo', githubRepo);
 
-  renderPage();
+  this.render(hbs`{{github/issue-link githubIssue=githubIssue githubRepo=githubRepo size=size}}`);
 
   page.url.click();
 });

--- a/tests/integration/components/github/pull-request-icon-test.js
+++ b/tests/integration/components/github/pull-request-icon-test.js
@@ -6,14 +6,6 @@ import { set } from '@ember/object';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{github/pull-request-icon
-      githubPullRequest=githubPullRequest
-    }}
-  `);
-}
-
 moduleForComponent('github/pull-request-icon', 'Integration | Component | github/pull request icon', {
   integration: true,
   beforeEach() {
@@ -26,31 +18,43 @@ moduleForComponent('github/pull-request-icon', 'Integration | Component | github
 
 test('it renders a purple merge icon if pull request merged', function(assert) {
   assert.expect(2);
+
   set(this, 'githubPullRequest', { merged: true });
-  renderPage();
+
+  this.render(hbs`{{github/pull-request-icon githubPullRequest=githubPullRequest}}`);
+
   assert.ok(page.spriteIcon.svg.hasClass('github-merge-48'), 'The svg renders a merge icon.');
   assert.ok(page.spriteIcon.svg.hasClass('solid-purple'), 'The svg renders a purple icon.');
 });
 
 test('it renders a red PR icon if pull request closed', function(assert) {
   assert.expect(2);
+
   set(this, 'githubPullRequest', { merged: false, state: 'closed' });
-  renderPage();
+
+  this.render(hbs`{{github/pull-request-icon githubPullRequest=githubPullRequest}}`);
+
   assert.ok(page.spriteIcon.svg.hasClass('github-pull-request-48'), 'The svg renders a PR icon.');
   assert.ok(page.spriteIcon.svg.hasClass('solid-red'), 'The svg renders a red icon.');
 });
 
 test('it renders a green PR icon if pull request open', function(assert) {
   assert.expect(2);
+
   set(this, 'githubPullRequest', { merged: false, state: 'open' });
-  renderPage();
+
+  this.render(hbs`{{github/pull-request-icon githubPullRequest=githubPullRequest}}`);
+
   assert.ok(page.spriteIcon.svg.hasClass('github-pull-request-48'), 'The svg renders a PR icon.');
   assert.ok(page.spriteIcon.svg.hasClass('solid-green'), 'The svg renders a green icon.');
 });
 
 test('it renders a loading icon in all other cases', function(assert) {
   assert.expect(1);
+
   set(this, 'githubPullRequest', null);
-  renderPage();
+
+  this.render(hbs`{{github/pull-request-icon githubPullRequest=githubPullRequest}}`);
+
   assert.ok(page.loadingIcon.isVisible, 'The loading icon renders.');
 });

--- a/tests/integration/components/github/repo-disconnect-confirm-modal-test.js
+++ b/tests/integration/components/github/repo-disconnect-confirm-modal-test.js
@@ -6,16 +6,6 @@ import pageComponent from 'code-corps-ember/tests/pages/components/github/repo-d
 
 let page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{github/repo-disconnect-confirm-modal
-      disconnect=disconnect
-      githubRepo=githubRepo
-      showModal=showModal
-    }}
-  `);
-}
-
 moduleForComponent('github/repo-disconnect-confirm-modal', 'Integration | Component | github/repo disconnect confirm modal', {
   integration: true,
   beforeEach() {
@@ -30,7 +20,13 @@ moduleForComponent('github/repo-disconnect-confirm-modal', 'Integration | Compon
 test('when button is clicked, modal opens', function(assert) {
   assert.expect(2);
 
-  renderPage();
+  this.render(hbs`
+    {{github/repo-disconnect-confirm-modal
+      disconnect=disconnect
+      githubRepo=githubRepo
+      showModal=showModal
+    }}
+  `);
 
   assert.notOk(page.modal.isVisible, 'Modal is initially hidden.');
   page.openButton.click();
@@ -41,7 +37,14 @@ test('when clicking outside the modal, the modal closes', function(assert) {
   assert.expect(2);
 
   set(this, 'showModal', true);
-  renderPage();
+
+  this.render(hbs`
+    {{github/repo-disconnect-confirm-modal
+      disconnect=disconnect
+      githubRepo=githubRepo
+      showModal=showModal
+    }}
+  `);
 
   assert.ok(page.modal.isVisible, 'Modal is initially visible.');
   page.overlay.click();
@@ -52,7 +55,14 @@ test('when hitting escape, the modal closes', function(assert) {
   assert.expect(2);
 
   set(this, 'showModal', true);
-  renderPage();
+
+  this.render(hbs`
+    {{github/repo-disconnect-confirm-modal
+      disconnect=disconnect
+      githubRepo=githubRepo
+      showModal=showModal
+    }}
+  `);
 
   assert.ok(page.modal.isVisible, 'Modal is initially visible.');
   page.modal.hitEscape();
@@ -69,7 +79,14 @@ test('when the name in the input matches the repo name', function(assert) {
     assert.ok(true, 'The disconnect action was called.');
   });
   set(this, 'showModal', true);
-  renderPage();
+
+  this.render(hbs`
+    {{github/repo-disconnect-confirm-modal
+      disconnect=disconnect
+      githubRepo=githubRepo
+      showModal=showModal
+    }}
+  `);
 
   page.modal.input.fillIn(githubRepo.name);
   page.modal.disconnectButton.click();
@@ -85,7 +102,14 @@ test('when the name in the input does not match the repo name', function(assert)
     assert.ok(true, 'The disconnect action was called.');
   });
   set(this, 'showModal', true);
-  renderPage();
+
+  this.render(hbs`
+    {{github/repo-disconnect-confirm-modal
+      disconnect=disconnect
+      githubRepo=githubRepo
+      showModal=showModal
+    }}
+  `);
 
   page.modal.input.fillIn('Tes');
   assert.ok(page.modal.disconnectButton.isDisabled, 'The button is disabled.');

--- a/tests/integration/components/github/repo-sync-test.js
+++ b/tests/integration/components/github/repo-sync-test.js
@@ -1,17 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { set } from '@ember/object';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import PageObject from 'ember-cli-page-object';
 import component from 'code-corps-ember/tests/pages/components/github/repo-sync';
 
 let page = PageObject.create(component);
-
-function renderPage() {
-  page.render(hbs`
-    {{github/repo-sync
-      githubRepo=githubRepo
-    }}
-  `);
-}
 
 function percentForStep(number) {
   return (number / 10) * 100;
@@ -29,8 +23,11 @@ moduleForComponent('github/repo-sync', 'Integration | Component | github/repo sy
 
 test('it renders everything for the default state', function(assert) {
   let githubRepo = { syncState: 'unsynced' };
-  this.set('githubRepo', githubRepo);
-  renderPage();
+
+  set(this, 'githubRepo', githubRepo);
+
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
+
   assert.ok(page.progressBar.displaysPercentage(0), 'The progress bar has not started.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Starting sync...', 'The progress text renders.');
@@ -38,63 +35,65 @@ test('it renders everything for the default state', function(assert) {
 });
 
 test('it renders for the sync states', function(assert) {
-  renderPage();
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
 
-  this.set('githubRepo', { syncState: 'fetching_pull_requests' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'fetching_pull_requests' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(1)), 'The progress bar has progressed to step 1.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Fetching pull requests...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubPullRequest, 'Pull request icon renders.');
 
-  this.set('githubRepo', { syncState: 'syncing_github_pull_requests', syncingPullRequestsCount: '1234' });
+  run(this, () => {
+    set(this, 'githubRepo', { syncState: 'syncing_github_pull_requests', syncingPullRequestsCount: '1234' });
+  });
   assert.ok(page.progressBar.displaysPercentage(percentForStep(2)), 'The progress bar has progressed to step 2.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Syncing 1,234 pull requests...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubPullRequest, 'Pull request icon renders.');
 
-  this.set('githubRepo', { syncState: 'fetching_issues' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'fetching_issues' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(3)), 'The progress bar has progressed to step 3.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Fetching issues...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubIssue, 'Issue icon renders.');
 
-  this.set('githubRepo', { syncState: 'syncing_github_issues', syncingIssuesCount: '1234' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_github_issues', syncingIssuesCount: '1234' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(4)), 'The progress bar has progressed to step 4.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Syncing 1,234 issues...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubIssue, 'Issue icon renders.');
 
-  this.set('githubRepo', { syncState: 'fetching_comments' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'fetching_comments' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(5)), 'The progress bar has progressed to step 5.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Fetching comments...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubComments, 'Comments icon renders.');
 
-  this.set('githubRepo', { syncState: 'syncing_github_comments', syncingCommentsCount: '1234' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_github_comments', syncingCommentsCount: '1234' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(6)), 'The progress bar has progressed to step 6.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Syncing 1,234 comments...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubComments, 'Comments icon renders.');
 
-  this.set('githubRepo', { syncState: 'syncing_users' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_users' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(7)), 'The progress bar has progressed to step 7.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Syncing GitHub users with Code Corps users...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isUser, 'User icon renders.');
 
-  this.set('githubRepo', { syncState: 'syncing_tasks' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_tasks' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(8)), 'The progress bar has progressed to step 8.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Syncing your GitHub issues with your tasks...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isTasks, 'Tasks icon renders.');
 
-  this.set('githubRepo', { syncState: 'syncing_comments' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_comments' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(9)), 'The progress bar has progressed to step 9.');
   assert.ok(page.progressBar.isAnimated, 'Progress bar is animated.');
   assert.equal(page.progressText.text, 'Syncing your GitHub comments with your comments...', 'The progress text renders.');
   assert.ok(page.spriteIcon.isComments, 'Comments icon renders.');
 
-  this.set('githubRepo', { syncState: 'synced' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'synced' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(10)), 'The progress bar has completed.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'Sync complete!', 'The progress text renders.');
@@ -102,58 +101,58 @@ test('it renders for the sync states', function(assert) {
 });
 
 test('it renders for the error states', function(assert) {
-  renderPage();
-  this.set('githubRepo', { syncState: 'errored_fetching_pull_requests' });
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
+
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_fetching_pull_requests' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(1)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred fetching your pull requests. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubPullRequest, 'Pull request icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_syncing_github_pull_requests' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_github_pull_requests' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(2)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred syncing your pull requests. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubPullRequest, 'Pull request icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_fetching_issues' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_fetching_issues' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(3)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred fetching your issues. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubIssue, 'Issue icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_syncing_github_issues' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_github_issues' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(4)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred syncing your issues. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubIssue, 'Issue icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_fetching_comments' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_fetching_comments' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(5)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred fetching your comments. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubComments, 'Comments icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_syncing_github_comments' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_github_comments' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(6)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred syncing your comments. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isGithubComments, 'Comments icon renders.');
 
-  this.set('githubRepo', { syncState: 'receiving_webhooks' });
-
-  this.set('githubRepo', { syncState: 'errored_syncing_users' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'receiving_webhooks' }));
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_users' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(7)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred syncing GitHub users with Code Corps users. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isUser, 'User icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_syncing_tasks' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_tasks' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(8)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred syncing your GitHub issues with your tasks. You can retry the sync now.', 'The progress text renders.');
   assert.ok(page.spriteIcon.isTasks, 'Tasks icon renders.');
 
-  this.set('githubRepo', { syncState: 'errored_syncing_comments' });
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_comments' }));
   assert.ok(page.progressBar.displaysPercentage(percentForStep(9)), 'The progress bar has stopped at the current stage.');
   assert.notOk(page.progressBar.isAnimated, 'Progress bar is not animated.');
   assert.equal(page.progressText.text, 'An error occurred syncing your GitHub comments with your comments. You can retry the sync now.', 'The progress text renders.');
@@ -161,25 +160,25 @@ test('it renders for the error states', function(assert) {
 });
 
 test('it does not renders the error progress bar for non-error states', function(assert) {
-  renderPage();
-  this.set('githubRepo', { syncState: 'syncing_github_comments' });
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_github_comments' }));
   assert.notOk(page.progressBar.hasError, 'Progress bar has no error state.');
 });
 
 test('it renders a solid blue icon for non-error states', function(assert) {
-  renderPage();
-  this.set('githubRepo', { syncState: 'syncing_github_comments' });
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
+  run(this, () => set(this, 'githubRepo', { syncState: 'syncing_github_comments' }));
   assert.ok(page.spriteIcon.svg.isSolidBlue, 'Icon is solid blue.');
 });
 
 test('it renders an error progress bar for the error states', function(assert) {
-  renderPage();
-  this.set('githubRepo', { syncState: 'errored_syncing_github_comments' });
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_github_comments' }));
   assert.ok(page.progressBar.hasError, 'Progress bar has the error state.');
 });
 
 test('it renders a solid red icon for error states', function(assert) {
-  renderPage();
-  this.set('githubRepo', { syncState: 'errored_syncing_github_comments' });
+  this.render(hbs`{{github/repo-sync githubRepo=githubRepo}}`);
+  run(this, () => set(this, 'githubRepo', { syncState: 'errored_syncing_github_comments' }));
   assert.ok(page.spriteIcon.svg.isSolidRed, 'Icon is solid red.');
 });

--- a/tests/integration/components/github/unconnected-installation-test.js
+++ b/tests/integration/components/github/unconnected-installation-test.js
@@ -7,16 +7,6 @@ import component from 'code-corps-ember/tests/pages/components/github/unconnecte
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{github/unconnected-installation
-      connect=(action connect)
-      githubAppInstallation=githubAppInstallation
-      organization=organization
-    }}
-  `);
-}
-
 function setHandlers(context, connect = () => {}) {
   set(context, 'connect', connect);
 }
@@ -44,7 +34,14 @@ test('renders correct elements for provided github app installation', function(a
   assert.expect(3);
 
   setProperties(this, { githubAppInstallation, organization });
-  renderPage();
+
+  this.render(hbs`
+    {{github/unconnected-installation
+      connect=(action connect)
+      githubAppInstallation=githubAppInstallation
+      organization=organization
+    }}
+  `);
 
   assert.ok(page.avatar.url.indexOf('foo-url') > -1, 'Avatar url is rendered.');
   assert.equal(page.login.text, 'foo-login', 'Account login is rendered.');
@@ -59,7 +56,13 @@ test('triggers/passes out all actions action', function(assert) {
     assert.ok('Connect action was called.');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{github/unconnected-installation
+      connect=(action connect)
+      githubAppInstallation=githubAppInstallation
+      organization=organization
+    }}
+  `);
 
   run(() => page.connect.click());
 });

--- a/tests/integration/components/image-drop-test.js
+++ b/tests/integration/components/image-drop-test.js
@@ -24,7 +24,7 @@ let droppedImageString = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEA
 test('it renders default state without a photo', function(assert) {
   // Set any properties with set(this, 'myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });"
-  page.render(hbs`{{image-drop}}`);
+  this.render(hbs`{{image-drop}}`);
 
   assert.equal(this.$('p.help-text').text().trim(), 'Click to add your photo.');
   assert.notOk(page.dropZone.isActive);
@@ -34,7 +34,7 @@ test('it renders default state without a photo', function(assert) {
 });
 
 test('it reacts to dragging on the application', function(assert) {
-  page.render(hbs`
+  this.render(hbs`
     {{#drag-zone}}
       {{image-drop}}
     {{/drag-zone}}
@@ -48,7 +48,7 @@ test('it reacts to dragging on the application', function(assert) {
 });
 
 test('it reacts to dragging on itself', function(assert) {
-  page.render(hbs`{{image-drop}}`);
+  this.render(hbs`{{image-drop}}`);
 
   this.$('.image-drop').trigger('dragover');
   assert.ok(page.dropZone.isActive);
@@ -60,7 +60,7 @@ test('it reacts to dragging on itself', function(assert) {
 test('it renders the original image', function(assert) {
   set(this, 'originalImage', originalImageString);
 
-  page.render(hbs`{{image-drop originalImage=originalImage}}`);
+  this.render(hbs`{{image-drop originalImage=originalImage}}`);
 
   let style = this.$('.image-drop').css('background-image');
   let expectedStyle = `url(${originalImageString})`;
@@ -71,7 +71,7 @@ test('it renders the dropped image', function(assert) {
   set(this, 'originalImage', originalImageString);
   set(this, 'droppedImage', droppedImageString);
 
-  page.render(hbs`{{image-drop originalImage=originalImage droppedImage=droppedImage}}`);
+  this.render(hbs`{{image-drop originalImage=originalImage droppedImage=droppedImage}}`);
 
   let style = this.$('.image-drop').css('background-image');
   let expectedStyle = `url(${droppedImageString})`;
@@ -80,7 +80,7 @@ test('it renders the dropped image', function(assert) {
 
 test('it handles a dropped image file', function(assert) {
   set(this, 'originalImage', originalImageString);
-  page.render(hbs`{{image-drop originalImage=originalImage}}`);
+  this.render(hbs`{{image-drop originalImage=originalImage}}`);
   let fileName = 'file.png';
 
   this.$('.image-drop').trigger('dragover');
@@ -96,7 +96,7 @@ test('it handles a dropped image file', function(assert) {
 
 test('it does not show the hover text if not hovering', function(assert) {
   set(this, 'hoverText', 'Some hover text.');
-  page.render(hbs`{{image-drop hoverText=hoverText}}`);
+  this.render(hbs`{{image-drop hoverText=hoverText}}`);
 
   assert.equal(this.$('.hover').text().trim(), 'Some hover text.');
   assert.equal(this.$('.hover').css('display'), 'none');
@@ -108,7 +108,7 @@ test('it does not show the hover text if not hovering', function(assert) {
 //   set(this, 'hoverText', 'Some hover text.');
 //   set(this, 'originalImage', originalImageString);
 
-//   page.render(hbs`{{image-drop originalImage=originalImage hoverText=hoverText}}`);
+//   this.render(hbs`{{image-drop originalImage=originalImage hoverText=hoverText}}`);
 
 //   Ember.run(() => { this.$('.image-drop').trigger('mouseenter'); });
 
@@ -117,7 +117,7 @@ test('it does not show the hover text if not hovering', function(assert) {
 // });
 
 test('it is circular if circle passed in', function(assert) {
-  page.render(hbs`{{image-drop circle=true}}`);
+  this.render(hbs`{{image-drop circle=true}}`);
 
   assert.ok(page.dropZone.isCircle);
 });

--- a/tests/integration/components/navigation-menu-test.js
+++ b/tests/integration/components/navigation-menu-test.js
@@ -6,10 +6,6 @@ import pageComponent from 'code-corps-ember/tests/pages/components/navigation-me
 
 const page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`{{navigation-menu}}`);
-}
-
 moduleForComponent('navigation-menu', 'Integration | Component | navigation menu', {
   integration: true,
   beforeEach() {
@@ -23,7 +19,7 @@ moduleForComponent('navigation-menu', 'Integration | Component | navigation menu
 test('it renders elements for the default menu when logged out', function(assert) {
   assert.expect(9);
 
-  renderPage();
+  this.render(hbs`{{navigation-menu}}`);
 
   assert.ok(page.logo.isVisible, 'The logo is rendered.');
   assert.ok(page.projectsLink.isVisible, 'The link to projects route is rendered');
@@ -41,7 +37,7 @@ test('it renders elements for the default menu when logged in', function(assert)
 
   stubService(this, 'session', { isAuthenticated: true });
 
-  renderPage();
+  this.render(hbs`{{navigation-menu}}`);
 
   assert.ok(page.logo.isVisible, 'The logo is rendered.');
   assert.ok(page.projectsLink.isVisible, 'The link to projects route is rendered');
@@ -68,7 +64,7 @@ test('it renders elements for the onboarding menu correctly when on onboarding r
     progressPercentage: 25
   });
 
-  renderPage();
+  this.render(hbs`{{navigation-menu}}`);
 
   assert.ok(page.logo.isVisible, 'The logo is rendered.');
   assert.notOk(page.projectsLink.isVisible, 'The link to projects route is not rendered.');
@@ -96,7 +92,7 @@ test('it renders elements for the onboarding menu correctly when on project.than
     isViewingOnboarding: false
   });
 
-  renderPage();
+  this.render(hbs`{{navigation-menu}}`);
 
   assert.ok(page.logo.isVisible, 'The logo is rendered.');
   assert.notOk(page.projectsLink.isVisible, 'The link to projects route is not rendered');
@@ -125,7 +121,7 @@ test('it renders the project switcher menu when the user has organizations', fun
   });
   stubService(this, 'session', { isAuthenticated: true });
 
-  renderPage();
+  this.render(hbs`{{navigation-menu}}`);
 
   assert.ok(page.projectSwitcher.isVisible, 'The project switcher is rendered.');
 });
@@ -140,7 +136,7 @@ test('it does not render the project switcher menu when the user has no organiza
   });
   stubService(this, 'session', { isAuthenticated: true });
 
-  renderPage();
+  this.render(hbs`{{navigation-menu}}`);
 
   assert.notOk(page.projectSwitcher.isVisible, 'The project switcher is not rendered.');
 });

--- a/tests/integration/components/organization-header-test.js
+++ b/tests/integration/components/organization-header-test.js
@@ -27,7 +27,7 @@ test('it renders properly when not expanded', function(assert) {
 
   this.set('organization', organization);
 
-  page.render(hbs`{{organization-header organization=organization}}`);
+  this.render(hbs`{{organization-header organization=organization}}`);
 
   assert.notOk(page.isExpanded, 'Does not have expanded class');
   assert.equal(page.image.src, 'icon_thumb.png', 'Has a small image');
@@ -41,7 +41,7 @@ test('it renders properly when expanded', function(assert) {
 
   this.set('organization', organization);
 
-  page.render(hbs`{{organization-header organization=organization expanded=true}}`);
+  this.render(hbs`{{organization-header organization=organization expanded=true}}`);
 
   assert.ok(page.isExpanded, 'Has expanded class');
   assert.equal(page.image.src, 'icon_large.png', 'Has a large image');

--- a/tests/integration/components/organization-profile-test.js
+++ b/tests/integration/components/organization-profile-test.js
@@ -33,7 +33,7 @@ test('it renders all its elements', function(assert) {
 
   this.set('organization', organization);
 
-  page.render(hbs`{{organization-profile organization=organization}}`);
+  this.render(hbs`{{organization-profile organization=organization}}`);
 
   assert.ok(page.organizationHeader.isVisible, 'The header component renders');
   assert.ok(page.organizationHeader.isExpanded, 'The header is expanded');
@@ -42,5 +42,5 @@ test('it renders all its elements', function(assert) {
 
   // Test components populate with right data
   assert.equal(page.organizationHeader.title.text, 'Test Organization', 'The header has data');
-  assert.equal(page.projectList.items().count, 3, 'The projects render');
+  assert.equal(page.projectList.items.length, 3, 'The projects render');
 });

--- a/tests/integration/components/organization-settings-form-test.js
+++ b/tests/integration/components/organization-settings-form-test.js
@@ -30,7 +30,7 @@ test('it renders form elements', function(assert) {
 
   set(this, 'organization', organization);
 
-  page.render(hbs`{{organization-settings-form organization=organization}}`);
+  this.render(hbs`{{organization-settings-form organization=organization}}`);
 
   assert.equal(page.name.value, 'Test Organization');
   assert.equal(page.description.value, 'A test organization');
@@ -47,7 +47,7 @@ test('it calls save on organization when save button is clicked', function(asser
 
   set(this, 'organization', organization);
 
-  page.render(hbs`{{organization-settings-form organization=organization}}`);
+  this.render(hbs`{{organization-settings-form organization=organization}}`);
 
   page.save.click();
 

--- a/tests/integration/components/organization-settings-test.js
+++ b/tests/integration/components/organization-settings-test.js
@@ -21,7 +21,7 @@ moduleForComponent('organization-settings', 'Integration | Component | organizat
 test('it renders properly', function(assert) {
   assert.expect(2);
 
-  page.render(hbs`{{organization-settings}}`);
+  this.render(hbs`{{organization-settings}}`);
 
   assert.ok(page.organizationHeader.isVisible);
   assert.ok(page.organizationMenu.isVisible);

--- a/tests/integration/components/payments/account-setup-test.js
+++ b/tests/integration/components/payments/account-setup-test.js
@@ -22,8 +22,8 @@ function setHandlers(context, {
   });
 }
 
-function renderPage() {
-  page.render(hbs`
+function renderPage(testContext) {
+  testContext.render(hbs`
     {{payments/account-setup
       isBusy=isBusy
       onBankAccountInformationSubmitted=onBankAccountInformationSubmitted
@@ -62,7 +62,7 @@ test('it works properly when account needs to be created', function(assert) {
   }
 
   setHandlers(this, { onCreateStripeConnectAccount });
-  renderPage();
+  renderPage(this);
 
   // ensure correct component is rendered
   assert.ok(page.rendersCreateAccount, 'Create account form is rendered');
@@ -81,7 +81,7 @@ test('it works properly when account needs fund recipient information', function
   }
 
   setHandlers(this, { onRecipientDetailsSubmitted });
-  renderPage();
+  renderPage(this);
 
   assert.ok(page.rendersFundsRecipientRequired, 'Funds recipient component is rendered.');
   assert.ok(page.fundsRecipient.rendersDetailsFormRequired, 'Funds recipient details subcomponent is rendered.');
@@ -101,7 +101,7 @@ test('it works properly when account needs a document', function(assert) {
   }
 
   setHandlers(this, { onVerificationDocumentSubmitted });
-  renderPage();
+  renderPage(this);
 
   assert.ok(page.rendersFundsRecipientVerifying, 'Funds recipient component is rendered in verifying state.');
   assert.ok(page.fundsRecipient.rendersVerificationDocumentRequired, 'Document form is rendered.');
@@ -126,7 +126,7 @@ test('it works properly when account needs personal id information', function(as
   }
 
   setHandlers(this, { onLegalEntityPersonalIdNumberSubmitted });
-  renderPage();
+  renderPage(this);
 
   assert.ok(page.rendersFundsRecipientVerifying, 'Funds recipinet component is rendered in verifying state.');
   assert.ok(page.fundsRecipient.rendersLegalEntityPersonalIdNumberRequired, 'Personal id number subcomponent is rendered in required state.');
@@ -155,7 +155,7 @@ test('it works properly when account needs bank account information', function(a
   }
 
   setHandlers(this, { onBankAccountInformationSubmitted });
-  renderPage();
+  renderPage(this);
 
   assert.ok(page.rendersFundsRecipientVerified, 'Funds recipient component is rendered in verified state.');
   assert.ok(page.rendersBankAccountRequired, 'Bank account component is rendered in required state.');
@@ -177,7 +177,7 @@ test('it works properly when account is fully verified', function(assert) {
     bankAccountStatus: 'verified'
   });
 
-  renderPage();
+  renderPage(this);
 
   assert.ok(page.rendersFundsRecipientVerified, 'Funds recipient component is rendered in verified state.');
   assert.ok(page.rendersBankAccountVerified, 'Bank account component is rendered in verified state.');

--- a/tests/integration/components/payments/bank-account-test.js
+++ b/tests/integration/components/payments/bank-account-test.js
@@ -11,16 +11,6 @@ function setHandler(context, submitHandler = function() {}) {
   context.set('submitHandler', submitHandler);
 }
 
-function renderPage() {
-  page.render(hbs`
-    {{payments/bank-account
-      isBusy=isBusy
-      stripeConnectAccount=stripeConnectAccount
-      submit=submitHandler
-    }}
-  `);
-}
-
 moduleForComponent('payments/bank-account', 'Integration | Component | payments/bank account', {
   integration: true,
   beforeEach() {
@@ -38,7 +28,13 @@ test('it renders correctly for "pending" status', function(assert) {
   let stripeConnectAccount = { bankAccountStatus: 'pending_requirement' };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/bank-account
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler
+    }}
+  `);
 
   assert.ok(page.rendersPending, 'Component is rendered in pending status.');
 });
@@ -49,7 +45,13 @@ test('it renders correctly for "required" status', function(assert) {
   let stripeConnectAccount = { bankAccountStatus: 'required' };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/bank-account
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler
+    }}
+  `);
 
   assert.ok(page.rendersRequired, 'Component is rendered in required mode.');
   assert.ok(page.rendersAccountNumberField, 'Renders the account number field.');
@@ -68,7 +70,13 @@ test('it renders correctly for "verified" status', function(assert) {
   };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/bank-account
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler
+    }}
+  `);
 
   assert.ok(page.rendersVerified, 'Component is rendered in verified mode.');
   assert.equal(page.bankNameText, 'Wells Fargo', 'Renders bank account name.');
@@ -91,7 +99,14 @@ test('it sends properties with submit action', function(assert) {
     assert.deepEqual({ accountNumber, routingNumber }, input, 'Correct parameters were sent out with action.');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/bank-account
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler
+    }}
+  `);
+
   page.accountNumber(input.accountNumber)
     .routingNumber(input.routingNumber)
     .clickSubmit();
@@ -104,7 +119,13 @@ test('it disables controls when busy', function(assert) {
   set(this, 'isBusy', true);
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/bank-account
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler
+    }}
+  `);
 
   assert.ok(page.accountNumberFieldIsDisabled, 'Account number field is disabled when busy.');
   assert.ok(page.routingNumberFieldIsDisabled, 'Routing number field is disabled when buys.');

--- a/tests/integration/components/payments/contact-info-test.js
+++ b/tests/integration/components/payments/contact-info-test.js
@@ -18,7 +18,7 @@ moduleForComponent('payments/contact-info', 'Integration | Component | payments/
 
 test('it renders email', function(assert) {
   assert.expect(1);
-  page.render(hbs`{{payments/contact-info email='test@example.com'}}`);
+  this.render(hbs`{{payments/contact-info email='test@example.com'}}`);
   assert.equal(page.email, 'test@example.com', 'The email is rendered');
 });
 

--- a/tests/integration/components/payments/create-account-test.js
+++ b/tests/integration/components/payments/create-account-test.js
@@ -12,16 +12,6 @@ function setHandler(context, submitHandler = function() {}) {
   context.set('submitHandler', submitHandler);
 }
 
-function renderPage() {
-  page.render(hbs`
-    {{payments/create-account
-      isBusy=isBusy
-      onCreateStripeConnectAccount=submitHandler
-      stripeConnectAccount=stripeConnectAccount
-    }}
-  `);
-}
-
 moduleForComponent('payments/create-account', 'Integration | Component | payments/create account', {
   integration: true,
   beforeEach() {
@@ -36,7 +26,15 @@ moduleForComponent('payments/create-account', 'Integration | Component | payment
 test('it renders correctly when there is no stripeConnectAccount', function(assert) {
   assert.expect(3);
   set(this, 'stripeConnectAccount', null);
-  renderPage();
+
+  this.render(hbs`
+    {{payments/create-account
+      isBusy=isBusy
+      onCreateStripeConnectAccount=submitHandler
+      stripeConnectAccount=stripeConnectAccount
+    }}
+  `);
+
   assert.ok(page.rendersHeader, 'Renders header');
   assert.ok(page.hasRequiredStatus, 'Is required');
   assert.ok(page.rendersSection, 'Renders section');
@@ -45,7 +43,15 @@ test('it renders correctly when there is no stripeConnectAccount', function(asse
 test('it renders correctly when there is a stripeConnectAccount', function(assert) {
   assert.expect(3);
   set(this, 'stripeConnectAccount', { id: 1 });
-  renderPage();
+
+  this.render(hbs`
+    {{payments/create-account
+      isBusy=isBusy
+      onCreateStripeConnectAccount=submitHandler
+      stripeConnectAccount=stripeConnectAccount
+    }}
+  `);
+
   assert.ok(page.rendersHeader, 'Renders header');
   assert.ok(page.hasVerifiedStatus, 'Is verified');
   assert.notOk(page.rendersSection, 'Does not render section');
@@ -54,7 +60,13 @@ test('it renders correctly when there is a stripeConnectAccount', function(asser
 test('it renders "Terms of Service" acceptance info', function(assert) {
   assert.expect(2);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/create-account
+      isBusy=isBusy
+      onCreateStripeConnectAccount=submitHandler
+      stripeConnectAccount=stripeConnectAccount
+    }}
+  `);
 
   // This is some pretty specific testing we have here, but I think, for legal purposes, it makes sense for tests to ensure
   // no one clears the element containing this text by accident.
@@ -77,7 +89,14 @@ test('it sends properties with submit action', function(assert) {
     assert.equal(diff, 0, 'The timestamp uses seconds and not milliseconds');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/create-account
+      isBusy=isBusy
+      onCreateStripeConnectAccount=submitHandler
+      stripeConnectAccount=stripeConnectAccount
+    }}
+  `);
+
   page.countrySelect.country.fillIn('US');
   page.clickSubmit();
 });
@@ -87,6 +106,13 @@ test('it disables controls when busy', function(assert) {
 
   set(this, 'isBusy', true);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/create-account
+      isBusy=isBusy
+      onCreateStripeConnectAccount=submitHandler
+      stripeConnectAccount=stripeConnectAccount
+    }}
+  `);
+
   assert.ok(page.submitButtonIsDisabled, 'Submit button is disabled when busy.');
 });

--- a/tests/integration/components/payments/donation-goals-test.js
+++ b/tests/integration/components/payments/donation-goals-test.js
@@ -7,15 +7,6 @@ import paymentsDonationGoalsComponent from '../../../pages/components/payments/d
 
 let page = PageObject.create(paymentsDonationGoalsComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{payments/donation-goals
-      project=project
-      stripeConnectAccount=stripeConnectAccount
-    }}
-  `);
-}
-
 moduleForComponent('payments/donation-goals', 'Integration | Component | payments/donation goals', {
   integration: true,
   beforeEach() {
@@ -28,7 +19,9 @@ moduleForComponent('payments/donation-goals', 'Integration | Component | payment
 
 test('it renders correctly when pending requirement', function(assert) {
   assert.expect(3);
-  renderPage();
+
+  this.render(hbs`{{payments/donation-goals project=project stripeConnectAccount=stripeConnectAccount}}`);
+
   assert.ok(page.rendersHeader, 'Renders header');
   assert.ok(page.hasPendingRequirementStatus, 'Is pending requirement');
   assert.notOk(page.rendersSection, 'Does not render section');
@@ -36,9 +29,12 @@ test('it renders correctly when pending requirement', function(assert) {
 
 test('it renders correctly when required', function(assert) {
   assert.expect(3);
+
   set(this, 'project', { donationsActive: false });
   set(this, 'stripeConnectAccount', { payoutsEnabled: true });
-  renderPage();
+
+  this.render(hbs`{{payments/donation-goals project=project stripeConnectAccount=stripeConnectAccount}}`);
+
   assert.ok(page.rendersHeader, 'Renders header');
   assert.ok(page.hasRequiredStatus, 'Is required');
   assert.ok(page.rendersSection, 'Renders section');
@@ -46,9 +42,12 @@ test('it renders correctly when required', function(assert) {
 
 test('it renders correctly when verified', function(assert) {
   assert.expect(3);
+
   set(this, 'project', { donationsActive: true });
   set(this, 'stripeConnectAccount', { payoutsEnabled: true });
-  renderPage();
+
+  this.render(hbs`{{payments/donation-goals project=project stripeConnectAccount=stripeConnectAccount}}`);
+
   assert.ok(page.rendersHeader, 'Renders header');
   assert.ok(page.hasVerifiedStatus, 'Is verified');
   assert.notOk(page.rendersSection, 'Does not render section');
@@ -56,8 +55,11 @@ test('it renders correctly when verified', function(assert) {
 
 test('it renders a link to set up donation goals when possible', function(assert) {
   assert.expect(1);
+
   set(this, 'project', { canActivateDonations: true, donationsActive: false });
   set(this, 'stripeConnectAccount', { payoutsEnabled: true });
-  renderPage();
+
+  this.render(hbs`{{payments/donation-goals project=project stripeConnectAccount=stripeConnectAccount}}`);
+
   assert.ok(page.rendersLinkToDonationGoals, 'Renders link to donation goals.');
 });

--- a/tests/integration/components/payments/funds-recipient-test.js
+++ b/tests/integration/components/payments/funds-recipient-test.js
@@ -11,17 +11,6 @@ function setHandlers(context, { detailsHandler = function() {}, documentHandler 
   setProperties(context, { detailsHandler, documentHandler, idHandler });
 }
 
-function renderPage() {
-  page.render(hbs`
-    {{payments/funds-recipient
-      stripeConnectAccount=stripeConnectAccount
-      onRecipientDetailsSubmitted=detailsHandler
-      onVerificationDocumentSubmitted=documentHandler
-      onLegalEntityPersonalIdNumberSubmitted=idHandler
-    }}
-  `);
-}
-
 moduleForComponent('payments/funds-recipient', 'Integration | Component | payments/funds recipient', {
   integration: true,
   beforeEach() {
@@ -39,7 +28,14 @@ test('it renders correctly when "pending"', function(assert) {
   let stripeConnectAccount = { recipientStatus: 'pending_requirement' };
   this.set('stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   assert.ok(page.rendersPending, 'Component is rendered in pending mode.');
 });
@@ -50,7 +46,14 @@ test('it renders correctly when "required"', function(assert) {
   let stripeConnectAccount = { recipientStatus: 'required' };
   this.set('stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   assert.ok(page.rendersRequired, 'Component is rendered in required mode.');
   assert.ok(page.rendersDetailsForm, 'Component renders the details form subcomponent.');
@@ -62,7 +65,14 @@ test('it renders correctly when "verifying" and document status "required"', fun
   let stripeConnectAccount = { recipientStatus: 'verifying' };
   this.set('stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   assert.ok(page.rendersVerifying, 'Component is rendered in verifying mode.');
   assert.ok(page.rendersVerificationDocument, 'Component renders the verification document subcomponent.');
@@ -79,7 +89,14 @@ test('it renders correctly when "verified"', function(assert) {
   };
   this.set('stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   assert.ok(page.rendersVerified, 'Component is rendered in verified mode.');
   assert.equal(page.individualNameText, 'Joe Individual', 'Component renders the name of the registered individual.');
@@ -97,7 +114,14 @@ test('it renders correctly when "verified" for company', function(assert) {
   };
   this.set('stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   assert.ok(page.rendersVerified, 'Component is rendered in verified mode.');
   assert.ok(page.individualNameText, 'Joe Individual', 'Component renders the name of the registered individual.');
@@ -115,7 +139,14 @@ test('it passes out submit action from details subcomponent', function(assert) {
   }
   setHandlers(this, { detailsHandler });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   page.detailsForm.clickSubmit();
 });
@@ -133,7 +164,14 @@ test('it passes out submit action from details subcomponent', function(assert) {
 //   };
 //   setHandlers(this, { documentHandler });
 
-//   renderPage();
+// this.render(hbs`
+//   {{payments/funds-recipient
+//     stripeConnectAccount=stripeConnectAccount
+//     onRecipientDetailsSubmitted=detailsHandler
+//     onVerificationDocumentSubmitted=documentHandler
+//     onLegalEntityPersonalIdNumberSubmitted=idHandler
+//   }}
+// `);
 
 //   page.verificationDocument.pickFile(this);
 // });
@@ -149,7 +187,14 @@ test('it passes out submit action from personal id number subcomponent', functio
   }
   setHandlers(this, { idHandler });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient
+      stripeConnectAccount=stripeConnectAccount
+      onRecipientDetailsSubmitted=detailsHandler
+      onVerificationDocumentSubmitted=documentHandler
+      onLegalEntityPersonalIdNumberSubmitted=idHandler
+    }}
+  `);
 
   page.legalEntityPersonalIdNumber.clickSubmit();
 });

--- a/tests/integration/components/payments/funds-recipient/details-form-test.js
+++ b/tests/integration/components/payments/funds-recipient/details-form-test.js
@@ -7,12 +7,6 @@ import detailsFormComponent from 'code-corps-ember/tests/pages/components/paymen
 
 let page = PageObject.create(detailsFormComponent);
 
-function renderPage() {
-  page.render(
-    hbs`{{payments/funds-recipient/details-form stripeConnectAccount=stripeConnectAccount onSubmit=onSubmit}}`
-  );
-}
-
 moduleForComponent('payments/funds-recipient/details-form', 'Integration | Component | payments/funds recipient/details form', {
   integration: true,
   beforeEach() {
@@ -50,7 +44,9 @@ test('it keeps the business properties when submitting in business mode', functi
 
   this.set('stripeConnectAccount', account);
 
-  renderPage();
+  this.render(
+    hbs`{{payments/funds-recipient/details-form stripeConnectAccount=stripeConnectAccount onSubmit=onSubmit}}`
+  );
 
   page.selectCompany()
     .legalEntityBusinessName(account.legalEntityBusinessName)
@@ -99,7 +95,9 @@ test('it unsets the business properties when submitting in individual mode', fun
 
   this.set('stripeConnectAccount', account);
 
-  renderPage();
+  this.render(
+    hbs`{{payments/funds-recipient/details-form stripeConnectAccount=stripeConnectAccount onSubmit=onSubmit}}`
+  );
 
   page.selectIndividual()
     .legalEntityFirstName(account.legalEntityFirstName)

--- a/tests/integration/components/payments/funds-recipient/identity-document-file-upload-test.js
+++ b/tests/integration/components/payments/funds-recipient/identity-document-file-upload-test.js
@@ -58,10 +58,6 @@ moduleForComponent(
   }
 );
 
-function renderPage() {
-  page.render(template);
-}
-
 test('it renders', function(assert) {
   assert.expect(1);
   this.render(hbs`{{payments/funds-recipient/identity-document-file-upload}}`);
@@ -86,7 +82,7 @@ test('it sends uploadStarted, uploadProgress, uploadDone actions on valid upload
     done();
   });
 
-  renderPage();
+  this.render(template);
 
   // we specify timing, so that the underlying pretender instance will do
   // progress updates as well
@@ -105,7 +101,7 @@ test('it sends a validationError action if file is larger than 8mb', function(as
     done();
   });
 
-  renderPage();
+  this.render(template);
 
   page.selectFile(largePNG);
 });
@@ -121,7 +117,7 @@ test('it sends a validationError action if file not a jpg or a png', function(as
     done();
   });
 
-  renderPage();
+  this.render(template);
 
   this.server.post('https://uploads.stripe.com/v1/files', { id: 'ok' });
 
@@ -140,7 +136,7 @@ test('it sends uploadError when there is a server issue', function(assert) {
     done();
   });
 
-  renderPage();
+  this.render(template);
 
   // we specify timing, so that the underlying pretender instance will do
   // progress updates as well

--- a/tests/integration/components/payments/funds-recipient/personal-id-number-test.js
+++ b/tests/integration/components/payments/funds-recipient/personal-id-number-test.js
@@ -11,15 +11,6 @@ function setHandler(context, submitHandler = function() {}) {
   set(context, 'submitHandler', submitHandler);
 }
 
-function renderPage() {
-  page.render(hbs`
-    {{payments/funds-recipient/personal-id-number
-      isBusy=isBusy
-      stripeConnectAccount=stripeConnectAccount
-      submit=submitHandler}}
-  `);
-}
-
 moduleForComponent('payments/funds-recipient/personal-id-number', 'Integration | Component | payments/funds recipient/personal id number', {
   integration: true,
   beforeEach() {
@@ -37,7 +28,12 @@ test('it renders correctly for "pending" status', function(assert) {
   let stripeConnectAccount = { personalIdNumberStatus: 'pending_requirement' };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/personal-id-number
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler}}
+  `);
 
   assert.equal(page.text, '', 'Component renders nothing at all.');
 });
@@ -48,7 +44,12 @@ test('it renders correctly for "required" status', function(assert) {
   let stripeConnectAccount = { personalIdNumberStatus: 'required' };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/personal-id-number
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler}}
+  `);
 
   assert.ok(page.renderslegalEntityPersonalIdNumberField, 'Component renders the account number field.');
   assert.ok(page.rendersSubmitButton, 'Component renders the submit button.');
@@ -60,7 +61,12 @@ test('it renders correctly for "verifying" status', function(assert) {
   let stripeConnectAccount = { personalIdNumberStatus: 'verifying' };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/personal-id-number
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler}}
+  `);
 
   assert.equal(page.text, "We're verifying your ID number.");
 });
@@ -71,7 +77,12 @@ test('it renders correctly for "verified" status', function(assert) {
   let stripeConnectAccount = { personalIdNumberStatus: 'verified' };
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/personal-id-number
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler}}
+  `);
 
   assert.equal(page.text, '', 'Component renders nothing at all.');
 });
@@ -88,7 +99,13 @@ test('it sends properties with submit action', function(assert) {
     assert.equal(legalEntityPersonalIdNumber, number, 'Correct parameter was sent out with action.');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/personal-id-number
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler}}
+  `);
+
   page.legalEntityPersonalIdNumber(legalEntityPersonalIdNumber).clickSubmit();
 });
 
@@ -99,7 +116,12 @@ test('it disables controls when busy', function(assert) {
   set(this, 'isBusy', true);
   set(this, 'stripeConnectAccount', stripeConnectAccount);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/personal-id-number
+      isBusy=isBusy
+      stripeConnectAccount=stripeConnectAccount
+      submit=submitHandler}}
+  `);
 
   assert.ok(page.legalEntityPersonalIdNumberFieldIsDisabled, 'Personal ID number field is disabled when busy.');
   assert.ok(page.submitButtonIsDisabled, 'Submit button is disabled when busy.');

--- a/tests/integration/components/payments/funds-recipient/verification-document-test.js
+++ b/tests/integration/components/payments/funds-recipient/verification-document-test.js
@@ -6,17 +6,6 @@ import verificationDocumentComponent from 'code-corps-ember/tests/pages/componen
 
 let page = PageObject.create(verificationDocumentComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{payments/funds-recipient/verification-document
-      error=error
-      isBusy=isBusy
-      isUploading=isUploading
-      progressPercentage=progressPercentage
-      stripeConnectAccount=stripeConnectAccount}}
-  `);
-}
-
 moduleForComponent('payments/funds-recipient/verification-document', 'Integration | Component | payments/funds recipient/verification document', {
   integration: true,
   beforeEach() {
@@ -32,7 +21,14 @@ test('it renders nothing if status is not "required" or "verifying"', function(a
 
   this.set('stripeConnectAccount', { verificationDocumentStatus: 'pending_required' });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.equal(page.text, '', 'Nothing is rendered');
 });
@@ -41,7 +37,15 @@ test('it renders file upload subcomponent if status is "required"', function(ass
   assert.expect(1);
 
   this.set('stripeConnectAccount', { verificationDocumentStatus: 'required' });
-  renderPage();
+
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.ok(page.rendersFileUpload, 'File upload subcomponent is rendered');
 });
@@ -51,7 +55,14 @@ test('it renders information if stautus is "verifying"', function(assert) {
 
   this.set('stripeConnectAccount', { verificationDocumentStatus: 'verifying' });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.equal(page.text, 'Please be patient while we review the document you provided.', 'Info text is rendered');
 });
@@ -62,7 +73,14 @@ test('it shows as busy if busy', function(assert) {
   this.set('stripeConnectAccount', { verificationDocumentStatus: 'required' });
   this.set('isBusy', true);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.equal(page.text, 'Processing...', 'Only a busy indicator is rendered.');
 });
@@ -74,7 +92,14 @@ test('it shows the progress message when uploading', function(assert) {
   this.set('isUploading', true);
   this.set('progressPercentage', 20);
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.equal(page.text, 'Uploading... 20', 'Progress message is rendered');
 });
@@ -84,7 +109,14 @@ test('it shows errors if any', function(assert) {
   this.set('stripeConnectAccount', { verificationDocumentStatus: 'required' });
   this.set('error', 'Lorem ipsum');
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.equal(page.error.text, 'Lorem ipsum', 'Error is rendered');
 });
@@ -93,7 +125,14 @@ test('it renders Stripe error correctly', function(assert) {
   assert.expect(2);
   this.set('stripeConnectAccount', { verificationDocumentStatus: 'errored' });
 
-  renderPage();
+  this.render(hbs`
+    {{payments/funds-recipient/verification-document
+      error=error
+      isBusy=isBusy
+      isUploading=isUploading
+      progressPercentage=progressPercentage
+      stripeConnectAccount=stripeConnectAccount}}
+  `);
 
   assert.ok(page.error.isVisible, 'Error is rendered');
   assert.ok(page.rendersFileUpload, 'File upload subcomponent is rendered');

--- a/tests/integration/components/progress-bar-container-test.js
+++ b/tests/integration/components/progress-bar-container-test.js
@@ -16,25 +16,25 @@ moduleForComponent('progress-bar-container', 'Integration | Component | progress
 });
 
 test('it propagates the right width', function(assert) {
-  page.render(hbs`{{progress-bar-container percentage=100}}`);
+  this.render(hbs`{{progress-bar-container percentage=100}}`);
 
   assert.ok(page.progressBar.displaysPercentage(100));
 });
 
 test('it renders as animated', function(assert) {
-  page.render(hbs`{{progress-bar-container animated=true}}`);
+  this.render(hbs`{{progress-bar-container animated=true}}`);
 
   assert.ok(page.progressBar.isAnimated);
 });
 
 test('it renders without error by default', function(assert) {
-  page.render(hbs`{{progress-bar-container}}`);
+  this.render(hbs`{{progress-bar-container}}`);
 
   assert.notOk(page.progressBar.hasError);
 });
 
 test('it renders with error when passed in', function(assert) {
-  page.render(hbs`{{progress-bar-container error=true}}`);
+  this.render(hbs`{{progress-bar-container error=true}}`);
 
   assert.ok(page.progressBar.hasError);
 });

--- a/tests/integration/components/progress-bar-test.js
+++ b/tests/integration/components/progress-bar-test.js
@@ -16,25 +16,25 @@ moduleForComponent('progress-bar', 'Integration | Component | progress bar', {
 });
 
 test('it sets the style when percentage is set', function(assert) {
-  page.render(hbs`{{progress-bar percentage=100}}`);
+  this.render(hbs`{{progress-bar percentage=100}}`);
 
   assert.ok(page.displaysPercentage(100));
 });
 
 test('it sets the style when no percentage is set', function(assert) {
-  page.render(hbs`{{progress-bar}}`);
+  this.render(hbs`{{progress-bar}}`);
 
   assert.ok(page.displaysPercentage(0));
 });
 
 test('it renders without error by default', function(assert) {
-  page.render(hbs`{{progress-bar}}`);
+  this.render(hbs`{{progress-bar}}`);
 
   assert.notOk(page.hasError);
 });
 
 test('it renders with error when passed in', function(assert) {
-  page.render(hbs`{{progress-bar error=true}}`);
+  this.render(hbs`{{progress-bar error=true}}`);
 
   assert.ok(page.hasError);
 });

--- a/tests/integration/components/project-card-test.js
+++ b/tests/integration/components/project-card-test.js
@@ -7,12 +7,6 @@ import pageComponent from 'code-corps-ember/tests/pages/components/project-card'
 
 let page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{project-card onJoin=onJoin project=project skills=skills}}
-  `);
-}
-
 moduleForComponent('project-card', 'Integration | Component | project card', {
   integration: true,
   beforeEach() {
@@ -44,7 +38,8 @@ test('it renders', function(assert) {
   stubService(this, 'user-categories', { findUserCategory() {} });
 
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`{{project-card onJoin=onJoin project=project skills=skills}}`);
 
   assert.equal(this.$('.icon-container img').attr('src'), project.iconLargeUrl);
   assert.equal(this.$('.details-container h4').text().trim(), project.title);
@@ -62,7 +57,8 @@ test('it renders the right icon when the user is not loaded', function(assert) {
   stubService(this, 'user-categories', { findUserCategory() {} });
 
   set(this, 'project', project);
-  renderPage();
+
+  this.render(hbs`{{project-card onJoin=onJoin project=project skills=skills}}`);
 
   assert.equal(this.$('ul.project-card__project-users li:first img').length, 0);
 });

--- a/tests/integration/components/project-card/donation-progress-test.js
+++ b/tests/integration/components/project-card/donation-progress-test.js
@@ -23,7 +23,7 @@ test('it renders proper information', function(assert) {
 
   this.set('donationGoal', mockGoal);
 
-  page.render(hbs`{{project-card/donation-progress donationGoal=donationGoal amountDonated=500}}`);
+  this.render(hbs`{{project-card/donation-progress donationGoal=donationGoal amountDonated=500}}`);
 
   assert.equal(page.amountValue, '$500', 'Correct amount value is rendered');
   assert.equal(page.percentageLabel, 'of $1,000 goal', 'Correct percentage label is rendered');
@@ -38,7 +38,7 @@ test('it renders decimal values if there are any', function(assert) {
 
   this.set('donationGoal', mockGoal);
 
-  page.render(hbs`{{project-card/donation-progress donationGoal=donationGoal amountDonated=505.50}}`);
+  this.render(hbs`{{project-card/donation-progress donationGoal=donationGoal amountDonated=505.50}}`);
 
   assert.equal(page.amountValue, '$505.50', 'Correct amount is rendered');
   assert.equal(page.percentageLabel, 'of $1,000 goal', 'Correct percentage label is rendered');

--- a/tests/integration/components/project-card/project-users-test.js
+++ b/tests/integration/components/project-card/project-users-test.js
@@ -33,17 +33,17 @@ const someUsersHidden = createProjectUsers(9);
 test('it shows all users if less than 8', function(assert) {
   set(this, 'projectUsers', allUsersVisible);
 
-  page.render(hbs`{{project-card/project-users projectUsers=projectUsers}}`);
+  this.render(hbs`{{project-card/project-users projectUsers=projectUsers}}`);
 
-  assert.equal(page.users().count, 6, 'All 6 users are rendered');
+  assert.equal(page.users.length, 6, 'All 6 users are rendered');
   assert.notOk(page.userCount.isVisible, "The 'more' text isn't rendered");
 });
 
 test('it shows all users if more than 8', function(assert) {
   set(this, 'projectUsers', someUsersHidden);
 
-  page.render(hbs`{{project-card/project-users projectUsers=projectUsers}}`);
+  this.render(hbs`{{project-card/project-users projectUsers=projectUsers}}`);
 
-  assert.equal(page.users().count, 8, '8 users are rendered');
+  assert.equal(page.users.length, 8, '8 users are rendered');
   assert.equal(page.userCount.text, '+1 more', "The '+1 more' text is rendered");
 });

--- a/tests/integration/components/project-categories-list-test.js
+++ b/tests/integration/components/project-categories-list-test.js
@@ -7,10 +7,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`{{project-categories-list categories=categories}}`);
-}
-
 moduleForComponent('project-categories-list', 'Integration | Component | project categories list', {
   integration: true,
   beforeEach() {
@@ -42,12 +38,13 @@ test('it renders the categories and sorts them by name', function(assert) {
   stubService(this, 'user-categories', { findUserCategory() {} });
 
   this.set('categories', categories);
-  renderPage();
+
+  this.render(hbs`{{project-categories-list categories=categories}}`);
 
   // trigger lazy rendering of tooltips
-  [0, 1, 2].forEach((index) => page.projectCategoryItems(index).mouseenter());
-  assert.equal(page.projectCategoryItems().count, 3);
-  assert.equal(page.projectCategoryItems(0).tooltip.text, 'Alphabets');
-  assert.equal(page.projectCategoryItems(1).tooltip.text, 'Society');
-  assert.equal(page.projectCategoryItems(2).tooltip.text, 'Zoology');
+  [0, 1, 2].forEach((index) => page.projectCategoryItems.objectAt(index).mouseenter());
+  assert.equal(page.projectCategoryItems.length, 3);
+  assert.equal(page.projectCategoryItems.objectAt(0).tooltip.text, 'Alphabets');
+  assert.equal(page.projectCategoryItems.objectAt(1).tooltip.text, 'Society');
+  assert.equal(page.projectCategoryItems.objectAt(2).tooltip.text, 'Zoology');
 });

--- a/tests/integration/components/project-category-item-test.js
+++ b/tests/integration/components/project-category-item-test.js
@@ -15,10 +15,6 @@ let mockUserCategoriesService = {
   }
 };
 
-function renderPage() {
-  page.render(hbs`{{project-category-item category=category}}`);
-}
-
 moduleForComponent('project-category-item', 'Integration | Component | project category item', {
   integration: true,
   beforeEach() {
@@ -47,7 +43,8 @@ test('it works for unselected categories', function(assert) {
   };
 
   this.set('category', category);
-  renderPage();
+
+  this.render(hbs`{{project-category-item category=category}}`);
 
   assert.ok(page.linkIcon.classContains('technology'), 'Dynamic category class is properly bound.');
   assert.notOk(page.linkIcon.classContains('selected'), 'Icon is unselected.');
@@ -71,7 +68,8 @@ test('it works for selected categories', function(assert) {
   };
 
   this.set('category', category);
-  renderPage();
+
+  this.render(hbs`{{project-category-item category=category}}`);
 
   assert.ok(page.linkIcon.classContains('society'));
   assert.ok(page.linkIcon.classContains('selected'));

--- a/tests/integration/components/project-header-test.js
+++ b/tests/integration/components/project-header-test.js
@@ -27,7 +27,7 @@ test('it renders title', function(assert) {
 
   this.set('project', mockProject);
 
-  page.render(hbs`{{project-header project=project}}`);
+  this.render(hbs`{{project-header project=project}}`);
 
   assert.equal(page.icon.src, mockProject.iconThumbUrl, 'Icon is rendered');
   assert.equal(page.title.text, mockProject.title, 'Title is rendered');
@@ -45,7 +45,7 @@ test('it triggers binding when clicking join project button', function(assert) {
     }
   });
 
-  page.render(hbs`{{project-header project=project}}`);
+  this.render(hbs`{{project-header project=project}}`);
 
   page.projectJoinModal.openButton.click();
   page.projectJoinModal.modal.joinProjectButton.click();

--- a/tests/integration/components/project-item-test.js
+++ b/tests/integration/components/project-item-test.js
@@ -31,7 +31,7 @@ test('it renders the correct UI elements', function(assert) {
     title: 'A project',
     description: 'A description'
   });
-  page.render(hbs`{{project-item project=project}}`);
+  this.render(hbs`{{project-item project=project}}`);
 
   assert.equal(page.icon.src, 'icon.png', 'The project icon is properly bound');
   assert.equal(page.title, 'A project', 'The project title is properly bound');

--- a/tests/integration/components/project-join-modal-test.js
+++ b/tests/integration/components/project-join-modal-test.js
@@ -7,16 +7,6 @@ import pageComponent from 'code-corps-ember/tests/pages/components/project-join-
 
 let page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{project-join-modal
-      onJoin=onJoin
-      project=project
-      showModal=showModal
-      skills=skills}}
-  `);
-}
-
 moduleForComponent('project-join-modal', 'Integration | Component | project join modal', {
   integration: true,
   beforeEach() {
@@ -32,16 +22,19 @@ test('ui is rendered correctly when modal is open', function(assert) {
   assert.expect(1);
 
   let skills = [{ title: 'CSS' }, { title: 'HTML' }];
+
   set(this, 'skills', skills);
   set(this, 'showModal', true);
-  renderPage();
-  assert.equal(page.modal.relatedSkills.skillListItems.listItems().count, 2, 'Related skills are rendered.');
+
+  this.render(hbs`{{project-join-modal onJoin=onJoin project=project showModal=showModal skills=skills}}`);
+
+  assert.equal(page.modal.relatedSkills.skillListItems.listItems.length, 2, 'Related skills are rendered.');
 });
 
 test('when button is clicked, modal opens', function(assert) {
   assert.expect(2);
 
-  renderPage();
+  this.render(hbs`{{project-join-modal onJoin=onJoin project=project showModal=showModal skills=skills}}`);
 
   assert.notOk(page.modal.isVisible, 'Modal is initially hidden.');
   page.openButton.click();
@@ -52,7 +45,8 @@ test('when clicking outside the modal, the modal closes', function(assert) {
   assert.expect(2);
 
   set(this, 'showModal', true);
-  renderPage();
+
+  this.render(hbs`{{project-join-modal onJoin=onJoin project=project showModal=showModal skills=skills}}`);
 
   assert.ok(page.modal.isVisible, 'Modal is initially visible.');
   page.overlay.click();
@@ -63,7 +57,8 @@ test('when hitting escape, the modal closes', function(assert) {
   assert.expect(2);
 
   set(this, 'showModal', true);
-  renderPage();
+
+  this.render(hbs`{{project-join-modal onJoin=onJoin project=project showModal=showModal skills=skills}}`);
 
   assert.ok(page.modal.isVisible, 'Modal is initially visible.');
   page.modal.hitEscape();
@@ -84,7 +79,7 @@ test('when hitting "join project" button, the service is called', function(asser
     }
   });
 
-  renderPage();
+  this.render(hbs`{{project-join-modal onJoin=onJoin project=project showModal=showModal skills=skills}}`);
 
   page.modal.joinProjectButton.click();
 });

--- a/tests/integration/components/project-list-test.js
+++ b/tests/integration/components/project-list-test.js
@@ -49,10 +49,10 @@ test('it sorts the list by id', function(assert) {
   });
 
   set(this, 'projects', mockProjects);
-  page.render(hbs`{{project-list projects=projects}}`);
+  this.render(hbs`{{project-list projects=projects}}`);
 
   for (let i = 0; i < 3; i++) {
     let id = i + 1;
-    assert.equal(page.items(i).text, `Project ${id}`);
+    assert.equal(page.items.objectAt(i).text, `Project ${id}`);
   }
 });

--- a/tests/integration/components/project-long-description-test.js
+++ b/tests/integration/components/project-long-description-test.js
@@ -44,7 +44,7 @@ test('it renders properly when decription is blank and the user cannot add to it
   assert.expect(3);
 
   set(this, 'project', blankProject);
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   assert.ok(page.noDescription.cannotAdd, 'The correct element is shown');
   assert.notOk(page.editorWithPreview.isVisible, 'The editor is not shown');
@@ -57,7 +57,7 @@ test('it renders properly when description is blank and the user can add to it',
   set(this, 'project', blankProject);
   stubService(this, 'current-user', { user: owner });
 
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   assert.ok(page.noDescription.canAdd, 'The correct element is shown');
   assert.ok(page.editorWithPreview.isVisible, 'The editor is shown');
@@ -69,7 +69,7 @@ test('it renders properly when description is present and user cannot edit', fun
 
   set(this, 'project', projectWithDescription);
 
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   assert.notOk(page.longDescription.isEmpty, 'The section for empty description is not shown');
   assert.notOk(page.editorWithPreview.isVisible, 'The editor is not shown, since we are in read mode');
@@ -85,7 +85,7 @@ test('it renders properly when description is present and user can edit', functi
   set(this, 'project', projectWithDescription);
   stubService(this, 'current-user', { user: owner });
 
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   assert.notOk(page.longDescription.isEmpty, 'The section for empty description is not shown');
   assert.notOk(page.editorWithPreview.isVisible, 'The editor is not shown, since we are in read mode');
@@ -108,7 +108,7 @@ test('it is possible to add a description', function(assert) {
   set(this, 'project', savableProject);
   stubService(this, 'current-user', { user: owner });
 
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   page.save.click();
 });
@@ -128,7 +128,7 @@ test('it is possible to edit a description', function(assert) {
   set(this, 'project', savableProject);
   stubService(this, 'current-user', { user: owner });
 
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   assert.notOk(page.editorWithPreview.isVisible, 'The editor is not shown, since we are in read mode');
   page.edit.click();
@@ -140,7 +140,7 @@ test('it renders list items in the description with bullet points', function(ass
   assert.expect(2);
 
   set(this, 'project', projectWithListedDescription);
-  page.render(hbs`{{project-long-description project=project}}`);
+  this.render(hbs`{{project-long-description project=project}}`);
 
   assert.equal(page.longDescription.list.listItem.text, 'list item 1', 'the description text shows the list');
   assert.equal(this.$('li').css('listStyleType'), 'disc', 'list in description text is displayed with bullet points');

--- a/tests/integration/components/project-menu-test.js
+++ b/tests/integration/components/project-menu-test.js
@@ -22,11 +22,11 @@ test('when not authenticated, it renders properly', function(assert) {
 
   stubService(this, 'session', { isAuthenticated: false });
 
-  page.render(hbs`{{project-menu}}`);
+  this.render(hbs`{{project-menu}}`);
 
-  assert.equal(page.links().count, 2, 'The correct number of links render');
-  assert.equal(page.links(0).text, 'About', 'The about link is rendered');
-  assert.equal(page.links(1).text, 'Tasks', 'The tasks link is rendered');
+  assert.equal(page.links.length, 2, 'The correct number of links render');
+  assert.equal(page.links.objectAt(0).text, 'About', 'The about link is rendered');
+  assert.equal(page.links.objectAt(1).text, 'Tasks', 'The tasks link is rendered');
 });
 
 test('when authenticated, and user cannot manage project, it renders properly', function(assert) {
@@ -35,11 +35,11 @@ test('when authenticated, and user cannot manage project, it renders properly', 
   stubService(this, 'session', { isAuthenticated: true });
   this.register('ability:project', Ability.extend({ canManage: false }));
 
-  page.render(hbs`{{project-menu}}`);
+  this.render(hbs`{{project-menu}}`);
 
-  assert.equal(page.links().count, 2, 'The correct number of links render');
-  assert.equal(page.links(0).text, 'About', 'The about link is rendered');
-  assert.equal(page.links(1).text, 'Tasks', 'The tasks link is rendered');
+  assert.equal(page.links.length, 2, 'The correct number of links render');
+  assert.equal(page.links.objectAt(0).text, 'About', 'The about link is rendered');
+  assert.equal(page.links.objectAt(1).text, 'Tasks', 'The tasks link is rendered');
 });
 
 test('when authenticated, and user can manage project, it renders properly', function(assert) {
@@ -48,17 +48,17 @@ test('when authenticated, and user can manage project, it renders properly', fun
   stubService(this, 'session', { isAuthenticated: true });
   this.register('ability:project', Ability.extend({ canAdminister: true, canManage: true }));
 
-  page.render(hbs`{{project-menu}}`);
+  this.render(hbs`{{project-menu}}`);
 
-  assert.equal(page.links().count, 8, 'The correct number of links render');
-  assert.equal(page.links(0).text, 'About', 'The about link is rendered');
-  assert.equal(page.links(1).text, 'Tasks', 'The tasks link is rendered');
-  assert.equal(page.links(2).text, 'People', 'The people link is rendered');
-  assert.equal(page.links(3).text, 'Conversations', 'The conversations link is rendered');
-  assert.equal(page.links(4).text, 'Donations', 'The donations link is rendered');
-  assert.equal(page.links(5).text, 'Payments', 'The payments link is rendered');
-  assert.equal(page.links(6).text, 'Integrations', 'The integrations link is rendered');
-  assert.equal(page.links(7).text, 'Settings', 'The settings link is rendered');
+  assert.equal(page.links.length, 8, 'The correct number of links render');
+  assert.equal(page.links.objectAt(0).text, 'About', 'The about link is rendered');
+  assert.equal(page.links.objectAt(1).text, 'Tasks', 'The tasks link is rendered');
+  assert.equal(page.links.objectAt(2).text, 'People', 'The people link is rendered');
+  assert.equal(page.links.objectAt(3).text, 'Conversations', 'The conversations link is rendered');
+  assert.equal(page.links.objectAt(4).text, 'Donations', 'The donations link is rendered');
+  assert.equal(page.links.objectAt(5).text, 'Payments', 'The payments link is rendered');
+  assert.equal(page.links.objectAt(6).text, 'Integrations', 'The integrations link is rendered');
+  assert.equal(page.links.objectAt(7).text, 'Settings', 'The settings link is rendered');
 });
 
 test('when authenticated, and user can manage project, and project has pending members', function(assert) {
@@ -73,9 +73,9 @@ test('when authenticated, and user can manage project, and project has pending m
   };
   this.set('project', project);
 
-  page.render(hbs`{{project-menu project=project}}`);
+  this.render(hbs`{{project-menu project=project}}`);
 
-  assert.equal(page.links(2).badge.text, '1 pending', 'The correct number of pending members render');
+  assert.equal(page.links.objectAt(2).badge.text, '1 pending', 'The correct number of pending members render');
 });
 
 test('when authenticated, and user can manage project, and project has no pending members', function(assert) {
@@ -90,7 +90,7 @@ test('when authenticated, and user can manage project, and project has no pendin
   };
   this.set('project', project);
 
-  page.render(hbs`{{project-menu project=project}}`);
+  this.render(hbs`{{project-menu project=project}}`);
 
-  assert.notOk(page.links(2).badge.isVisible, 'The pending members badge does not render');
+  assert.notOk(page.links.objectAt(2).badge.isVisible, 'The pending members badge does not render');
 });

--- a/tests/integration/components/project-notifications-test.js
+++ b/tests/integration/components/project-notifications-test.js
@@ -5,15 +5,6 @@ import component from 'code-corps-ember/tests/pages/components/project-notificat
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{project-notifications
-      project=project
-      submitForReview=submitForReview
-    }}
-  `);
-}
-
 moduleForComponent('project-notifications', 'Integration | Component | project notifications', {
   integration: true,
   beforeEach() {
@@ -29,7 +20,7 @@ test('when the project is approved', function(assert) {
 
   this.set('project', { approved: true });
 
-  renderPage();
+  this.render(hbs`{{project-notifications project=project submitForReview=submitForReview}}`);
 
   assert.notOk(page.callout.isVisible, 'Callout is not visible.');
 });
@@ -39,7 +30,7 @@ test('when the project is not approved and has no description', function(assert)
 
   this.set('project', { approved: false, longDescriptionBody: null, approvalRequested: false });
 
-  renderPage();
+  this.render(hbs`{{project-notifications project=project submitForReview=submitForReview}}`);
 
   assert.ok(page.callout.isVisible, 'Callout is visible.');
   assert.ok(page.callout.descriptionNeeded.isVisible, 'Description is needed');
@@ -58,7 +49,7 @@ test('when the project is not approved and has a description but no review', fun
   this.set('project', { approved: false, longDescriptionBody: 'Body', approvalRequested: false });
   this.set('submitForReview', submitForReview);
 
-  renderPage();
+  this.render(hbs`{{project-notifications project=project submitForReview=submitForReview}}`);
 
   assert.ok(page.callout.isVisible, 'Callout is visible.');
   assert.notOk(page.callout.descriptionNeeded.isVisible, 'Description is already added');
@@ -74,7 +65,7 @@ test('when the project is not approved and is awaiting approval', function(asser
 
   this.set('project', { approved: false, longDescriptionBody: 'Body', approvalRequested: true });
 
-  renderPage();
+  this.render(hbs`{{project-notifications project=project submitForReview=submitForReview}}`);
 
   assert.ok(page.callout.isVisible, 'Callout is visible.');
   assert.notOk(page.callout.descriptionNeeded.isVisible, 'Description is already added');

--- a/tests/integration/components/project-settings-form-test.js
+++ b/tests/integration/components/project-settings-form-test.js
@@ -31,7 +31,7 @@ test('it renders form elements properly', function(assert) {
 
   set(this, 'project', project);
 
-  page.render(hbs`{{project-settings-form project=project}}`);
+  this.render(hbs`{{project-settings-form project=project}}`);
 
   assert.equal(page.title.value, 'Test Project');
   assert.equal(page.description.value, 'A test project');
@@ -49,7 +49,7 @@ test('it calls save on project when save button is clicked', function(assert) {
 
   set(this, 'project', project);
 
-  page.render(hbs`{{project-settings-form project=project}}`);
+  this.render(hbs`{{project-settings-form project=project}}`);
 
   page.save.click();
 

--- a/tests/integration/components/project-skill-item-test.js
+++ b/tests/integration/components/project-skill-item-test.js
@@ -10,10 +10,6 @@ function setHandler(context, clickHandler = () => {}) {
   set(context, 'clickHandler', clickHandler);
 }
 
-function renderPage() {
-  page.render(hbs`{{project-skill-item skill=skill onClicked=clickHandler}}`);
-}
-
 moduleForComponent('project-skill-item', 'Integration | Component | project skill item', {
   integration: true,
   beforeEach() {
@@ -27,21 +23,28 @@ moduleForComponent('project-skill-item', 'Integration | Component | project skil
 
 test('it renders loading spinnner if skill is loading', function(assert) {
   assert.expect(2);
+
   set(this, 'skill', { isLoading: true, title: 'Test' });
-  renderPage();
+
+  this.render(hbs`{{project-skill-item skill=skill onClicked=clickHandler}}`);
+
   assert.ok(page.isLoading, 'Component is rendered as loading');
   assert.equal(page.text, '', 'Title is not rendered');
 });
 
 test('it renders skill title if skill is loaded', function(assert) {
   assert.expect(1);
+
   set(this, 'skill', { title: 'Test' });
-  renderPage();
+
+  this.render(hbs`{{project-skill-item skill=skill onClicked=clickHandler}}`);
+
   assert.equal(page.text, 'Test', 'Title is rendered');
 });
 
 test('it calls action on click', function(assert) {
   assert.expect(1);
+
   let mockSkill = { id: 'skill', title: 'Skill' };
   set(this, 'skill', mockSkill);
 
@@ -49,6 +52,7 @@ test('it calls action on click', function(assert) {
     assert.deepEqual(skill, mockSkill, 'The sent skill matches the assigned skill.');
   });
 
-  renderPage();
+  this.render(hbs`{{project-skill-item skill=skill onClicked=clickHandler}}`);
+
   page.click();
 });

--- a/tests/integration/components/project-skills-list-test.js
+++ b/tests/integration/components/project-skills-list-test.js
@@ -10,27 +10,9 @@ function setHandler(context, clickHandler = () => {}) {
   set(context, 'clickHandler', clickHandler);
 }
 
-function renderPage() {
-  page.render(hbs`
-    {{project-skills-list
-      project=project
-      excludedSkills=excludedSkills
-      onSkillClicked=clickHandler
-      showHeader=showHeader
-      header=header
-    }}
-  `);
-}
-
-let ruby = { title: 'Ruby', id: 1 };
-let css = { title: 'CSS', id: 2 };
-
-let project = {
-  projectSkills: [
-    { skill: ruby },
-    { skill: css }
-  ]
-};
+const ruby = { title: 'Ruby', id: 1 };
+const css = { title: 'CSS', id: 2 };
+const project = { projectSkills: [{ skill: ruby }, { skill: css }] };
 
 moduleForComponent('project-skills-list', 'Integration | Component | project skills list', {
   integration: true,
@@ -47,7 +29,16 @@ test('it renders header if set that way', function(assert) {
   assert.expect(1);
 
   setProperties(this, { showHeader: true, header: 'Test' });
-  renderPage();
+
+  this.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
 
   assert.equal(page.header.text, 'Test');
 });
@@ -56,7 +47,16 @@ test('it hides header by default', function(assert) {
   assert.expect(1);
 
   set(this, 'header', 'Test');
-  renderPage();
+
+  this.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
 
   assert.notOk(page.headerIsVisible, 'Header is not rendered');
 });
@@ -66,11 +66,19 @@ test('it renders a list of project skills', function(assert) {
 
   set(this, 'project', project);
 
-  renderPage();
+  this.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
 
-  assert.equal(page.skills().count, 2, 'Correct number of skills is rendered.');
-  assert.equal(page.skills(0).text, 'Ruby', 'Skill is rendered correctly.');
-  assert.equal(page.skills(1).text, 'CSS', 'Skill is rendered correctly.');
+  assert.equal(page.skills.length, 2, 'Correct number of skills is rendered.');
+  assert.equal(page.skills.objectAt(0).text, 'Ruby', 'Skill is rendered correctly.');
+  assert.equal(page.skills.objectAt(1).text, 'CSS', 'Skill is rendered correctly.');
 });
 
 test('it is able to filter out skills if exclusion list is provided', function(assert) {
@@ -79,16 +87,32 @@ test('it is able to filter out skills if exclusion list is provided', function(a
   set(this, 'project', project);
   set(this, 'excludedSkills', [css]);
 
-  renderPage();
+  this.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
 
-  assert.equal(page.skills().count, 1, 'Correct number of skills is rendered.');
-  assert.equal(page.skills(0).text, 'Ruby', 'Skill is rendered correctly.');
+  assert.equal(page.skills.length, 1, 'Correct number of skills is rendered.');
+  assert.equal(page.skills.objectAt(0).text, 'Ruby', 'Skill is rendered correctly.');
 });
 
 test('it renders fallback if there are no skills to render', function(assert) {
   assert.expect(1);
 
-  renderPage();
+  this.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
 
   assert.ok(page.fallbackIsVisible, 'Fallback is rendered.');
 });
@@ -102,7 +126,15 @@ test('it calls proper function when clicking a skill', function(assert) {
     assert.deepEqual(skill, css, 'Correct skill was sent on click.');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{project-skills-list
+      project=project
+      excludedSkills=excludedSkills
+      onSkillClicked=clickHandler
+      showHeader=showHeader
+      header=header
+    }}
+  `);
 
-  page.skills(1).click();
+  page.skills.objectAt(1).click();
 });

--- a/tests/integration/components/project-switcher-menu-test.js
+++ b/tests/integration/components/project-switcher-menu-test.js
@@ -7,10 +7,6 @@ import { Ability } from 'ember-can';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`{{project-switcher-menu user=user}}`);
-}
-
 let user = {
   organizations: [
     {
@@ -41,20 +37,20 @@ test('it renders the links', function(assert) {
 
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{project-switcher-menu user=user}}`);
 
-  assert.equal(page.menu.organizations().count, 1, 'One organization renders.');
-  assert.equal(page.menu.projects().count, 1, 'One project renders.');
-  assert.equal(page.menu.organizations(0).text, user.organizations[0].name, 'The organization name is correct.');
-  assert.equal(page.menu.projects(0).text, user.organizations[0].projects[0].title, 'The project title is correct.');
-  assert.equal(page.menu.projects(0).icon.url, user.organizations[0].projects[0].iconThumbUrl, 'The project icon URL is correct.');
+  assert.equal(page.menu.organizations.length, 1, 'One organization renders.');
+  assert.equal(page.menu.projects.length, 1, 'One project renders.');
+  assert.equal(page.menu.organizations.objectAt(0).text, user.organizations[0].name, 'The organization name is correct.');
+  assert.equal(page.menu.projects.objectAt(0).text, user.organizations[0].projects[0].title, 'The project title is correct.');
+  assert.equal(page.menu.projects.objectAt(0).icon.url, user.organizations[0].projects[0].iconThumbUrl, 'The project icon URL is correct.');
 });
 
 test('it renders the new project link if the user can manage', function(assert) {
   set(this, 'user', user);
   this.register('ability:organization', Ability.extend({ canManage: true }));
 
-  renderPage();
+  this.render(hbs`{{project-switcher-menu user=user}}`);
 
   assert.ok(page.menu.newProjectLink.isVisible, 'The new project link renders.');
 });
@@ -65,7 +61,7 @@ test('it does not render the new project link if the user cannot manage', functi
   set(this, 'user', user);
   this.register('ability:organization', Ability.extend({ canManage: false }));
 
-  renderPage();
+  this.render(hbs`{{project-switcher-menu user=user}}`);
 
   assert.notOk(page.menu.newProjectLink.isVisible, 'The new project link does not render.');
 });

--- a/tests/integration/components/project-switcher-test.js
+++ b/tests/integration/components/project-switcher-test.js
@@ -5,10 +5,6 @@ import component from 'code-corps-ember/tests/pages/components/project-switcher'
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`{{project-switcher user=user}}`);
-}
-
 moduleForComponent('project-switcher', 'Integration | Component | project switcher', {
   integration: true,
   beforeEach() {
@@ -22,7 +18,7 @@ moduleForComponent('project-switcher', 'Integration | Component | project switch
 test('it hides and shows', async function(assert) {
   assert.expect(12);
 
-  renderPage();
+  this.render(hbs`{{project-switcher user=user}}`);
 
   assert.ok(page.hasHiddenClass, 'Has the hidden class by default.');
   assert.notOk(page.hasVisibleClass, 'Does not have the visible class by default.');

--- a/tests/integration/components/project-user-role-modal-test.js
+++ b/tests/integration/components/project-user-role-modal-test.js
@@ -14,17 +14,6 @@ import { Ability } from 'ember-can';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{project-user-role-modal
-      project=project
-      projectUser=projectUser
-      save=save
-      showModal=showModal
-    }}
-  `);
-}
-
 moduleForComponent('project-user-role-modal', 'Integration | Component | project user role modal', {
   integration: true,
   beforeEach() {
@@ -40,7 +29,14 @@ moduleForComponent('project-user-role-modal', 'Integration | Component | project
 test('it shows and hides', function(assert) {
   assert.expect(3);
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   assert.notOk(page.modal.isVisible, 'Modal is hidden');
   page.openButton.click();
@@ -52,7 +48,14 @@ test('it shows and hides', function(assert) {
 test('it renders a tooltip on the button', function(assert) {
   assert.expect(5);
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   assertTooltipNotRendered(assert);
 
@@ -84,7 +87,14 @@ test('it does not allow an owner to demote themselves', function(assert) {
   this.register('ability:project', Ability.extend({ canManage: true }));
   set(this, 'showModal', true);
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   assert.ok(page.modal.radioGroupOwner.adminCannotRemove.isVisible, 'Admin cannot remove text is visible');
   assert.ok(page.modal.radioGroupOwner.radioButton.isChecked, 'Admin radio button is checked');
@@ -111,7 +121,14 @@ test('it allows an owner to demote a different owner', function(assert) {
   this.register('ability:project', Ability.extend({ canManage: true }));
   set(this, 'showModal', true);
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   assert.notOk(page.modal.radioGroupOwner.adminCannotRemove.isVisible, 'Admin cannot remove text is hidden');
   assert.ok(page.modal.radioGroupOwner.radioButton.isChecked, 'Admin radio button is checked');
@@ -138,7 +155,14 @@ test('it changes the role when the radio buttons are selected', function(assert)
   this.register('ability:project', Ability.extend({ canManage: true }));
   set(this, 'showModal', true);
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   assert.notOk(page.modal.radioGroupAdmin.radioButton.isChecked);
   assert.ok(page.modal.radioGroupContributor.radioButton.isChecked);
@@ -163,7 +187,14 @@ test('it does not show owner option when cannot manage', function(assert) {
   this.register('ability:project', Ability.extend({ canManage: false }));
   set(this, 'showModal', true);
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   assert.notOk(page.modal.radioGroupOwner.isVisible);
 });
@@ -188,7 +219,14 @@ test('it sends the project user on save', function(assert) {
     assert.deepEqual(r, 'admin');
   });
 
-  renderPage();
+  this.render(hbs`
+    {{project-user-role-modal
+      project=project
+      projectUser=projectUser
+      save=save
+      showModal=showModal
+    }}
+  `);
 
   page.modal.radioGroupAdmin.radioButton.click();
   page.modal.save();

--- a/tests/integration/components/project-users-test.js
+++ b/tests/integration/components/project-users-test.js
@@ -29,10 +29,10 @@ test('it renders an item for each member in the list', function(assert) {
   }
 
   set(this, 'users', mockUsers);
-  page.render(hbs`{{project-users users=users}}`);
+  this.render(hbs`{{project-users users=users}}`);
 
   assert.equal(page.userCount, 18, 'The correct number of users are rendered');
-  assert.ok(page.users(0).imageSource.indexOf('image_1.png') > -1, 'The correct photo renders');
+  assert.ok(page.users.objectAt(0).imageSource.indexOf('image_1.png') > -1, 'The correct photo renders');
 });
 
 test('it renders loading items differently', function(assert) {
@@ -46,8 +46,8 @@ test('it renders loading items differently', function(assert) {
   ];
 
   set(this, 'users', mockUsers);
-  page.render(hbs`{{project-users users=users}}`);
+  this.render(hbs`{{project-users users=users}}`);
 
-  assert.notOk(page.users(0).imageIsVisible, 'The photo does not render');
-  assert.ok(page.users(0).placeholderIsVisible, 'The placeholder renders');
+  assert.notOk(page.users.objectAt(0).imageIsVisible, 'The photo does not render');
+  assert.ok(page.users.objectAt(0).placeholderIsVisible, 'The placeholder renders');
 });

--- a/tests/integration/components/related-skills-test.js
+++ b/tests/integration/components/related-skills-test.js
@@ -15,10 +15,6 @@ let userSkillsService = {
   }
 };
 
-function renderPage() {
-  page.render(hbs`{{related-skills skills=skills}}`);
-}
-
 moduleForComponent('related-skills', 'Integration | Component | related skills', {
   integration: true,
   beforeEach() {
@@ -36,11 +32,12 @@ test('it shows no expander for few skills', function(assert) {
   let skills = [{ title: 'Ruby' }];
 
   this.set('skills', skills);
-  renderPage();
+
+  this.render(hbs`{{related-skills skills=skills}}`);
 
   assert.notOk(page.overflowHidden, 'Overflow is visible.');
   assert.ok(page.expander.hidden, 'Expander button is hidden.');
-  assert.equal(page.skillListItems.listItems().count, 1, 'Correct number of skills is rendered.');
+  assert.equal(page.skillListItems.listItems.length, 1, 'Correct number of skills is rendered.');
 });
 
 test('it does not show expander if overflowHidden is not set', function(assert) {
@@ -54,7 +51,8 @@ test('it does not show expander if overflowHidden is not set', function(assert) 
   }
 
   this.set('skills', skills);
-  renderPage();
+
+  this.render(hbs`{{related-skills skills=skills}}`);
 
   assert.notOk(page.overflow.hidden, 'Overflow is not hidden.');
 });
@@ -70,7 +68,7 @@ test('it shows expander and toggles for lots of skills when the component is mod
   }
 
   this.set('skills', skills);
-  page.render(hbs`{{related-skills overflowHidden=true skills=skills}}`);
+  this.render(hbs`{{related-skills overflowHidden=true skills=skills}}`);
 
   assert.ok(page.overflow.hidden, 'Overflow is hidden.');
   assert.ok(page.expander.visible, 'Expander button is visible.');

--- a/tests/integration/components/role-item-test.js
+++ b/tests/integration/components/role-item-test.js
@@ -13,11 +13,6 @@ import PageObject from 'ember-cli-page-object';
 import component from 'code-corps-ember/tests/pages/components/role-item';
 
 const page = PageObject.create(component);
-const template = hbs`{{role-item role=role userRoles=userRoles}}`;
-
-function renderPage() {
-  page.render(template);
-}
 
 let mockUserRolesService = {
   findUserRole: () => null,
@@ -31,7 +26,7 @@ let mockUserRolesServiceForErrors = {
   removeRole: () => RSVP.reject()
 };
 
-let mobileDeveloper = {
+const mobileDeveloper = {
   id: 'foo',
   name: 'Mobile Developer',
   ability: 'Mobile Development',
@@ -57,7 +52,7 @@ test('it renders role content properly', function(assert) {
 
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   assert.equal(page.button.text, mobileDeveloper.ability, 'Role ability is rendered on button.');
 });
@@ -71,7 +66,7 @@ test('it renders role as selected if associated service returns a user role', fu
 
   set(this, 'userRoles', userRoles);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   assert.ok(page.isSelected, 'Component is rendered as selected.');
 });
@@ -85,7 +80,7 @@ test('it renders role as unselected if associated service returns no user role',
 
   set(this, 'userRoles', userRoles);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   assert.ok(page.isUnselected, 'Component is rendered as unselected.');
 });
@@ -104,7 +99,7 @@ test('it calls proper action on service when clicking a selected role', function
   set(this, 'userRoles', userRoles);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   page.button.click();
 });
@@ -123,7 +118,7 @@ test('it calls proper action on service when clicking an unselected role', funct
   set(this, 'userRoles', userRoles);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   page.button.click();
 });
@@ -134,7 +129,7 @@ test('it creates a flash message on an error when adding', function(assert) {
   set(this, 'userRoles', mockUserRolesServiceForErrors);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   page.button.click(),
 
@@ -153,7 +148,7 @@ test('it creates a flash message on an error when removing', function(assert) {
   set(this, 'userRoles', mockUserRolesServiceForErrors);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   page.button.click(),
 
@@ -187,7 +182,7 @@ test('it sets and unsets loading state when adding', async function(assert) {
   set(this, 'userRoles', userRoles);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   await page.button.click();
 
@@ -214,7 +209,7 @@ test('it sets and unsets loading state on error when adding', async function(ass
   set(this, 'userRoles', userRoles);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   await page.button.click();
 
@@ -241,7 +236,7 @@ test('it sets and unsets loading state when removing', async function(assert) {
   set(this, 'userRoles', userRoles);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   await page.button.click();
 
@@ -268,7 +263,7 @@ test('it sets and unsets loading state on error when removing', async function(a
   set(this, 'userRoles', userRoles);
   set(this, 'role', mobileDeveloper);
 
-  renderPage();
+  this.render(hbs`{{role-item role=role userRoles=userRoles}}`);
 
   await page.button.click();
 

--- a/tests/integration/components/select-inline-dropdown/list-item-test.js
+++ b/tests/integration/components/select-inline-dropdown/list-item-test.js
@@ -19,16 +19,6 @@ moduleForComponent(
   }
 );
 
-function renderPage() {
-  page.render(hbs`
-    {{select-inline-dropdown/list-item
-      iconUrl=iconUrl
-      primaryText=primaryText
-      secondaryText=secondaryText
-      lastSearchedText=lastSearchedText
-    }}`);
-}
-
 test('it renders correctly', function(assert) {
   assert.expect(5);
 
@@ -39,7 +29,13 @@ test('it renders correctly', function(assert) {
 
   setProperties(this, { iconUrl, primaryText, secondaryText, lastSearchedText });
 
-  renderPage();
+  this.render(hbs`
+    {{select-inline-dropdown/list-item
+      iconUrl=iconUrl
+      primaryText=primaryText
+      secondaryText=secondaryText
+      lastSearchedText=lastSearchedText
+    }}`);
 
   assert.equal(page.icon.url, iconUrl, 'Icon is rendered.');
   assert.equal(page.primary.text, primaryText, 'Primary text is rendered.');

--- a/tests/integration/components/select/birth-date-test.js
+++ b/tests/integration/components/select/birth-date-test.js
@@ -6,10 +6,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(selectBirthDateComponent);
 
-function renderPage() {
-  page.render(hbs`{{select/birth-date month=month day=day year=year}}`);
-}
-
 moduleForComponent('select/birth-date', 'Integration | Component | select/birth date', {
   integration: true,
   beforeEach() {
@@ -27,7 +23,7 @@ test('it sets the month strings correctly', function(assert) {
   set(this, 'month', 1);
   set(this, 'year', 2016);
 
-  renderPage();
+  this.render(hbs`{{select/birth-date month=month day=day year=year}}`);
 
   assert.equal(page.month.text, 'January February March April May June July August September October November December');
 });
@@ -39,7 +35,7 @@ test('it sets to the correct date', function(assert) {
   set(this, 'month', 1);
   set(this, 'year', 2016);
 
-  renderPage();
+  this.render(hbs`{{select/birth-date month=month day=day year=year}}`);
 
   page.month.fillIn('4');
   page.day.fillIn('13');

--- a/tests/integration/components/select/country-select-test.js
+++ b/tests/integration/components/select/country-select-test.js
@@ -8,10 +8,6 @@ function setHandler(context, onChange = function() {}) {
   set(context, 'onChange', onChange);
 }
 
-function renderPage() {
-  page.render(hbs`{{select/country-select country=country onChange=onChange}}`);
-}
-
 let page = PageObject.create(selectCountry);
 
 moduleForComponent('select/country-select', 'Integration | Component | select/country select', {
@@ -34,7 +30,7 @@ test('it triggers action on selection change', function(assert) {
     assert.equal(value, 'US', 'Action was triggered with proper parameter');
   });
 
-  renderPage();
+  this.render(hbs`{{select/country-select country=country onChange=onChange}}`);
 
   page.country.fillIn('US');
 });

--- a/tests/integration/components/select/github-repo-test.js
+++ b/tests/integration/components/select/github-repo-test.js
@@ -7,16 +7,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(selectGithubRepoComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{select/github-repo
-      githubRepos=githubRepos
-      selectedRepo=selectedRepo
-      onSelected=(action (mut selectedRepo))
-    }}
-  `);
-}
-
 moduleForComponent('select/github-repo', 'Integration | Component | select/github repo', {
   integration: true,
   beforeEach() {
@@ -37,11 +27,17 @@ test('it renders options', function(assert) {
 
   set(this, 'githubRepos', githubRepos);
 
-  renderPage();
+  this.render(hbs`
+    {{select/github-repo
+      githubRepos=githubRepos
+      selectedRepo=selectedRepo
+      onSelected=(action (mut selectedRepo))
+    }}
+  `);
 
-  assert.equal(page.select.options(0).text, 'Don\'t sync (default)', 'The default option of none renders.');
-  assert.equal(page.select.options(1).text, 'Repo 1');
-  assert.equal(page.select.options(2).text, 'Repo 2');
+  assert.equal(page.select.options.objectAt(0).text, 'Don\'t sync (default)', 'The default option of none renders.');
+  assert.equal(page.select.options.objectAt(1).text, 'Repo 1');
+  assert.equal(page.select.options.objectAt(2).text, 'Repo 2');
 });
 
 test('it triggers action on selection', function(assert) {
@@ -54,7 +50,13 @@ test('it triggers action on selection', function(assert) {
 
   set(this, 'githubRepos', [repo1, repo2]);
 
-  renderPage();
+  this.render(hbs`
+    {{select/github-repo
+      githubRepos=githubRepos
+      selectedRepo=selectedRepo
+      onSelected=(action (mut selectedRepo))
+    }}
+  `);
 
   run(() => page.select.fillIn('Repo 1'));
   run(() => {

--- a/tests/integration/components/select/state-select-test.js
+++ b/tests/integration/components/select/state-select-test.js
@@ -10,10 +10,6 @@ function setHandler(context, onChange = function() {}) {
   set(context, 'onChange', onChange);
 }
 
-function renderPage() {
-  page.render(hbs`{{select/state-select state=state onChange=onChange}}`);
-}
-
 moduleForComponent('select/state-select', 'Integration | Component | select/state select', {
   integration: true,
   beforeEach() {
@@ -33,7 +29,7 @@ test('it triggers action on selection change', function(assert) {
     assert.equal(newState, 'NY', 'Action was triggered with expected value');
   });
 
-  renderPage();
+  this.render(hbs`{{select/state-select state=state onChange=onChange}}`);
 
   page.state.fillIn('NY');
 });

--- a/tests/integration/components/settings-menu-test.js
+++ b/tests/integration/components/settings-menu-test.js
@@ -19,7 +19,7 @@ moduleForComponent('settings-menu', 'Integration | Component | settings menu', {
 test('it renders correct links', function(assert) {
   assert.expect(2);
 
-  page.render(hbs`{{settings-menu}}`);
+  this.render(hbs`{{settings-menu}}`);
 
   assert.ok(page.profileLink.isVisible, 'Profile link is rendered.');
   assert.ok(page.integrationsLink.isVisible, 'Integrations link is rendered.');

--- a/tests/integration/components/signup-email-input-test.js
+++ b/tests/integration/components/signup-email-input-test.js
@@ -20,7 +20,7 @@ moduleForComponent('signup-email-input', 'Integration | Component | signup email
 });
 
 test('it shows nothing when empty', function(assert) {
-  page.render(hbs`{{signup-email-input}}`);
+  this.render(hbs`{{signup-email-input}}`);
 
   assert.notOk(page.suggestionsArea.visible);
   assert.notOk(page.suggestionsArea.visible);
@@ -39,15 +39,15 @@ test('it shows suggestions when invalid', async function(assert) {
     });
   });
   this.set('user', { email: null });
-  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
+  this.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
   page.fillIn('incomplete@');
   await page.keydown();
 
   assert.notOk(page.suggestionsArea.ok);
   assert.ok(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 1);
-  assert.equal(page.suggestionsArea.suggestions(0).text, 'Please enter a valid email.');
+  assert.equal(page.suggestionsArea.suggestions.length, 1);
+  assert.equal(page.suggestionsArea.suggestions.objectAt(0).text, 'Please enter a valid email.');
 });
 
 test('it shows suggestions when unavailable', async function(assert) {
@@ -63,15 +63,15 @@ test('it shows suggestions when unavailable', async function(assert) {
     });
   });
   this.set('user', { email: null });
-  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
+  this.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
   page.fillIn('taken@gmail.com');
   await page.keydown();
 
   assert.notOk(page.suggestionsArea.ok);
   assert.ok(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 1);
-  assert.equal(page.suggestionsArea.suggestions(0).text, 'This email is already registered. Want to login?');
+  assert.equal(page.suggestionsArea.suggestions.length, 1);
+  assert.equal(page.suggestionsArea.suggestions.objectAt(0).text, 'This email is already registered. Want to login?');
 });
 
 test('it shows ok when valid and available', async function(assert) {
@@ -87,14 +87,14 @@ test('it shows ok when valid and available', async function(assert) {
     });
   });
   this.set('user', { email: null });
-  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
+  this.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
   page.fillIn('available@gmail.com');
   await page.keydown();
 
   assert.ok(page.suggestionsArea.ok);
   assert.notOk(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 0);
+  assert.equal(page.suggestionsArea.suggestions.length, 0);
 });
 
 test('it resets to invalid when deleted', async function(assert) {
@@ -110,7 +110,7 @@ test('it resets to invalid when deleted', async function(assert) {
     });
   });
   this.set('user', { email: 'available@gmail.com' });
-  page.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
+  this.render(hbs`{{signup-email-input user=user emailValidated=emailValidated}}`);
 
   page.fillIn('');
   await page.keydown();

--- a/tests/integration/components/signup-form-test.js
+++ b/tests/integration/components/signup-form-test.js
@@ -7,10 +7,6 @@ import component from 'code-corps-ember/tests/pages/components/signup-form';
 
 const page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`{{signup-form user=user}}`);
-}
-
 moduleForComponent('signup-form', 'Integration | Component | signup form', {
   integration: true,
   beforeEach() {
@@ -24,7 +20,7 @@ moduleForComponent('signup-form', 'Integration | Component | signup form', {
 test('it renders required ui elements', function(assert) {
   assert.expect(4);
 
-  renderPage();
+  this.render(hbs`{{signup-form user=user}}`);
 
   assert.ok(page.usernameInput.isVisible, 'The username field renders');
   assert.ok(page.emailInput.isVisible, 'The email field renders');
@@ -35,7 +31,7 @@ test('it renders required ui elements', function(assert) {
 test('renders different title if user is donating', function(assert) {
   assert.expect(2);
 
-  renderPage();
+  this.render(hbs`{{signup-form user=user}}`);
 
   let normalUser = { signUpContext: null };
   let donatingUser = { signUpContext: 'donation' };

--- a/tests/integration/components/signup-password-input-test.js
+++ b/tests/integration/components/signup-password-input-test.js
@@ -16,34 +16,34 @@ moduleForComponent('signup-password-input', 'Integration | Component | signup pa
 });
 
 test('it shows nothing when empty', function(assert) {
-  page.render(hbs`{{signup-password-input}}`);
+  this.render(hbs`{{signup-password-input}}`);
 
   assert.notOk(page.suggestionsArea.visible);
 });
 
 test('it shows suggestions when needed', function(assert) {
   this.set('user', { password: 'password' });
-  page.render(hbs`{{signup-password-input user=user}}`);
+  this.render(hbs`{{signup-password-input user=user}}`);
 
   assert.ok(page.suggestionsArea.ok, 'renders a check');
-  assert.equal(page.suggestionsArea.suggestions().count, 2);
-  assert.equal(page.suggestionsArea.suggestions(0).text, 'Tips for a stronger password:');
-  assert.equal(page.suggestionsArea.suggestions(1).text, 'Add another word or two. Uncommon words are better.');
+  assert.equal(page.suggestionsArea.suggestions.length, 2);
+  assert.equal(page.suggestionsArea.suggestions.objectAt(0).text, 'Tips for a stronger password:');
+  assert.equal(page.suggestionsArea.suggestions.objectAt(1).text, 'Add another word or two. Uncommon words are better.');
 });
 
 test('it shows password strength', function(assert) {
   // https://xkcd.com/936/
   this.set('user', { password: 'correcthorsebatterystaple' });
-  page.render(hbs`{{signup-password-input user=user}}`);
+  this.render(hbs`{{signup-password-input user=user}}`);
 
   assert.ok(page.progressBar.displaysPercentage(100));
 });
 
 test('it shows minimum length error', function(assert) {
   this.set('user', { password: 'p' });
-  page.render(hbs`{{signup-password-input user=user}}`);
+  this.render(hbs`{{signup-password-input user=user}}`);
 
   assert.ok(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 1);
-  assert.equal(page.suggestionsArea.suggestions(0).text, 'Your password must be at least 6 characters.');
+  assert.equal(page.suggestionsArea.suggestions.length, 1);
+  assert.equal(page.suggestionsArea.suggestions.objectAt(0).text, 'Your password must be at least 6 characters.');
 });

--- a/tests/integration/components/signup-username-input-test.js
+++ b/tests/integration/components/signup-username-input-test.js
@@ -22,7 +22,7 @@ moduleForComponent('signup-username-input', 'Integration | Component | signup us
 });
 
 test('it shows nothing when empty', function(assert) {
-  page.render(hbs`{{signup-username-input}}`);
+  this.render(hbs`{{signup-username-input}}`);
 
   assert.notOk(page.suggestionsArea.visible);
   assert.notOk(page.suggestionsArea.visible);
@@ -41,15 +41,15 @@ test('it shows suggestions when invalid', async function(assert) {
     });
   });
   this.set('user', { username: null });
-  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
+  this.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
   page.fillIn('lots--of--hypens');
   await page.keydown();
 
   assert.notOk(page.suggestionsArea.ok);
   assert.ok(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 1);
-  assert.equal(page.suggestionsArea.suggestions(0).text, 'Please enter a username with only letters, numbers, or underscores.');
+  assert.equal(page.suggestionsArea.suggestions.length, 1);
+  assert.equal(page.suggestionsArea.suggestions.objectAt(0).text, 'Please enter a username with only letters, numbers, or underscores.');
 });
 
 test('it shows suggestions when unavailable', async function(assert) {
@@ -65,15 +65,15 @@ test('it shows suggestions when unavailable', async function(assert) {
     });
   });
   this.set('user', { username: null });
-  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
+  this.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
   page.fillIn('taken');
   await page.keydown();
 
   assert.notOk(page.suggestionsArea.ok);
   assert.ok(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 1);
-  assert.equal(page.suggestionsArea.suggestions(0).text, 'This username is already registered. Want to login?');
+  assert.equal(page.suggestionsArea.suggestions.length, 1);
+  assert.equal(page.suggestionsArea.suggestions.objectAt(0).text, 'This username is already registered. Want to login?');
 });
 
 test('it shows ok when valid and available', async function(assert) {
@@ -89,14 +89,14 @@ test('it shows ok when valid and available', async function(assert) {
     });
   });
   this.set('user', { username: null });
-  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
+  this.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
   page.fillIn('available');
   await page.keydown();
 
   assert.ok(page.suggestionsArea.ok);
   assert.notOk(page.suggestionsArea.notOk);
-  assert.equal(page.suggestionsArea.suggestions().count, 0);
+  assert.equal(page.suggestionsArea.suggestions.length, 0);
 });
 
 test('it resets to show nothing when cleared', async function(assert) {
@@ -112,7 +112,7 @@ test('it resets to show nothing when cleared', async function(assert) {
     });
   });
   this.set('user', { username: 'available' });
-  page.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
+  this.render(hbs`{{signup-username-input user=user usernameValidated=usernameValidated}}`);
 
   page.fillIn('');
   await page.keydown();

--- a/tests/integration/components/site-footer-test.js
+++ b/tests/integration/components/site-footer-test.js
@@ -7,20 +7,16 @@ import stubService from 'code-corps-ember/tests/helpers/stub-service';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`{{site-footer media=media}}`);
-}
-
 function assertReducedFooter(assert) {
-  assert.equal(page.rows().count, 6);
+  assert.equal(page.rows.length, 6);
 
-  assert.equal(page.rows(0).text, 'About');
-  assert.equal(page.rows(1).text, 'Team');
-  assert.equal(page.rows(2).text, 'Help');
-  assert.equal(page.rows(2).link.href, 'https://help.codecorps.org');
-  assert.equal(page.rows(3).text, 'Terms');
-  assert.equal(page.rows(4).text, 'Privacy');
-  assert.equal(page.rows(5).text, 'Blog');
+  assert.equal(page.rows.objectAt(0).text, 'About');
+  assert.equal(page.rows.objectAt(1).text, 'Team');
+  assert.equal(page.rows.objectAt(2).text, 'Help');
+  assert.equal(page.rows.objectAt(2).link.href, 'https://help.codecorps.org');
+  assert.equal(page.rows.objectAt(3).text, 'Terms');
+  assert.equal(page.rows.objectAt(4).text, 'Privacy');
+  assert.equal(page.rows.objectAt(5).text, 'Blog');
 }
 
 moduleForComponent('site-footer', 'Integration | Component | site footer', {
@@ -37,38 +33,38 @@ test('it renders all elements when showing the full footer', function(assert) {
   setBreakpointForIntegrationTest(this, 'full');
   stubService(this, 'site-footer', { isShrunken: false });
 
-  renderPage();
+  this.render(hbs`{{site-footer media=media}}`);
 
-  assert.equal(page.columns().count, 4);
+  assert.equal(page.columns.length, 4);
 
-  assert.equal(page.columns(0).header, 'Code Corps');
-  assert.equal(page.columns(1).header, 'Help');
-  assert.equal(page.columns(2).header, 'Learn');
-  assert.equal(page.columns(3).header, 'Connect');
+  assert.equal(page.columns.objectAt(0).header, 'Code Corps');
+  assert.equal(page.columns.objectAt(1).header, 'Help');
+  assert.equal(page.columns.objectAt(2).header, 'Learn');
+  assert.equal(page.columns.objectAt(3).header, 'Connect');
 
-  page.columns(0).as((column) => {
-    assert.equal(column.rows(0).text, 'About us');
-    assert.equal(column.rows(1).text, 'Team');
+  page.columns.objectAt(0).as((column) => {
+    assert.equal(column.rows.objectAt(0).text, 'About us');
+    assert.equal(column.rows.objectAt(1).text, 'Team');
   });
 
-  page.columns(1).as((column) => {
-    assert.equal(column.rows(0).text, 'Help Center');
-    assert.equal(column.rows(0).link.href, 'https://help.codecorps.org');
-    assert.equal(column.rows(1).text, 'Terms of Use');
-    assert.equal(column.rows(2).text, 'Privacy Policy');
+  page.columns.objectAt(1).as((column) => {
+    assert.equal(column.rows.objectAt(0).text, 'Help Center');
+    assert.equal(column.rows.objectAt(0).link.href, 'https://help.codecorps.org');
+    assert.equal(column.rows.objectAt(1).text, 'Terms of Use');
+    assert.equal(column.rows.objectAt(2).text, 'Privacy Policy');
   });
 
-  assert.equal(page.columns(2).rows(0).text, 'Blog');
+  assert.equal(page.columns.objectAt(2).rows.objectAt(0).text, 'Blog');
 
-  page.columns(3).as((column) => {
-    assert.equal(column.rows(0).text, 'GitHub');
-    assert.equal(column.rows(0).link.href, 'https://github.com/code-corps');
-    assert.equal(column.rows(1).text, 'Slack');
-    assert.equal(column.rows(1).link.href, 'http://slack.codecorps.org');
-    assert.equal(column.rows(2).text, 'Twitter');
-    assert.equal(column.rows(2).link.href, 'https://twitter.com/thecodecorps');
-    assert.equal(column.rows(3).text, 'Facebook');
-    assert.equal(column.rows(3).link.href, 'https://www.facebook.com/thecodecorps');
+  page.columns.objectAt(3).as((column) => {
+    assert.equal(column.rows.objectAt(0).text, 'GitHub');
+    assert.equal(column.rows.objectAt(0).link.href, 'https://github.com/code-corps');
+    assert.equal(column.rows.objectAt(1).text, 'Slack');
+    assert.equal(column.rows.objectAt(1).link.href, 'http://slack.codecorps.org');
+    assert.equal(column.rows.objectAt(2).text, 'Twitter');
+    assert.equal(column.rows.objectAt(2).link.href, 'https://twitter.com/thecodecorps');
+    assert.equal(column.rows.objectAt(3).text, 'Facebook');
+    assert.equal(column.rows.objectAt(3).link.href, 'https://www.facebook.com/thecodecorps');
   });
 });
 
@@ -76,7 +72,7 @@ test('it renders only the horizontal elements when showing the shrunken footer',
   setBreakpointForIntegrationTest(this, 'full');
   stubService(this, 'site-footer', { isShrunken: true });
 
-  renderPage();
+  this.render(hbs`{{site-footer media=media}}`);
 
   assertReducedFooter(assert);
 });
@@ -85,7 +81,7 @@ test('it renders only the horizontal elements for the medium breakpoint', functi
   setBreakpointForIntegrationTest(this, 'medium');
   stubService(this, 'site-footer', { isShrunken: false });
 
-  renderPage();
+  this.render(hbs`{{site-footer media=media}}`);
 
   assertReducedFooter(assert);
 });

--- a/tests/integration/components/skill-list-item-link-test.js
+++ b/tests/integration/components/skill-list-item-link-test.js
@@ -13,10 +13,6 @@ function setHandlers(context, toggleHandler = function() {}) {
   context.set('toggleHandler', toggleHandler);
 }
 
-function renderPage() {
-  page.render(hbs`{{skill-list-item-link skill=skill matched=matched toggleSkill=toggleHandler}}`);
-}
-
 moduleForComponent('skill-list-item-link', 'Integration | Component | skill list item link', {
   integration: true,
   beforeEach() {
@@ -32,7 +28,7 @@ test('it renders correctly for skill', function(assert) {
   assert.expect(1);
 
   set(this, 'skill', { title: 'Ember.js' });
-  renderPage();
+  this.render(hbs`{{skill-list-item-link skill=skill matched=matched toggleSkill=toggleHandler}}`);
 
   assert.equal(page.skillTitle.text, 'Ember.js', 'The skill title renders');
 });
@@ -49,14 +45,14 @@ test('it toggles the action when clicked and authenticated', function(assert) {
     assert.deepEqual(skill, toggledSkill);
   }
   setHandlers(this, toggleHandler);
-  renderPage();
+  this.render(hbs`{{skill-list-item-link skill=skill matched=matched toggleSkill=toggleHandler}}`);
 
   page.click();
 });
 
 test('it does not have clicked or removed classes at first', function(assert) {
   assert.expect(2);
-  renderPage();
+  this.render(hbs`{{skill-list-item-link skill=skill matched=matched toggleSkill=toggleHandler}}`);
   assert.notOk(page.hasJustClicked, 'Does not have clicked class');
   assert.notOk(page.hasJustRemoved, 'Does not have removed class');
 });
@@ -65,7 +61,7 @@ test('it correctly adds and removes clicked class', function(assert) {
   assert.expect(2);
 
   stubService(this, 'session', mockSession);
-  renderPage();
+  this.render(hbs`{{skill-list-item-link skill=skill matched=matched toggleSkill=toggleHandler}}`);
 
   page.mouseenter();
   page.click();
@@ -95,7 +91,7 @@ test('it does not add removed class when unmatched', function(assert) {
 
   stubService(this, 'session', mockSession);
   set(this, 'matched', false);
-  renderPage();
+  this.render(hbs`{{skill-list-item-link skill=skill matched=matched toggleSkill=toggleHandler}}`);
 
   page.mouseenter();
 

--- a/tests/integration/components/skill-list-items-test.js
+++ b/tests/integration/components/skill-list-items-test.js
@@ -54,22 +54,22 @@ test('it renders the skills sorted by match and then alphabetically', function(a
 
   assert.equal(page.listItemCount, 4, 'Renders the correct number of skills');
 
-  page.listItems(0).as((item) => {
+  page.listItems.objectAt(0).as((item) => {
     assert.equal(item.skillListItemSpan.text, 'HTML');
     assert.ok(item.skillListItemSpan.hasMatched);
   });
 
-  page.listItems(1).as((item) => {
+  page.listItems.objectAt(1).as((item) => {
     assert.equal(item.skillListItemSpan.text, 'Ember.js');
     assert.notOk(item.skillListItemSpan.hasMatched);
   });
 
-  page.listItems(2).as((item) => {
+  page.listItems.objectAt(2).as((item) => {
     assert.equal(item.skillListItemSpan.text, 'Rails');
     assert.notOk(item.skillListItemSpan.hasMatched);
   });
 
-  page.listItems(3).as((item) => {
+  page.listItems.objectAt(3).as((item) => {
     assert.equal(item.skillListItemSpan.text, 'Ruby');
     assert.notOk(item.skillListItemSpan.hasMatched);
   });

--- a/tests/integration/components/skills-typeahead-result-test.js
+++ b/tests/integration/components/skills-typeahead-result-test.js
@@ -41,7 +41,7 @@ test('it renders as selected with the highlighted string', function(assert) {
   set(this, 'skill', skill);
   set(this, 'query', query);
 
-  page.render(hbs`
+  this.render(hbs`
     {{skills-typeahead-result
       query=query
       skill=skill
@@ -51,9 +51,9 @@ test('it renders as selected with the highlighted string', function(assert) {
 
   assert.ok(page.listItemIsSelected);
 
-  assert.equal(page.highlightedStrings(0).text, 'Ru');
-  assert.equal(page.highlightedStrings(1).text, 'on');
-  assert.equal(page.highlightedStrings(2).text, 'R');
+  assert.equal(page.highlightedStrings.objectAt(0).text, 'Ru');
+  assert.equal(page.highlightedStrings.objectAt(1).text, 'on');
+  assert.equal(page.highlightedStrings.objectAt(2).text, 'R');
 });
 
 test('it sends the hover action on mouseEnter', function(assert) {
@@ -65,7 +65,7 @@ test('it sends the hover action on mouseEnter', function(assert) {
   this.on('hover', (hoveredSkill) => {
     assert.deepEqual(skill, hoveredSkill);
   });
-  page.render(hbs`
+  this.render(hbs`
     {{skills-typeahead-result
       hover="hover"
       query=query
@@ -86,7 +86,7 @@ test('it sends the selectSkill action on mouseDown', function(assert) {
     assert.ok(true);
   });
 
-  page.render(hbs`
+  this.render(hbs`
     {{skills-typeahead-result
       hover="hover"
       query=query

--- a/tests/integration/components/skills-typeahead-test.js
+++ b/tests/integration/components/skills-typeahead-test.js
@@ -54,7 +54,7 @@ moduleForComponent('skills-typeahead', 'Integration | Component | skills typeahe
 
 test('it does nothing when pressing a random key', function(assert) {
   assert.expect(1);
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) skillsList=mockListService}}`);
   page.pressRKey();
   assert.equal(page.inputValue, '');
 });
@@ -63,7 +63,7 @@ test('it fetches results when changing the input', function(assert) {
   let done = assert.async();
   assert.expect(5);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
 
@@ -71,13 +71,13 @@ test('it fetches results when changing the input', function(assert) {
   page.keydown();
   focus('input');
 
-  page.dropdown.inputItems(0).as((item) => {
-    assert.equal(item.highlightedStrings(0).text, 'Ruby');
+  page.dropdown.inputItems.objectAt(0).as((item) => {
+    assert.equal(item.highlightedStrings.objectAt(0).text, 'Ruby');
     assert.ok(item.listItemIsSelected);
   });
 
-  page.dropdown.inputItems(1).as((item) => {
-    assert.equal(item.highlightedStrings(1).text, 'Ra');
+  page.dropdown.inputItems.objectAt(1).as((item) => {
+    assert.equal(item.highlightedStrings.objectAt(1).text, 'Ra');
     assert.notOk(item.listItemIsSelected);
   });
 
@@ -88,30 +88,30 @@ test('it changes the selection when arrowing up or down', function(assert) {
   let done = assert.async();
   assert.expect(10);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.keydown();
   focus('input');
 
-  assert.ok(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.notOk(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
 
   page.pressDownKey();
-  assert.notOk(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.ok(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
 
   page.pressDownKey();
-  assert.ok(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.notOk(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
 
   page.pressUpKey();
-  assert.notOk(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.ok(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
 
   page.pressUpKey();
-  assert.ok(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.notOk(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
 
   done();
 });
@@ -120,7 +120,7 @@ test('it hides and clears input when hitting esc key', function(assert) {
   let done = assert.async();
   assert.expect(3);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.keydown();
@@ -139,18 +139,18 @@ test('it changes the selection when hovering', function(assert) {
   let done = assert.async();
   assert.expect(4);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.keydown();
   focus('input');
 
-  assert.ok(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.notOk(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
 
   page.dropdown.mouseenterSecondItem();
-  assert.notOk(page.dropdown.inputItems(0).listItemIsSelected);
-  assert.ok(page.dropdown.inputItems(1).listItemIsSelected);
+  assert.notOk(page.dropdown.inputItems.objectAt(0).listItemIsSelected);
+  assert.ok(page.dropdown.inputItems.objectAt(1).listItemIsSelected);
   done();
 });
 
@@ -158,7 +158,7 @@ test('it selects the skill when hitting enter', function(assert) {
   let done = assert.async();
   assert.expect(2);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.keydown();
@@ -173,7 +173,7 @@ test('it selects the skill when hitting comma', function(assert) {
   let done = assert.async();
   assert.expect(2);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.pressCommaKey();
@@ -187,7 +187,7 @@ test('it selects the skill when clicking it', function(assert) {
   let done = assert.async();
   assert.expect(2);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.keydown();
@@ -209,7 +209,7 @@ test('it does nothing when there are no results', function(assert) {
   };
   set(this, 'store.query', query);
 
-  page.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
+  this.render(hbs`{{skills-typeahead selectSkill=(action selectHandler) query=query skillsList=mockListService}}`);
 
   page.fillIn('ruby ra');
   page.keydown();

--- a/tests/integration/components/slugged-route-model-details-test.js
+++ b/tests/integration/components/slugged-route-model-details-test.js
@@ -6,16 +6,6 @@ import component from 'code-corps-ember/tests/pages/components/slugged-route-mod
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{slugged-route-model-details
-      sluggedRoute=sluggedRoute
-      organization=sluggedRoute.organization
-      user=sluggedRoute.user
-    }}`
-  );
-}
-
 moduleForComponent('slugged-route-model-details', 'Integration | Component | slugged route model details', {
   integration: true,
   beforeEach() {
@@ -33,7 +23,13 @@ test('when the slugged route is an organization, it renders the organization com
   let sluggedRoute = { organization: {} };
 
   this.set('sluggedRoute', sluggedRoute);
-  renderPage();
+  this.render(hbs`
+    {{slugged-route-model-details
+      sluggedRoute=sluggedRoute
+      organization=sluggedRoute.organization
+      user=sluggedRoute.user
+    }}`
+  );
 
   assert.ok(page.organizationProfile.isVisible, 'organization component is rendered.');
 });
@@ -44,7 +40,13 @@ test('when the slugged route is a user, it renders the user component', function
   let sluggedRoute = { user: {} };
 
   this.set('sluggedRoute', sluggedRoute);
-  renderPage();
+  this.render(hbs`
+    {{slugged-route-model-details
+      sluggedRoute=sluggedRoute
+      organization=sluggedRoute.organization
+      user=sluggedRoute.user
+    }}`
+  );
 
   assert.ok(page.userDetails.isVisible, 'the user component is rendered.');
 });

--- a/tests/integration/components/stripe-connect-button-test.js
+++ b/tests/integration/components/stripe-connect-button-test.js
@@ -16,7 +16,7 @@ test('it renders all required elements', function(assert) {
 
   page.setContext(this);
   this.set('url', url);
-  page.render(hbs`{{stripe-connect-button url=url}}`);
+  this.render(hbs`{{stripe-connect-button url=url}}`);
 
   page.as((component) => {
     assert.equal(component.text, 'Connect with Stripe');

--- a/tests/integration/components/submittable-textarea-test.js
+++ b/tests/integration/components/submittable-textarea-test.js
@@ -5,10 +5,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(pageComponent);
 
-function renderPage() {
-  page.render(hbs`{{submittable-textarea modifiedSubmit=modifiedSubmitHandler}}`);
-}
-
 function setHandler(context, modifiedSubmitHandler = () => {}) {
   context.set('modifiedSubmitHandler', modifiedSubmitHandler);
 }
@@ -27,7 +23,7 @@ moduleForComponent('submittable-textarea', 'Integration | Component | submittabl
 // This test is necessary because a new line after yield in the file will
 // cause a new line in the textarea itself
 test('it has no extra content when created', function(assert) {
-  renderPage();
+  this.render(hbs`{{submittable-textarea modifiedSubmit=modifiedSubmitHandler}}`);
   assert.equal(page.value, '', 'Element is blank.');
 });
 
@@ -38,7 +34,7 @@ test('it sends the modifiedSubmit action on command/ctrl + enter', function(asse
     assert.equal(page.value, '', 'Action was called. Input content was unchanged.');
   });
 
-  renderPage();
+  this.render(hbs`{{submittable-textarea modifiedSubmit=modifiedSubmitHandler}}`);
 
   page.keySubmit();
 });

--- a/tests/integration/components/svg/sprite-icon-test.js
+++ b/tests/integration/components/svg/sprite-icon-test.js
@@ -6,15 +6,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{svg/sprite-icon
-      icon=icon
-      style=style
-    }}
-  `);
-}
-
 moduleForComponent('svg/sprite-icon', 'Integration | Component | svg/sprite icon', {
   integration: true,
   beforeEach() {
@@ -31,7 +22,7 @@ test('it renders the icon and style', function(assert) {
   set(this, 'icon', 'github-48');
   set(this, 'style', 'solid-light-gray');
 
-  renderPage();
+  this.render(hbs`{{svg/sprite-icon icon=icon style=style}}`);
 
   assert.equal(page.svg.use.xlinkHref, '#github-48', 'The icon xlink href value is properly bound.');
   assert.ok(page.svg.isSolidLightGray, 'The svg has the style class.');
@@ -39,13 +30,13 @@ test('it renders the icon and style', function(assert) {
 
 test('it renders the default size', function(assert) {
   assert.expect(1);
-  renderPage();
+  this.render(hbs`{{svg/sprite-icon icon=icon style=style}}`);
   assert.ok(page.svg.hasClass('size-16'), 'The svg has a default size.');
 });
 
 test('it renders a different size', function(assert) {
   assert.expect(1);
   set(this, 'size', '50');
-  renderPage();
+  this.render(hbs`{{svg/sprite-icon icon=icon style=style}}`);
   assert.ok(page.svg.hasClass('size-50'), 'The svg renders the passed size.');
 });

--- a/tests/integration/components/task-assignment-test.js
+++ b/tests/integration/components/task-assignment-test.js
@@ -1,5 +1,5 @@
 import RSVP from 'rsvp';
-import { set, setProperties } from '@ember/object';
+import { setProperties } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import PageObject from 'ember-cli-page-object';
@@ -12,17 +12,6 @@ import { initialize as initializeKeyboard } from 'ember-keyboard';
 const { PromiseObject } = DS;
 
 let page = PageObject.create(taskAssignmentComponent);
-
-function renderPage() {
-  page.render(hbs`
-    {{task-assignment
-      canTriggerAssignment=canTriggerAssignment
-      deferredRendering=deferredRendering
-      task=task
-      taskUser=taskUser
-      users=users
-    }}`);
-}
 
 moduleForComponent('task-assignment', 'Integration | Component | task assignment', {
   integration: true,
@@ -60,10 +49,10 @@ test('assignment works if user has ability', function(assert) {
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment task=task users=users}}`);
 
   page.select.trigger.open();
-  page.select.dropdown.options(0).select();
+  page.select.dropdown.options.objectAt(0).select();
 });
 
 test('unassignment works if user has ability', function(assert) {
@@ -88,10 +77,10 @@ test('unassignment works if user has ability', function(assert) {
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment task=task taskUser=taskUser users=users}}`);
 
   page.select.trigger.open();
-  page.select.dropdown.options(0).select();
+  page.select.dropdown.options.objectAt(0).select();
 });
 
 test('assignment dropdown renders if user has ability', function(assert) {
@@ -112,11 +101,11 @@ test('assignment dropdown renders if user has ability', function(assert) {
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment task=task users=users}}`);
 
   page.select.trigger.open();
-  assert.equal(page.select.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
-  assert.equal(page.select.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
+  assert.equal(page.select.dropdown.options.objectAt(0).text, 'testuser1', 'First user is rendered.');
+  assert.equal(page.select.dropdown.options.objectAt(1).text, 'testuser2', 'Second user is rendered.');
 });
 
 test('assignment dropdown renders when records are still being loaded', function(assert) {
@@ -143,12 +132,12 @@ test('assignment dropdown renders when records are still being loaded', function
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment task=task users=users}}`);
 
   RSVP.all(users).then(() => {
     page.select.trigger.open();
-    assert.equal(page.select.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
-    assert.equal(page.select.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
+    assert.equal(page.select.dropdown.options.objectAt(0).text, 'testuser1', 'First user is rendered.');
+    assert.equal(page.select.dropdown.options.objectAt(1).text, 'testuser2', 'Second user is rendered.');
     done();
   });
 });
@@ -175,7 +164,7 @@ test('assignment dropdown does not render if user has no ability', function(asse
 
   this.register('ability:task', Ability.extend({ canAssign: false }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment task=task taskUser=taskUser users=users}}`);
 
   assert.notOk(page.select.triggerRenders, 'Dropdown trigger for assignment does not render.');
   page.assignedUser.as((user) => {
@@ -188,11 +177,11 @@ test('when rendering is deffered and user does not have ability and no assigned 
 
   let task = { id: 'task' };
 
-  set(this, 'task', task);
-  set(this, 'deferredRendering', true);
   this.register('ability:task', Ability.extend({ canAssign: false }));
 
-  renderPage();
+  setProperties(this, { task, deferredRendering: true });
+
+  this.render(hbs`{{task-assignment deferredRendering=deferredRendering task=task}}`);
 
   assert.notOk(page.select.triggerRenders, 'Dropdown trigger for assignment does not render.');
   assert.notOk(page.assignedUser.isVisible, 'Assigned user does not render.');
@@ -204,11 +193,11 @@ test('when rendering is deffered and user has ability and no assigned user', fun
 
   let task = { id: 'task' };
 
-  set(this, 'task', task);
-  set(this, 'deferredRendering', true);
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  setProperties(this, { task, deferredRendering: true });
+
+  this.render(hbs`{{task-assignment deferredRendering=deferredRendering task=task}}`);
 
   assert.notOk(page.select.triggerRenders, 'Dropdown trigger for assignment does not render.');
   assert.notOk(page.assignedUser.isVisible, 'Assigned user does not render.');
@@ -220,19 +209,17 @@ test('when rendering is deffered and user does not have ability and there is an 
 
   let task = { id: 'task' };
 
-  set(this, 'task', task);
-  set(this, 'deferredRendering', true);
   let user1 = {
     id: 'user1',
     username: 'testuser1',
     photoThumbUrl: 'test.png'
   };
 
-  setProperties(this, { task, taskUser: user1 });
+  setProperties(this, { task, taskUser: user1, deferredRendering: true });
 
   this.register('ability:task', Ability.extend({ canAssign: false }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment deferredRendering=deferredRendering task=task taskUser=taskUser}}`);
 
   assert.notOk(page.select.triggerRenders, 'Dropdown trigger for assignment does not render.');
   assert.ok(page.assignedUser.isVisible, 'Assigned user renders.');
@@ -266,12 +253,12 @@ test('assignment dropdown typeahead', function(assert) {
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment task=task users=users}}`);
 
   page.select.trigger.open();
   page.select.dropdown.input.fillIn('testuser2');
 
-  assert.equal(page.select.dropdown.options(0).text, 'testuser2', 'Only the second user is rendered.');
+  assert.equal(page.select.dropdown.options.objectAt(0).text, 'testuser2', 'Only the second user is rendered.');
 });
 
 test('pressing Space assigns self to task when able', function(assert) {
@@ -298,7 +285,7 @@ test('pressing Space assigns self to task when able', function(assert) {
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment canTriggerAssignment=canTriggerAssignment task=task users=users}}`);
 
   page.triggerKeyDown('Space');
 });
@@ -327,7 +314,12 @@ test('pressing Space unassigns self from task when able', function(assert) {
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment
+    canTriggerAssignment=canTriggerAssignment
+    task=task
+    taskUser=taskUser
+    users=users}}`
+  );
 
   page.triggerKeyDown('Space');
 });
@@ -335,12 +327,13 @@ test('pressing Space unassigns self from task when able', function(assert) {
 test('pressing A when the user has ability', function(assert) {
   assert.expect(2);
 
+  this.register('ability:task', Ability.extend({ canAssign: true }));
+
   let canTriggerAssignment = true;
   let task = { id: 'task' };
   setProperties(this, { canTriggerAssignment, task });
-  this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment canTriggerAssignment=canTriggerAssignment task=task}}`);
 
   page.triggerKeyDown('KeyA');
   assert.ok(page.select.dropdown.isVisible, 'Dropdown renders.');
@@ -351,12 +344,13 @@ test('pressing A when the user has ability', function(assert) {
 test('pressing A when the user does not have ability', function(assert) {
   assert.expect(1);
 
+  this.register('ability:task', Ability.extend({ canAssign: false }));
+
   let canTriggerAssignment = true;
   let task = { id: 'task' };
   setProperties(this, { canTriggerAssignment, task });
-  this.register('ability:task', Ability.extend({ canAssign: false }));
 
-  renderPage();
+  this.render(hbs`{{task-assignment canTriggerAssignment=canTriggerAssignment task=task}}`);
 
   page.triggerKeyDown('KeyA');
   assert.notOk(page.select.dropdown.isVisible, 'Dropdown does not render.');

--- a/tests/integration/components/task-card-test.js
+++ b/tests/integration/components/task-card-test.js
@@ -14,17 +14,6 @@ const { PromiseObject } = DS;
 
 let page = PageObject.create(taskCardComponent);
 
-function renderPage() {
-  page.render(hbs`
-    {{task-card
-      clickedTask=clickedTask
-      keyboardActivated=keyboardActivated
-      task=task
-      taskUser=taskUser
-      users=users
-    }}`);
-}
-
 function setHandler(context, clickedTaskHandler = function() {}) {
   set(context, 'clickedTaskHandler', clickedTaskHandler);
 }
@@ -52,7 +41,8 @@ test('it renders all the required elements', function(assert) {
   };
 
   set(this, 'task', task);
-  renderPage();
+
+  this.render(hbs`{{task-card task=task}}`);
 
   assert.equal(page.number.text, '#1', 'The number renders');
   assert.equal(page.time.text, '2 days ago', 'The time renders');
@@ -65,7 +55,8 @@ test('it renders a pull request icon if associated to a pull request', function(
   let task = { githubPullRequest: { id: 'foo' } };
 
   set(this, 'task', task);
-  renderPage();
+
+  this.render(hbs`{{task-card task=task}}`);
 
   assert.ok(page.pullRequestIcon.isVisible, 'The pull request icon renders');
 });
@@ -76,7 +67,7 @@ test('it does not render a pull request icon if not associated to a pull request
   let task = { githubPullRequest: null };
 
   set(this, 'task', task);
-  renderPage();
+  this.render(hbs`{{task-card task=task}}`);
 
   assert.notOk(page.pullRequestIcon.isVisible, 'The pull request icon does not render');
 });
@@ -85,7 +76,7 @@ test('it can reposition if it has the ability', function(assert) {
   assert.expect(1);
   this.register('ability:task', Ability.extend({ canReposition: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card}}`);
 
   assert.ok(page.canReposition, 'Can reposition');
 });
@@ -94,26 +85,33 @@ test('it cannot reposition if it does not have the ability', function(assert) {
   assert.expect(1);
   this.register('ability:task', Ability.extend({ canReposition: false }));
 
-  renderPage();
+  this.render(hbs`{{task-card}}`);
 
   assert.notOk(page.canReposition, 'Cannot reposition');
 });
 
 test('it renders the GitHub issue link icon if it has an issue and is hovering', function(assert) {
   assert.expect(1);
+
   let isLoaded = true;
   let task = { githubIssue: { isLoaded }, githubRepo: { isLoaded } };
+
   set(this, 'task', task);
-  renderPage();
+
+  this.render(hbs`{{task-card task=task}}`);
+
   page.mouseenter();
   assert.ok(page.issueLink.isVisible, 'The GitHub issue link is visible');
 });
 
 test('it does not render the GitHub issue link icon if it does not have an issue and is hovering', function(assert) {
   assert.expect(1);
+
   let task = { githubIssue: null };
   set(this, 'task', task);
-  renderPage();
+
+  this.render(hbs`{{task-card task=task}}`);
+
   page.mouseenter();
   assert.notOk(page.issueLink.isVisible, 'The GitHub issue link is not visible');
 });
@@ -121,17 +119,16 @@ test('it does not render the GitHub issue link icon if it does not have an issue
 test('it sends action if clicked and not loading', function(assert) {
   assert.expect(1);
 
-  let task = {
-    isLoading: false,
-    number: 1
-  };
+  let task = { isLoading: false, number: 1 };
 
   set(this, 'clickedTask', function(clickedTask) {
     assert.deepEqual(clickedTask, task);
   });
+
   set(this, 'task', task);
 
-  renderPage();
+  this.render(hbs`{{task-card clickedTask=clickedTask task=task}}`);
+
   page.click();
 });
 
@@ -146,9 +143,11 @@ test('it does not send action if clicked and loading', function(assert) {
   set(this, 'clickedTask', function() {
     assert.notOk();
   });
+
   set(this, 'task', task);
 
-  renderPage();
+  this.render(hbs`{{task-card clickedTask=clickedTask task=task}}`);
+
   page.click();
   assert.ok(true);
 });
@@ -176,11 +175,11 @@ test('assignment works if user has ability and card is hovered', function(assert
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task users=users}}`);
 
   page.mouseenter();
   page.taskAssignment.select.trigger.open();
-  page.taskAssignment.select.dropdown.options(0).select();
+  page.taskAssignment.select.dropdown.options.objectAt(0).select();
 });
 
 test('unassignment works if user has ability and card is hovered', function(assert) {
@@ -205,11 +204,11 @@ test('unassignment works if user has ability and card is hovered', function(asse
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task users=users taskUser=taskUser}}`);
 
   page.mouseenter();
   page.taskAssignment.select.trigger.open();
-  page.taskAssignment.select.dropdown.options(0).select();
+  page.taskAssignment.select.dropdown.options.objectAt(0).select();
 });
 
 test('assignment dropdown renders if user has ability and card is hovered', function(assert) {
@@ -230,12 +229,12 @@ test('assignment dropdown renders if user has ability and card is hovered', func
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task users=users}}`);
 
   page.mouseenter();
   page.taskAssignment.select.trigger.open();
-  assert.equal(page.taskAssignment.select.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
-  assert.equal(page.taskAssignment.select.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
+  assert.equal(page.taskAssignment.select.dropdown.options.objectAt(0).text, 'testuser1', 'First user is rendered.');
+  assert.equal(page.taskAssignment.select.dropdown.options.objectAt(1).text, 'testuser2', 'Second user is rendered.');
 });
 
 test('assignment dropdown renders when records are still being loaded and card  is hovered', function(assert) {
@@ -262,13 +261,13 @@ test('assignment dropdown renders when records are still being loaded and card  
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task users=users}}`);
 
   page.mouseenter();
   RSVP.all(users).then(() => {
     page.taskAssignment.select.trigger.open();
-    assert.equal(page.taskAssignment.select.dropdown.options(0).text, 'testuser1', 'First user is rendered.');
-    assert.equal(page.taskAssignment.select.dropdown.options(1).text, 'testuser2', 'Second user is rendered.');
+    assert.equal(page.taskAssignment.select.dropdown.options.objectAt(0).text, 'testuser1', 'First user is rendered.');
+    assert.equal(page.taskAssignment.select.dropdown.options.objectAt(1).text, 'testuser2', 'Second user is rendered.');
     done();
   });
 });
@@ -295,7 +294,7 @@ test('assignment dropdown does not render if user has no ability and card is hov
 
   this.register('ability:task', Ability.extend({ canAssign: false }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task taskUser=taskUser users=users}}`);
 
   page.mouseenter();
   assert.notOk(page.taskAssignment.select.triggerRenders, 'Dropdown trigger for assignment does not render.');
@@ -304,7 +303,7 @@ test('assignment dropdown does not render if user has no ability and card is hov
   });
 });
 
-test('the selected-item component is visable when a task has a user assigned ', function(assert) {
+test('the selected-item component is visible when a task has a user assigned ', function(assert) {
   assert.expect(1);
 
   let task = { id: 'task' };
@@ -314,7 +313,8 @@ test('the selected-item component is visable when a task has a user assigned ', 
 
   setProperties(this, { task, users, taskUser });
 
-  renderPage();
+  this.render(hbs`{{task-card task=task taskUser=taskUser users=users}}`);
+
   assert.ok(page.selectedItem.isVisible, 'the selected item component is rendered');
 });
 
@@ -323,7 +323,8 @@ test('the unselected-item component is visible when a task has no user assigned'
 
   this.register('ability:task', Ability.extend({ canAssign: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card taskUser=null}}`);
+
   assert.ok(page.unselectedItem.isVisible, 'the unselected item component renders.');
 });
 
@@ -345,7 +346,7 @@ test('it archives task when hovering and pressing C key', function(assert) {
   set(this, 'task', task);
   this.register('ability:task', Ability.extend({ canArchive: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task}}`);
 
   page.mouseenter();
   page.triggerKeyDown('KeyC');
@@ -364,11 +365,10 @@ test('it does not archive task when not hovering and pressing C key', function(a
     }
   };
 
-  set(this, 'task', task);
   this.register('ability:task', Ability.extend({ canArchive: true }));
-  set(this, 'keyboardActivated', true); // manually activate the keyboard
 
-  renderPage();
+  setProperties(this, { task, keyboardActivated: true }); // manually activate the keyboard
+  this.render(hbs`{{task-card task=task keyboardActivated=keyboardActivated}}`);
 
   page.triggerKeyDown('KeyC');
   assert.ok(true);
@@ -397,11 +397,11 @@ test('it does not archive task when assigning a user and pressing C key', functi
     }
   };
 
-  setProperties(this, { task, users });
   this.register('ability:task', Ability.extend({ canArchive: true, canAssign: true }));
-  set(this, 'keyboardActivated', true); // manually activate the keyboard
 
-  renderPage();
+  setProperties(this, { task, users, keyboardActivated: true }); // manually activate the keyboard
+
+  this.render(hbs`{{task-card task=task keyboardActivated=keyboardActivated users=users}}`);
 
   // Hover, open the dropdown, press C key
   page.mouseenter();
@@ -431,7 +431,7 @@ test('it does not archive task when left hovering and pressing C key', function(
   set(this, 'task', task);
   this.register('ability:task', Ability.extend({ canArchive: true }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task}}`);
 
   page.mouseenter();
   page.mouseleave();
@@ -455,7 +455,7 @@ test('it does not archive task when the user does not have the ability', functio
   set(this, 'task', task);
   this.register('ability:task', Ability.extend({ canArchive: false }));
 
-  renderPage();
+  this.render(hbs`{{task-card task=task}}`);
 
   page.mouseenter();
   page.triggerKeyDown('KeyC');

--- a/tests/integration/components/task-card/user/selected-item-test.js
+++ b/tests/integration/components/task-card/user/selected-item-test.js
@@ -12,16 +12,6 @@ import selectedItem from 'code-corps-ember/tests/pages/components/task-card/user
 
 let page = PageObject.create(selectedItem);
 
-function renderPage() {
-  page.render(hbs`
-    {{
-      task-card/user/selected-item
-      select=(hash selected = selectedOption)
-      task=task
-    }}
-  `);
-}
-
 moduleForComponent('task-card/user/selected-item', 'Integration | Component | task card/user/selected item', {
   integration: true,
   beforeEach() {
@@ -32,14 +22,16 @@ moduleForComponent('task-card/user/selected-item', 'Integration | Component | ta
   }
 });
 
-test('the default state when user task is loaded', function(assert) {
+test('lazy renders as unselected by default', function(assert) {
   assert.expect(2);
-  renderPage();
+
+  this.render(hbs`{{task-card/user/selected-item}}`);
+
   assert.notOk(page.selectedIcon.isVisible, 'The selected icon does not render.');
   assert.notOk(page.isTooltipTarget, 'There is no tooltip because it lazy renders.');
 });
 
-test('the selected user is rendered as an icon', function(assert) {
+test('renders selected user as an icon', function(assert) {
   assert.expect(1);
 
   let mockUser = {
@@ -47,8 +39,10 @@ test('the selected user is rendered as an icon', function(assert) {
     username: 'testuser'
   };
 
-  set(this, 'selectedOption', mockUser);
-  renderPage();
+  set(this, 'select', { selected: mockUser });
+
+  page.render(hbs`{{task-card/user/selected-item select=select}}`);
+
   assert.equal(page.selectedIcon.src, mockUser.photoThumbUrl, 'the user photo was rendered in the icon.');
 });
 
@@ -56,13 +50,14 @@ test('the tooltip renders lazily, triggered by mouseEnter', function(assert) {
   assert.expect(6);
 
   let mockUser = {
-
     photoThumbUrl: 'test.png',
     username: 'testuser'
   };
 
-  set(this, 'selectedOption', mockUser);
-  renderPage();
+  set(this, 'select', { selected: mockUser });
+
+  page.render(hbs`{{task-card/user/selected-item select=select}}`);
+
   assertTooltipNotRendered(assert);
 
   page.mouseenter();

--- a/tests/integration/components/task-card/user/unselected-item-test.js
+++ b/tests/integration/components/task-card/user/unselected-item-test.js
@@ -11,14 +11,6 @@ import unselectedItem from 'code-corps-ember/tests/pages/components/task-card/us
 
 let page = PageObject.create(unselectedItem);
 
-function renderPage() {
-  page.render(hbs`
-    {{task-card/user/unselected-item
-      task=task
-    }}
-  `);
-}
-
 moduleForComponent('task-card/user/unselected-item', 'Integration | Component | task card/user/unselected item', {
   integration: true,
   beforeEach() {
@@ -32,7 +24,7 @@ moduleForComponent('task-card/user/unselected-item', 'Integration | Component | 
 test('the tooltip is not rendered initially', function(assert) {
   let task = { userTask: { isLoading: true } };
   this.set('task', task);
-  renderPage();
+  this.render(hbs`{{task-card/user/unselected-item task=task}}`);
   assert.notOk(page.isTooltipTarget, 'There is not a tooltip.');
   assert.ok(page.loadingIcon.isVisible, 'The loading icon renders.');
 });
@@ -40,7 +32,7 @@ test('the tooltip is not rendered initially', function(assert) {
 test('the default state when user task is loaded', function(assert) {
   let task = { userTask: { isLoading: false } };
   this.set('task', task);
-  renderPage();
+  this.render(hbs`{{task-card/user/unselected-item task=task}}`);
   assert.notOk(page.loadingIcon.isVisible, 'The loading icon does not render.');
   assert.notOk(page.isTooltipTarget, 'There is no tooltip because it lazy renders.');
 });
@@ -48,7 +40,8 @@ test('the default state when user task is loaded', function(assert) {
 test('the tooltip renders lazily, triggered by mouseEnter', function(assert) {
   assert.expect(5);
 
-  renderPage();
+  this.render(hbs`{{task-card/user/unselected-item}}`);
+
   assertTooltipNotRendered(assert);
 
   page.mouseenter();

--- a/tests/integration/components/task-comment-list-test.js
+++ b/tests/integration/components/task-comment-list-test.js
@@ -7,12 +7,6 @@ import taskCommentList from 'code-corps-ember/tests/pages/components/task-commen
 
 let page = pageObject.create(taskCommentList);
 
-function renderPage() {
-  page.render(hbs`
-  {{task-comment-list comments=comments}}`
-  );
-}
-
 moduleForComponent('task-comment-list', 'Integration | Component | task comment list', {
   integration: true,
   beforeEach() {
@@ -30,7 +24,7 @@ moduleForComponent('task-comment-list', 'Integration | Component | task comment 
 
 test('it renders', function(assert) {
   assert.expect(1);
-  renderPage();
+  this.render(hbs`{{task-comment-list comments=comments}}`);
   assert.ok(page.isVisible, 'The component\'s element renders');
 });
 
@@ -44,13 +38,13 @@ test('It renders a list of comments if there are comments', function(assert) {
   ];
 
   this.set('comments', comments);
-  renderPage();
-  assert.equal(page.comments().count, 3, 'The correct number of comments is rendered');
+  this.render(hbs`{{task-comment-list comments=comments}}`);
+  assert.equal(page.comments.length, 3, 'The correct number of comments is rendered');
 });
 
 test('it renders nothing when there are no comments', function(assert) {
   assert.expect(1);
   this.set('comments', []);
-  renderPage();
-  assert.equal(page.comments().count, 0, 'No comments are rendered');
+  this.render(hbs`{{task-comment-list comments=comments}}`);
+  assert.equal(page.comments.length, 0, 'No comments are rendered');
 });

--- a/tests/integration/components/task-details-test.js
+++ b/tests/integration/components/task-details-test.js
@@ -68,7 +68,7 @@ test('it renders all the ui elements properly bound', function(assert) {
     }
   });
 
-  page.render(hbs`{{task-details task=task}}`);
+  this.render(hbs`{{task-details task=task}}`);
 
   assert.equal(page.commentBody.text, 'A body', 'Body is correctly bound and rendered');
   assert.ok(page.codeThemeSelector.isVisible);
@@ -83,7 +83,7 @@ test('the task body is rendered as unescaped html', function(assert) {
 
   this.set('task', mockTask);
 
-  page.render(hbs`{{task-details task=task}}`);
+  this.render(hbs`{{task-details task=task}}`);
   assert.ok(page.commentBody.hasStrongText, 'An html element within the body element is rendered unescaped');
 });
 
@@ -93,7 +93,7 @@ test('user can switch between view and edit mode for task body', function(assert
 
   stubService(this, 'mention-fetcher', mockMentionFetcher);
 
-  page.render(hbs`{{task-details task=task}}`);
+  this.render(hbs`{{task-details task=task}}`);
   assert.ok(page.edit.isVisible, 'The edit button is rendered');
 
   page.edit.click();
@@ -121,7 +121,7 @@ test('it saves', function(assert) {
     return RSVP.resolve(task);
   });
 
-  page.render(hbs`{{task-details task=task saveTask=(action 'route-save')}}`);
+  this.render(hbs`{{task-details task=task saveTask=(action 'route-save')}}`);
   assert.equal(page.commentBody.text, 'A body', 'The original body is correct');
 
   page.edit.click();
@@ -139,7 +139,7 @@ test('if the task body is null render the no description element', function(asse
 
   this.set('task', mockTask);
 
-  page.render(hbs`{{task-details task=task}}`);
+  this.render(hbs`{{task-details task=task}}`);
   assert.ok(page.nullCommentBody.isVisible, 'The message for no comment body is rendered');
 });
 
@@ -152,6 +152,6 @@ test('if the task body is not null do not render the no description element', fu
 
   this.set('task', mockTask);
 
-  page.render(hbs`{{task-details task=task}}`);
+  this.render(hbs`{{task-details task=task}}`);
   assert.notOk(page.nullCommentBody.isVisible, 'The message for no comment body is not rendered if there is data');
 });

--- a/tests/integration/components/task-header-test.js
+++ b/tests/integration/components/task-header-test.js
@@ -28,7 +28,7 @@ moduleForComponent('task-header', 'Integration | Component | task header', {
 test('it renders all the ui elements properly bound', function(assert) {
   assert.expect(1);
   this.set('task', mockTask);
-  page.render(hbs`{{task-header task=task}}`);
+  this.render(hbs`{{task-header task=task}}`);
 
   assert.equal(page.taskTitle.title.text, 'A task #12', 'Title is correctly bound and rendered');
 });

--- a/tests/integration/components/task-list-cards-test.js
+++ b/tests/integration/components/task-list-cards-test.js
@@ -37,14 +37,14 @@ moduleForComponent('task-list-cards', 'Integration | Component | task list', {
 test('it renders all tasks', function(assert) {
   assert.expect(1);
   set(this, 'taskList', taskList);
-  page.render(hbs`{{task-list-cards taskList=taskList}}`);
-  assert.equal(page.taskCards().count, 2);
+  this.render(hbs`{{task-list-cards taskList=taskList}}`);
+  assert.equal(page.taskCards.length, 2);
 });
 
 test('it renders tasks in the correct order', function(assert) {
   assert.expect(2);
   set(this, 'taskList', taskList);
-  page.render(hbs`{{task-list-cards taskList=taskList}}`);
-  assert.equal(page.taskCards(0).number.text, '#2');
-  assert.equal(page.taskCards(1).number.text, '#1');
+  this.render(hbs`{{task-list-cards taskList=taskList}}`);
+  assert.equal(page.taskCards.objectAt(0).number.text, '#2');
+  assert.equal(page.taskCards.objectAt(1).number.text, '#1');
 });

--- a/tests/integration/components/task-status-button-test.js
+++ b/tests/integration/components/task-status-button-test.js
@@ -27,7 +27,7 @@ test('when task is open, it renders the button to close it', function(assert) {
   };
 
   this.set('task', mockTask);
-  page.render(hbs`{{task-status-button task=task}}`);
+  this.render(hbs`{{task-status-button task=task}}`);
 
   page.clickClose();
 
@@ -46,7 +46,7 @@ test('when task is closed, it renders the button to open it', function(assert) {
   };
 
   this.set('task', mockTask);
-  page.render(hbs`{{task-status-button task=task}}`);
+  this.render(hbs`{{task-status-button task=task}}`);
 
   page.clickOpen();
 

--- a/tests/integration/components/task-status-test.js
+++ b/tests/integration/components/task-status-test.js
@@ -20,7 +20,7 @@ test('it renders closed status', function(assert) {
 
   let task = { overallStatus: 'closed' };
   this.set('task', task);
-  page.render(hbs`{{task-status task=task}}`);
+  this.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isClosed, 'Has the closed class');
   assert.ok(page.iconClosed.isVisible);
@@ -32,7 +32,7 @@ test('it renders open status', function(assert) {
 
   let task = { overallStatus: 'open' };
   this.set('task', task);
-  page.render(hbs`{{task-status task=task}}`);
+  this.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isOpen, 'Has the open class');
   assert.ok(page.iconOpen.isVisible);
@@ -44,7 +44,7 @@ test('it renders pull request open status', function(assert) {
 
   let task = { hasGithubPullRequest: true, overallStatus: 'open' };
   this.set('task', task);
-  page.render(hbs`{{task-status task=task}}`);
+  this.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isOpen, 'Has the open class');
   assert.ok(page.iconPullRequest.isVisible, 'Pull request icon renders');
@@ -56,7 +56,7 @@ test('it renders pull request closed status', function(assert) {
 
   let task = { hasGithubPullRequest: true, overallStatus: 'closed' };
   this.set('task', task);
-  page.render(hbs`{{task-status task=task}}`);
+  this.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isClosed, 'Has the closed class');
   assert.ok(page.iconPullRequest.isVisible, 'Pull request icon renders');
@@ -68,7 +68,7 @@ test('it renders pull request merged status', function(assert) {
 
   let task = { hasGithubPullRequest: true, overallStatus: 'merged' };
   this.set('task', task);
-  page.render(hbs`{{task-status task=task}}`);
+  this.render(hbs`{{task-status task=task}}`);
 
   assert.ok(page.isMerged, 'Has the merged class');
   assert.ok(page.iconPullRequestMerged.isVisible, 'Pull request merged icon renders');

--- a/tests/integration/components/task-title-test.js
+++ b/tests/integration/components/task-title-test.js
@@ -46,7 +46,7 @@ test('it is not editable if not the right user', function(assert) {
   stubService(this, 'current-user', mockDifferentUser);
 
   assert.expect(1);
-  page.render(hbs`{{task-title}}`);
+  this.render(hbs`{{task-title}}`);
   assert.equal(this.$('.task-title .edit').length, 0);
 });
 
@@ -56,7 +56,7 @@ test('it switches between edit and view mode', function(assert) {
   stubService(this, 'current-user', mockCurrentUser);
 
   this.set('task', mockTask);
-  page.render(hbs`{{task-title task=task}}`);
+  this.render(hbs`{{task-title task=task}}`);
 
   assert.notOk(page.isEditing, 'Component is not in edit mode');
   assert.notOk(page.titleInput.isVisible, 'Input element is not rendered');
@@ -79,7 +79,7 @@ test('it saves', function(assert) {
   this.on('applyEdit', () => {
     return RSVP.resolve();
   });
-  page.render(hbs`{{task-title task=task saveTask=(action "applyEdit")}}`);
+  this.render(hbs`{{task-title task=task saveTask=(action "applyEdit")}}`);
 
   assert.equal(page.title.text, 'Original title #12', 'The original title is right');
 

--- a/tests/integration/components/task/archive-task-test.js
+++ b/tests/integration/components/task/archive-task-test.js
@@ -1,4 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { set } from '@ember/object';
+
 import hbs from 'htmlbars-inline-precompile';
 import PageObject from 'ember-cli-page-object';
 import component from 'code-corps-ember/tests/pages/components/task/archive-task';
@@ -7,19 +9,10 @@ import sinon from 'sinon';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{task/archive-task
-      archiveTask=archiveTaskHandler
-      task=task
-    }}`);
-}
-
 moduleForComponent('task/archive-task', 'Integration | Component | task/archive task', {
   integration: true,
   beforeEach() {
     page.setContext(this);
-    this.register('ability:task', Ability.extend({ canArchive: true }));
   },
   afterEach() {
     page.removeContext();
@@ -29,20 +22,21 @@ moduleForComponent('task/archive-task', 'Integration | Component | task/archive 
 test('can archive if user has ability', function(assert) {
   assert.expect(2);
 
+  this.register('ability:task', Ability.extend({ canArchive: true }));
+
   let stub = sinon.stub(window, 'confirm').callsFake(() => {
     assert.ok(true, 'Confirmation prompt was called.');
     return true;
   });
 
-  let task = { archived: false };
-  this.set('task', task);
-  this.set('archiveTaskHandler', function() {
+  this.register('ability:task', Ability.extend({ canArchive: true }));
+
+  set(this, 'task', { archived: false });
+  set(this, 'archiveTaskHandler', function() {
     assert.ok(true, 'archiveTask action was called.');
   });
 
-  this.register('ability:task', Ability.extend({ canArchive: true }));
-
-  renderPage();
+  this.render(hbs`{{task/archive-task archiveTask=archiveTaskHandler task=task}}`);
 
   page.archiveLink.click();
 
@@ -52,12 +46,10 @@ test('can archive if user has ability', function(assert) {
 test('cannot archive if user does not have ability', function(assert) {
   assert.expect(2);
 
-  let task = { archived: false };
-  this.set('task', task);
-
   this.register('ability:task', Ability.extend({ canArchive: false }));
+  set(this, 'task', { archived: false });
 
-  renderPage();
+  this.render(hbs`{{task/archive-task task=task}}`);
 
   assert.notOk(page.archiveLink.isVisible, 'Archive link is not visible');
   assert.notOk(page.archivedStatus.isVisible, 'Archived status is not visible because task is not archived');
@@ -66,10 +58,9 @@ test('cannot archive if user does not have ability', function(assert) {
 test('show archived status if archived', function(assert) {
   assert.expect(2);
 
-  let task = { archived: true };
-  this.set('task', task);
+  set(this, 'task', { archived: true });
 
-  renderPage();
+  this.render(hbs`{{task/archive-task task=task}}`);
 
   assert.notOk(page.archiveLink.isVisible, 'Archive link is not visible');
   assert.ok(page.archivedStatus.isVisible, 'Archived status is visible because task is archived');

--- a/tests/integration/components/task/sidebar/integrations-section-test.js
+++ b/tests/integration/components/task/sidebar/integrations-section-test.js
@@ -6,14 +6,6 @@ import PageObject from 'ember-cli-page-object';
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{task/sidebar/integrations-section
-      task=task
-    }}
-  `);
-}
-
 moduleForComponent('task/sidebar/integrations-section', 'Integration | Component | task/sidebar/integrations section', {
   integration: true,
   beforeEach() {
@@ -30,7 +22,7 @@ test('when connected to a GitHub Issue', function(assert) {
   let task = { githubIssue: { number: '123' } };
   set(this, 'task', task);
 
-  renderPage();
+  this.render(hbs`{{task/sidebar/integrations-section task=task}}`);
 
   assert.notOk(page.emptyMessage.isVisible, 'The empty message is not visible');
   assert.ok(page.issueLink.isVisible, 'The issue link is visible');
@@ -42,7 +34,7 @@ test('when not connected to a GitHub Issue', function(assert) {
   let task = { githubIssue: null };
   set(this, 'task', task);
 
-  renderPage();
+  this.render(hbs`{{task/sidebar/integrations-section task=task}}`);
 
   assert.ok(page.emptyMessage.isVisible, 'The empty message is visible');
   assert.notOk(page.issueLink.isVisible, 'The issue link is not visible');

--- a/tests/integration/components/task/user/users-list.js
+++ b/tests/integration/components/task/user/users-list.js
@@ -1,4 +1,4 @@
-import { setProperties, set } from '@ember/object';
+import { set } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import PageObject from 'ember-cli-page-object';
@@ -6,26 +6,10 @@ import component from 'code-corps-ember/tests/pages/components/task/user/users-l
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{task/user/users-list
-      action=hideHandler
-      task=task
-      user=user
-      userTask=userTask
-    }}
-  `);
-}
-
-function setHandlers(context, { hideHandler = function() {} } = {}) {
-  setProperties(context, { hideHandler });
-}
-
 moduleForComponent('task/user/users-list', 'Integration | Component | users list', {
   integration: true,
   beforeEach() {
     page.setContext(this);
-    setHandlers(this);
   },
   afterEach() {
     page.removeContext();
@@ -38,6 +22,15 @@ test('it sends the hide action when clicking to close', function(assert) {
     assert.ok();
   };
   set(this, 'hideHandler', hideHandler);
-  renderPage();
+
+  this.render(hbs`
+    {{task/user/users-list
+      action=hideHandler
+      task=task
+      user=user
+      userTask=userTask
+    }}
+  `);
+
   page.header.clickClose();
 });

--- a/tests/integration/components/thank-you-container-test.js
+++ b/tests/integration/components/thank-you-container-test.js
@@ -43,7 +43,7 @@ moduleForComponent('thank-you-container', 'Integration | Component | thank-you c
     });
 
     page.setContext(this);
-    page.render(hbs`{{thank-you-container project=project}}`);
+    this.render(hbs`{{thank-you-container project=project}}`);
   }
 });
 
@@ -56,5 +56,5 @@ test('it renders the thank you text', function(assert) {
 test('it renders a subset of 12 volunteers', function(assert) {
   assert.expect(1);
 
-  assert.equal(page.volunteers().count, 12);
+  assert.equal(page.volunteers.length, 12);
 });

--- a/tests/integration/components/user-byline-test.js
+++ b/tests/integration/components/user-byline-test.js
@@ -5,13 +5,7 @@ import PageObject from 'ember-cli-page-object';
 import pageComponent from 'code-corps-ember/tests/pages/components/user-byline';
 import moment from 'moment';
 
-let page = PageObject.create(pageComponent);
-
-function renderPage() {
-  page.render(hbs`
-    {{user-byline createdAt=createdAt createdFrom=createdFrom user=user}}
-  `);
-}
+const page = PageObject.create(pageComponent);
 
 moduleForComponent('user-byline', 'Integration | Component | user byline', {
   integration: true,
@@ -30,7 +24,7 @@ test('it renders when created from Code Corps', function(assert) {
   set(this, 'createdAt', moment().subtract(2, 'days'));
   set(this, 'createdFrom', 'code_corps');
 
-  renderPage();
+  this.render(hbs`{{user-byline createdAt=createdAt createdFrom=createdFrom user=user}}`);
 
   assert.equal(page.username.text, 'tester', 'The username of the comment author renders.');
   assert.equal(page.createdAt.text, '2 days ago', 'The time ago text renders.');
@@ -44,7 +38,7 @@ test('it renders when created from GitHub', function(assert) {
   set(this, 'createdAt', moment().subtract(2, 'days'));
   set(this, 'createdFrom', 'github');
 
-  renderPage();
+  this.render(hbs`{{user-byline createdAt=createdAt createdFrom=createdFrom user=user}}`);
 
   assert.equal(page.username.text, 'tester', 'The username of the comment author renders.');
   assert.equal(page.createdAt.text, '2 days ago', 'The time ago text renders.');

--- a/tests/integration/components/user-details-test.js
+++ b/tests/integration/components/user-details-test.js
@@ -30,7 +30,7 @@ test('it renders subcomponents', function(assert) {
   };
   set(this, 'user', user);
 
-  page.render(hbs`{{user-details user=user}}`);
+  this.render(hbs`{{user-details user=user}}`);
 
   assert.ok(page.userProjectsList.isVisible);
   assert.ok(page.userSidebar.isVisible);

--- a/tests/integration/components/user-dropdown-test.js
+++ b/tests/integration/components/user-dropdown-test.js
@@ -6,10 +6,6 @@ import userDropdownComponent from 'code-corps-ember/tests/pages/component/user-d
 
 let page = PageObject.create(userDropdownComponent);
 
-function renderPage() {
-  page.render(hbs`{{user-dropdown user=user action='hide'}}`);
-}
-
 moduleForComponent('user-dropdown', 'Integration | Component | user dropdown', {
   integration: true,
   beforeEach() {
@@ -38,7 +34,8 @@ test('it renders', function(assert) {
   assert.expect(1);
 
   this.set('user', stubUser);
-  renderPage();
+
+  this.render(hbs`{{user-dropdown user=user}}`);
 
   assert.ok(page.isVisible, 'The component renders');
 });
@@ -51,7 +48,8 @@ test('it triggers the hide action when clicked', function(assert) {
     assert.ok(true, 'It triggers the hide action when clicked');
   });
 
-  renderPage();
+  this.render(hbs`{{user-dropdown user=user action='hide'}}`);
+
   page.click();
 
 });

--- a/tests/integration/components/user-list-item-test.js
+++ b/tests/integration/components/user-list-item-test.js
@@ -27,15 +27,6 @@ function mockProjectUser(role) {
 
 let page = PageObject.create(component);
 
-function renderPage() {
-  page.render(hbs`
-    {{user-list-item
-      projectUser=projectUser
-      user=user
-    }}
-  `);
-}
-
 moduleForComponent('user-list-item', 'Integration | Component | user list item', {
   integration: true,
   beforeEach() {
@@ -52,7 +43,7 @@ test('it renders the basic information for the user', function(assert) {
 
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item user=user}}`);
 
   assert.equal(page.icon.url, user.photoThumbUrl);
   assert.equal(page.name.name.text, user.name);
@@ -66,7 +57,7 @@ test('it renders the username in the name if name is empty', function(assert) {
   set(user, 'name', '');
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item user=user}}`);
 
   assert.equal(page.name.name.text, get(user, 'username'));
 });
@@ -77,7 +68,7 @@ test('it renders the correct buttons when pending', function(assert) {
   set(this, 'projectUser', mockProjectUser('pending')); // pending
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item projectUser=projectUser user=user}}`);
 
   assert.ok(page.approveButton.isVisible, 'Approve button renders');
   assert.ok(page.denyButton.isVisible, 'Deny button renders');
@@ -91,7 +82,7 @@ test('it renders the correct buttons when not pending', function(assert) {
   set(this, 'projectUser', mockProjectUser('contributor'));
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item projectUser=projectUser user=user}}`);
 
   assert.notOk(page.approveButton.isVisible, 'Approve button does not render');
   assert.notOk(page.denyButton.isVisible, 'Deny button does not render');
@@ -113,7 +104,7 @@ test('it sends the approve action when clicking approve', function(assert) {
   set(this, 'projectUser', projectUser);
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item projectUser=projectUser user=user}}`);
 
   let stub = sinon.stub(window, 'confirm').callsFake(() => {
     assert.ok(true, 'Confirmation prompt was called.');
@@ -147,7 +138,7 @@ test('it sends the deny action when clicking deny', function(assert) {
   set(this, 'projectUser', projectUser);
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item projectUser=projectUser user=user}}`);
 
   let stub = sinon.stub(window, 'confirm').callsFake(() => {
     assert.ok(true, 'Confirmation prompt was called.');
@@ -175,7 +166,7 @@ test('it changes the role when editing', function(assert) {
   set(this, 'projectUser', projectUser);
   set(this, 'user', user);
 
-  renderPage();
+  this.render(hbs`{{user-list-item projectUser=projectUser user=user}}`);
 
   page.projectUserRoleModal.openButton.click();
   page.projectUserRoleModal.modal.radioGroupAdmin.radioButton.click();

--- a/tests/integration/components/user-menu-test.js
+++ b/tests/integration/components/user-menu-test.js
@@ -34,7 +34,7 @@ test('it renders properly', function(assert) {
   assert.expect(7);
 
   set(this, 'user', stubUser);
-  page.render(hbs`{{user-menu user=user}}`);
+  this.render(hbs`{{user-menu user=user}}`);
 
   page.toggle();
 
@@ -55,7 +55,7 @@ test('clicking the menu toggles the dropdown', function(assert) {
   assert.expect(3);
 
   set(this, 'user', stubUser);
-  page.render(hbs`{{user-menu user=user}}`);
+  this.render(hbs`{{user-menu user=user}}`);
 
   assert.ok(page.dropdownIsHidden, 'The dropdown is initially hidden');
   page.toggle();

--- a/tests/integration/components/user-projects-list-test.js
+++ b/tests/integration/components/user-projects-list-test.js
@@ -25,7 +25,7 @@ test('with no projects renders all required elements', function(assert) {
     username: 'JoshSmith'
   });
 
-  page.render(hbs`{{user-projects-list user=user projects=projects}}`);
+  this.render(hbs`{{user-projects-list user=user projects=projects}}`);
 
   assert.equal(page.header, 'Projects', 'The header renders');
   assert.equal(page.emptyState, 'JoshSmith', 'Component\'s element is rendered');
@@ -51,7 +51,7 @@ test('with several organizations renders all required elements', function(assert
     username: 'JoshSmith'
   });
 
-  page.render(hbs`{{user-projects-list user=user projects=projects}}`);
+  this.render(hbs`{{user-projects-list user=user projects=projects}}`);
 
   assert.equal(page.header, 'Projects', 'The header renders');
   assert.equal(page.listItemCount, 3, 'All project items render');

--- a/tests/integration/components/user-settings-form-test.js
+++ b/tests/integration/components/user-settings-form-test.js
@@ -33,7 +33,7 @@ test('it renders form elements properly', function(assert) {
 
   set(this, 'user', user);
 
-  page.render(hbs`{{user-settings-form user=user}}`);
+  this.render(hbs`{{user-settings-form user=user}}`);
 
   assert.equal(page.biographyValue, 'A test user');
   assert.equal(page.firstNameValue, 'Test');
@@ -54,7 +54,7 @@ test('it calls save on user when save button is clicked', function(assert) {
 
   set(this, 'user', user);
 
-  page.render(hbs`{{user-settings-form user=user}}`);
+  this.render(hbs`{{user-settings-form user=user}}`);
 
   page.clickSave();
 

--- a/tests/integration/components/user-sidebar-test.js
+++ b/tests/integration/components/user-sidebar-test.js
@@ -49,7 +49,7 @@ test('it renders all required elements', function(assert) {
   let user = mockUser();
   set(this, 'user', user);
 
-  page.render(hbs`{{user-sidebar user=user}}`);
+  this.render(hbs`{{user-sidebar user=user}}`);
 
   assert.equal(page.name, 'Josh Smith', 'Their name renders');
   assert.equal(page.username, 'JoshSmith', 'Their username renders');
@@ -66,7 +66,7 @@ test('it does not show some details if blank', function(assert) {
   let user = {};
   set(this, 'user', user);
 
-  page.render(hbs`{{user-sidebar user=user}}`);
+  this.render(hbs`{{user-sidebar user=user}}`);
 
   assert.ok(page.biographyIsHidden);
   assert.ok(page.twitterHandleHidden);
@@ -81,7 +81,7 @@ test('it sets the name to username if name is blank', function(assert) {
   };
   set(this, 'user', user);
 
-  page.render(hbs`{{user-sidebar user=user}}`);
+  this.render(hbs`{{user-sidebar user=user}}`);
 
   assert.equal(page.name, 'joshsmith');
 });

--- a/tests/integration/components/user/display-username-test.js
+++ b/tests/integration/components/user/display-username-test.js
@@ -25,7 +25,7 @@ test('it renders only the username if present', function(assert) {
 
   this.set('user', user);
 
-  page.render(hbs`{{user/display-username user=user}}`);
+  this.render(hbs`{{user/display-username user=user}}`);
 
   assert.ok(page.username.isVisible);
   assert.notOk(page.githubUsername.isVisible);
@@ -42,7 +42,7 @@ test('it renders only the username regardless of whether both are present', func
 
   this.set('user', user);
 
-  page.render(hbs`{{user/display-username user=user}}`);
+  this.render(hbs`{{user/display-username user=user}}`);
 
   assert.ok(page.username.isVisible);
   assert.notOk(page.githubUsername.isVisible);
@@ -59,7 +59,7 @@ test('it renders only the github username if only it is present', function(asser
 
   this.set('user', user);
 
-  page.render(hbs`{{user/display-username user=user}}`);
+  this.render(hbs`{{user/display-username user=user}}`);
 
   assert.notOk(page.username.isVisible);
   assert.ok(page.githubUsername.isVisible);

--- a/tests/integration/components/user/skills-list-test.js
+++ b/tests/integration/components/user/skills-list-test.js
@@ -35,11 +35,11 @@ test('it renders each skill in the list', function(assert) {
 
   this.set('user', user);
 
-  page.render(hbs`{{user/skills-list user=user}}`);
+  this.render(hbs`{{user/skills-list user=user}}`);
 
-  assert.equal(page.skills().count, 2);
-  assert.equal(page.skills(0).text, 'Ember.js');
-  assert.equal(page.skills(1).text, 'JavaScript');
+  assert.equal(page.skills.length, 2);
+  assert.equal(page.skills.objectAt(0).text, 'Ember.js');
+  assert.equal(page.skills.objectAt(1).text, 'JavaScript');
 });
 
 test('it renders the empty state when no skills', function(assert) {
@@ -52,7 +52,7 @@ test('it renders the empty state when no skills', function(assert) {
 
   this.set('user', user);
 
-  page.render(hbs`{{user/skills-list user=user}}`);
+  this.render(hbs`{{user/skills-list user=user}}`);
 
   assert.ok(page.emptyState.isVisible);
 });

--- a/tests/integration/components/volunteer-headshot-test.js
+++ b/tests/integration/components/volunteer-headshot-test.js
@@ -23,7 +23,7 @@ moduleForComponent('volunteer-headshot', 'Integration | Component | volunteer he
       userRoles
     });
     page.setContext(this);
-    page.render(hbs`{{volunteer-headshot volunteer=user}}`);
+    this.render(hbs`{{volunteer-headshot volunteer=user}}`);
   }
 });
 

--- a/tests/pages/admin.js
+++ b/tests/pages/admin.js
@@ -6,9 +6,5 @@ import {
 
 export default create({
   visit: visitable('/admin'),
-
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  })
+  flashMessages: collection('.flash-messages--full-width .flash-message')
 });

--- a/tests/pages/admin/github-events/index.js
+++ b/tests/pages/admin/github-events/index.js
@@ -22,30 +22,14 @@ export default create({
     fillIn: fillable()
   },
 
-  flashErrors: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message.alert-danger'
-  }),
+  flashErrors: collection('.flash-messages--full-width .flash-message.alert-danger'),
 
-  logItems: collection({
-    itemScope: '[data-test-log-row]',
-    item: {
-      action: {
-        scope: '[data-test-action]'
-      },
-      eventType: {
-        scope: '[data-test-event-type]'
-      },
-      failureReason: {
-        scope: '[data-test-failure-reason]'
-      },
-      status: {
-        scope: '[data-test-status]'
-      },
-      time: {
-        scope: '[data-test-time]'
-      }
-    }
+  logItems: collection('[data-test-log-row]', {
+    action: { scope: '[data-test-action]' },
+    eventType: { scope: '[data-test-event-type]' },
+    failureReason: { scope: '[data-test-failure-reason]' },
+    status: { scope: '[data-test-status]' },
+    time: { scope: '[data-test-time]' }
   }),
 
   next: {

--- a/tests/pages/admin/github-events/show.js
+++ b/tests/pages/admin/github-events/show.js
@@ -3,10 +3,7 @@ import { collection, create, visitable } from 'ember-cli-page-object';
 export default create({
   visit: visitable('/admin/github/events/:id'),
 
-  flashErrors: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message.alert-danger'
-  }),
+  flashErrors: collection('.flash-messages--full-width .flash-message.alert-danger'),
 
   error: {
     scope: '[data-test-error]'
@@ -20,10 +17,7 @@ export default create({
     scope: '[data-test-failure-reason]'
   },
 
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  }),
+  flashMessages: collection('.flash-messages--full-width .flash-message'),
 
   githubDeliveryId: {
     scope: '[data-test-github-delivery-id]'

--- a/tests/pages/admin/organization-invites/index.js
+++ b/tests/pages/admin/organization-invites/index.js
@@ -3,37 +3,18 @@ import { collection, create, visitable } from 'ember-cli-page-object';
 export default create({
   visit: visitable('/admin/organization-invites'),
 
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  }),
+  flashMessages: collection('.flash-messages--full-width', '.flash-message'),
 
-  flashErrors: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message.alert-danger'
-  }),
+  flashErrors: collection('.flash-messages--full-width .flash-message.alert-danger'),
 
-  logItems: collection({
-    itemScope: '[data-test-log-row]',
-    item: {
-      actions: {
-        scope: '[data-test-actions]',
-        button: {
-          scope: 'button'
-        }
-      },
-      approvalStatus: {
-        scope: '[data-test-approval-status]'
-      },
-      email: {
-        scope: '[data-test-email]'
-      },
-      icon: {
-        scope: '[data-test-icon]'
-      },
-      name: {
-        scope: '[data-test-name]'
-      }
-    }
+  logItems: collection('[data-test-log-row]', {
+    actions: {
+      scope: '[data-test-actions]',
+      button: { scope: 'button' }
+    },
+    approvalStatus: { scope: '[data-test-approval-status]' },
+    email: { scope: '[data-test-email]' },
+    icon: { scope: '[data-test-icon]' },
+    name: { scope: '[data-test-name]' }
   })
 });

--- a/tests/pages/admin/organization-invites/new.js
+++ b/tests/pages/admin/organization-invites/new.js
@@ -9,24 +9,16 @@ import {
 export default create({
   visit: visitable('admin/organization-invites/new'),
 
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  }),
+  flashMessages: collection('.flash-messages--full-width .flash-message'),
 
-  flashErrors: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message.alert-danger'
-  }),
+  flashErrors: collection('.flash-messages--full-width .flash-message.alert-danger'),
 
   inviteForm: {
     scope: '[data-test-invite-form]',
 
     clickSubmit: clickable('[data-test-submit]'),
 
-    errors: collection({
-      itemScope: '.input-group.has-error'
-    }),
+    errors: collection('.input-group.has-error'),
 
     inputEmail: fillable('[name=email]'),
     inputOrganizationName: fillable('[name=organizationName]')

--- a/tests/pages/admin/projects/index.js
+++ b/tests/pages/admin/projects/index.js
@@ -3,35 +3,20 @@ import { attribute, collection, create, visitable } from 'ember-cli-page-object'
 export default create({
   visit: visitable('/admin/projects'),
 
-  flashErrors: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message.alert-danger'
-  }),
+  flashErrors: collection('.flash-messages--full-width .flash-message.alert-danger'),
 
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  }),
+  flashMessages: collection('.flash-messages--full-width .flash-message'),
 
-  items: collection({
-    itemScope: '[data-test-log-row]',
-    item: {
-      actions: {
-        scope: '[data-test-actions]',
-        approve: {
-          scope: 'button'
-        }
-      },
-      approvalStatus: {
-        scope: '[data-test-approval-status]'
-      },
-      icon: {
-        scope: '[data-test-icon]',
-        src: attribute('src', 'img')
-      },
-      title: {
-        scope: '[data-test-title]'
-      }
-    }
+  items: collection('[data-test-log-row]', {
+    actions: {
+      scope: '[data-test-actions]',
+      approve: { scope: 'button' }
+    },
+    approvalStatus: { scope: '[data-test-approval-status]' },
+    icon: {
+      scope: '[data-test-icon]',
+      src: attribute('src', 'img')
+    },
+    title: { scope: '[data-test-title]' }
   })
 });

--- a/tests/pages/components/_suggestions-area.js
+++ b/tests/pages/components/_suggestions-area.js
@@ -12,10 +12,5 @@ export default {
   notOk: hasClass('not-ok'),
   visible: isVisible(),
 
-  suggestions: collection({
-    itemScope: 'li',
-    item: {
-      text: text()
-    }
-  })
+  suggestions: collection('li', { text: text() })
 };

--- a/tests/pages/components/categories-list.js
+++ b/tests/pages/components/categories-list.js
@@ -5,11 +5,5 @@ import {
 
 export default {
   scope: '.start__interests',
-
-  items: collection({
-    itemScope: '.category-item',
-    item: {
-      name: text('button')
-    }
-  })
+  items: collection('.category-item', { name: text('button') })
 };

--- a/tests/pages/components/category-checkboxes.js
+++ b/tests/pages/components/category-checkboxes.js
@@ -7,14 +7,8 @@ import {
 export default {
   scope: '.category-checkboxes',
 
-  checkboxes: collection({
-    itemScope: 'li',
-    item: {
-      isChecked: property('checked', 'input'),
-      label: {
-        scope: 'label',
-        name: text()
-      }
-    }
+  checkboxes: collection('li', {
+    isChecked: property('checked', 'input'),
+    label: { scope: 'label', name: text() }
   })
 };

--- a/tests/pages/components/comment-item.js
+++ b/tests/pages/components/comment-item.js
@@ -36,9 +36,7 @@ export default {
     markdown: fillable('textarea[name=markdown]')
   },
 
-  errors: collection({
-    itemScope: '.error'
-  }),
+  errors: collection('.error'),
 
   username: {
     scope: '[data-test-username]'

--- a/tests/pages/components/conversations/conversation-thread.js
+++ b/tests/pages/components/conversations/conversation-thread.js
@@ -5,11 +5,5 @@ import conversationPart from 'code-corps-ember/tests/pages/components/conversati
 export default {
   scope: '.conversation-thread',
   conversationComposer,
-  conversationParts: collection({
-    scope: '.conversation-thread__messages',
-    item: conversationPart,
-    // when a collection scope is specified, itemScope is required
-    // in order to correctly detect when there is 0 items
-    itemScope: conversationPart.scope
-  })
+  conversationParts: collection(`.conversation-thread__messages ${conversationPart.scope}`, conversationPart)
 };

--- a/tests/pages/components/conversations/new-conversation-modal.js
+++ b/tests/pages/components/conversations/new-conversation-modal.js
@@ -16,18 +16,14 @@ export default {
       scope: '[data-test-body]',
       fillIn: fillable('textarea'),
       isErrored: hasClass('has-error'),
-      errors: collection({
-        itemScope: '.input-error'
-      })
+      errors: collection('.input-error')
     },
 
     subject: {
       scope: '[data-test-subject]',
       fillIn: fillable('input'),
       isErrored: hasClass('has-error'),
-      errors: collection({
-        itemScope: '.input-error'
-      })
+      errors: collection('.input-error')
     },
 
     close: clickable('.modal-close'),

--- a/tests/pages/components/create-comment-form.js
+++ b/tests/pages/components/create-comment-form.js
@@ -25,9 +25,7 @@ export default {
     markdown: fillable('textarea[name=markdown]')
   },
 
-  errors: collection({
-    itemScope: '.error'
-  }),
+  errors: collection('.error'),
 
   rendersLogin: isVisible('a[href$=login]'),
   rendersMarkdown: isVisible('[name=markdown]'),

--- a/tests/pages/components/donation-goals.js
+++ b/tests/pages/components/donation-goals.js
@@ -21,23 +21,9 @@ export default {
     isVisible: isVisible()
   },
 
-  donationGoalLoadings: collection({
-    itemScope: '.donation-goal-loading'
-  }),
-
-  donationGoals: collection({
-    itemScope: '.donation-goal',
-    item: {
-      donationGoal
-    }
-  }),
-
-  donationGoalEdits: collection({
-    itemScope: '.donation-goal-edit',
-    item: {
-      donationGoalEdit
-    }
-  }),
+  donationGoalLoadings: collection('.donation-goal-loading'),
+  donationGoals: collection('.donation-goal', donationGoal),
+  donationGoalEdits: collection('.donation-goal-edit', donationGoalEdit),
 
   edit: {
     scope: '.edit',

--- a/tests/pages/components/donation/donation-container.js
+++ b/tests/pages/components/donation/donation-container.js
@@ -20,10 +20,7 @@ export default {
   donationAmountText: text('.donation-container__amount'),
   paymentInformationText: text('.donation-container__information'),
 
-  cards: collection({
-    itemScope: '.card-item',
-    item: cardItem
-  }),
+  cards: collection('.card-item', cardItem),
 
   submitButtonIsVisible: isVisible('button'),
   submitButtonText: text('button'),

--- a/tests/pages/components/error-formatter.js
+++ b/tests/pages/components/error-formatter.js
@@ -2,12 +2,5 @@ import { collection, text } from 'ember-cli-page-object';
 
 export default {
   scope: '.error-formatter',
-
-  errors: collection({
-    itemScope: '.error',
-
-    item: {
-      message: text()
-    }
-  })
+  errors: collection('.error', { message: text() })
 };

--- a/tests/pages/components/github/connected-installation.js
+++ b/tests/pages/components/github/connected-installation.js
@@ -13,10 +13,7 @@ export default {
     scope: '[data-test-disconnect]'
   },
 
-  githubRepos: collection({
-    itemScope: '.github-repo',
-    item: githubRepo
-  }),
+  githubRepos: collection('.github-repo', githubRepo),
 
   login: {
     scope: '[data-test-login]'

--- a/tests/pages/components/login-form.js
+++ b/tests/pages/components/login-form.js
@@ -13,9 +13,7 @@ export default {
     isVisible: isVisible()
   },
 
-  errors: collection({
-    itemScope: 'p.error'
-  }),
+  errors: collection('p.error'),
 
   loginSuccessfully(email, password) {
     this.username(email).password(password).submit();

--- a/tests/pages/components/pager-control.js
+++ b/tests/pages/components/pager-control.js
@@ -11,12 +11,7 @@ export default {
     href: attribute('href')
   },
 
-  pages: collection({
-    itemScope: '.page',
-    item: {
-      href: attribute('href')
-    }
-  }),
+  pages: collection('.page', { href: attribute('href') }),
 
   previousPage: {
     scope: '.previous-page',

--- a/tests/pages/components/power-select.js
+++ b/tests/pages/components/power-select.js
@@ -23,17 +23,14 @@ export default {
     input: {
       scope: 'input'
     },
-    options: collection({
-      itemScope: '.ember-power-select-option',
-      item: {
-        select() {
-          // this.scope is a jQuery selector, so we can't use that because
-          // nativeMouseUp needs either a plain old js selector or a plain old
-          // DOM element, so we fetch the element first
-          let [domElement] = findElementWithAssert(this);
-          nativeMouseUp(domElement);
-          return this;
-        }
+    options: collection('.ember-power-select-option', {
+      select() {
+        // this.scope is a jQuery selector, so we can't use that because
+        // nativeMouseUp needs either a plain old js selector or a plain old
+        // DOM element, so we fetch the element first
+        let [domElement] = findElementWithAssert(this);
+        nativeMouseUp(domElement);
+        return this;
       }
     })
   },

--- a/tests/pages/components/project-card/project-users.js
+++ b/tests/pages/components/project-card/project-users.js
@@ -4,12 +4,6 @@ import {
 
 export default {
   scope: '.project-card__project-users',
-
-  userCount: {
-    scope: '[data-test-count]'
-  },
-
-  users: collection({
-    itemScope: '[data-test-user]'
-  })
+  userCount: { scope: '[data-test-count]' },
+  users: collection('[data-test-user]')
 };

--- a/tests/pages/components/project-categories-list.js
+++ b/tests/pages/components/project-categories-list.js
@@ -6,8 +6,5 @@ import projectCategoryItem from 'code-corps-ember/tests/pages/components/project
 export default {
   scope: '.categories',
 
-  projectCategoryItems: collection({
-    itemScope: '.project-category-item',
-    item: projectCategoryItem
-  })
+  projectCategoryItems: collection('.project-category-item', projectCategoryItem)
 };

--- a/tests/pages/components/project-list.js
+++ b/tests/pages/components/project-list.js
@@ -6,13 +6,6 @@ import {
 
 export default {
   scope: '.project-list',
-
   isVisible: isVisible(),
-
-  items: collection({
-    itemScope: '.project-item',
-    item: {
-      href: attribute('href', 'a:eq(0)')
-    }
-  })
+  items: collection('.project-item', { href: attribute('href', 'a:eq(0)') })
 };

--- a/tests/pages/components/project-menu.js
+++ b/tests/pages/components/project-menu.js
@@ -9,18 +9,15 @@ import {
 export default {
   scope: '.project__menu',
 
-  links: collection({
-    itemScope: 'li a',
-    item: {
-      badge: {
-        scope: 'span.info',
-        isVisible: isVisible(),
-        text: text()
-      },
-      href: attribute('href'),
-      isActive: hasClass('active'),
+  links: collection('li a', {
+    badge: {
+      scope: 'span.info',
       isVisible: isVisible(),
       text: text()
-    }
+    },
+    href: attribute('href'),
+    isActive: hasClass('active'),
+    isVisible: isVisible(),
+    text: text()
   })
 };

--- a/tests/pages/components/project-skills-list.js
+++ b/tests/pages/components/project-skills-list.js
@@ -16,8 +16,5 @@ export default {
 
   fallbackIsVisible: isVisible('.project-skills-list__fallback'),
 
-  skills: collection({
-    itemScope: '.skill',
-    item: projectSkillItem
-  })
+  skills: collection('.skill', projectSkillItem)
 };

--- a/tests/pages/components/project-switcher-menu.js
+++ b/tests/pages/components/project-switcher-menu.js
@@ -15,18 +15,12 @@ export default {
       scope: '[data-test-new-project]'
     },
 
-    organizations: collection({
-      itemScope: '[data-test-organization]'
-    }),
+    organizations: collection('[data-test-organization]'),
 
-    projects: collection({
-      itemScope: '[data-test-project]',
-
-      item: {
-        icon: {
-          scope: '[data-test-icon]',
-          url: attribute('src')
-        }
+    projects: collection('[data-test-project]', {
+      icon: {
+        scope: '[data-test-icon]',
+        url: attribute('src')
       }
     })
   }

--- a/tests/pages/components/project-users.js
+++ b/tests/pages/components/project-users.js
@@ -10,12 +10,9 @@ export default {
 
   userCount: count('li'),
 
-  users: collection({
-    itemScope: 'li',
-    item: {
-      imageSource: property('src', 'img'),
-      imageIsVisible: isVisible('img'),
-      placeholderIsVisible: isVisible('div.icon')
-    }
+  users: collection('li', {
+    imageSource: property('src', 'img'),
+    imageIsVisible: isVisible('img'),
+    placeholderIsVisible: isVisible('div.icon')
   })
 };

--- a/tests/pages/components/select/github-repo.js
+++ b/tests/pages/components/select/github-repo.js
@@ -14,8 +14,6 @@ export default {
       return this;
     },
 
-    options: collection({
-      itemScope: 'option'
-    })
+    options: collection('option')
   }
 };

--- a/tests/pages/components/site-footer.js
+++ b/tests/pages/components/site-footer.js
@@ -11,31 +11,16 @@ export default {
   clickAboutLink: clickable('ul > li:eq(0) li:eq(0) a'),
   clickTeamLink: clickable('ul > li:eq(0) li:eq(1) a'),
 
-  columns: collection({
-    itemScope: 'ul.footer-columns > li',
-    item: {
-      header: text('h4'),
-      rows: collection({
-        itemScope: 'ul.footer-links > li',
-        item: {
-          link: {
-            scope: 'a',
-            href: attribute('href')
-          },
-          text: text()
-        }
-      })
-    }
+  columns: collection('ul.footer-columns > li', {
+    header: text('h4'),
+    rows: collection('ul.footer-links > li', {
+      link: { scope: 'a', href: attribute('href') },
+      text: text()
+    })
   }),
 
-  rows: collection({
-    itemScope: 'ul.footer-links > li',
-    item: {
-      link: {
-        scope: 'a',
-        href: attribute('href')
-      },
-      text: text()
-    }
+  rows: collection('ul.footer-links > li', {
+    link: { scope: 'a', href: attribute('href') },
+    text: text()
   })
 };

--- a/tests/pages/components/skill-list-items.js
+++ b/tests/pages/components/skill-list-items.js
@@ -3,11 +3,6 @@ import skillListItem from './skill-list-item';
 
 export default {
   scope: 'ul.skills',
-
   listItemCount: count('li'),
-
-  listItems: collection({
-    itemScope: 'li',
-    item: skillListItem
-  })
+  listItems: collection('li', skillListItem)
 };

--- a/tests/pages/components/skills-typeahead-result.js
+++ b/tests/pages/components/skills-typeahead-result.js
@@ -7,7 +7,5 @@ export default {
   mouseenter: triggerable('mouseenter'),
   mousedown: triggerable('mousedown'),
 
-  highlightedStrings: collection({
-    itemScope: 'strong'
-  })
+  highlightedStrings: collection('strong')
 };

--- a/tests/pages/components/skills-typeahead.js
+++ b/tests/pages/components/skills-typeahead.js
@@ -26,10 +26,7 @@ export default {
     scope: '.dropdown-menu',
     resetScope: true,
 
-    inputItems: collection({
-      item: skillsTypeaheadResult,
-      itemScope: skillsTypeaheadResult.scope
-    }),
+    inputItems: collection(skillsTypeaheadResult.scope, skillsTypeaheadResult),
 
     mousedownSecondItem: triggerable('mousedown', 'li:eq(1)'),
     mouseenterSecondItem: triggerable('mouseenter', 'li:eq(1)')

--- a/tests/pages/components/task-board.js
+++ b/tests/pages/components/task-board.js
@@ -3,7 +3,5 @@ import taskListCards from 'code-corps-ember/tests/pages/components/task-list-car
 
 export default {
   scope: '.task-board',
-  taskLists: collection({
-    item: taskListCards
-  })
+  taskLists: collection('', taskListCards)
 };

--- a/tests/pages/components/task-comment-list.js
+++ b/tests/pages/components/task-comment-list.js
@@ -3,8 +3,5 @@ import {
 } from 'ember-cli-page-object';
 
 export default {
-  comments: collection({
-    scope: '.task-comment-list',
-    itemScope: '.comment-item'
-  })
+  comments: collection('.task-comment-list  .comment-item')
 };

--- a/tests/pages/components/task-list-cards.js
+++ b/tests/pages/components/task-list-cards.js
@@ -4,8 +4,5 @@ import {
 import taskCard from './task-card';
 
 export default {
-  taskCards: collection({
-    itemScope: '.task-card',
-    item: taskCard
-  })
+  taskCards: collection('.task-card', taskCard)
 };

--- a/tests/pages/components/thank-you-container.js
+++ b/tests/pages/components/thank-you-container.js
@@ -15,7 +15,5 @@ export default {
 
   thankYouText: text('[data-test-thank-you-message]'),
 
-  volunteers: collection({
-    scope: '[data-test-volunteer-headshot]'
-  })
+  volunteers: collection('[data-test-volunteer-headshot]')
 };

--- a/tests/pages/components/user/skills-list.js
+++ b/tests/pages/components/user/skills-list.js
@@ -9,7 +9,5 @@ export default {
     scope: '[data-test-user-skills-list-empty-state]'
   },
 
-  skills: collection({
-    itemScope: '[data-test-user-skills-list-item]'
-  })
+  skills: collection('[data-test-user-skills-list-item]')
 };

--- a/tests/pages/conversations.js
+++ b/tests/pages/conversations.js
@@ -9,11 +9,6 @@ import conversationListItemWithProject from 'code-corps-ember/tests/pages/compon
 
 export default create({
   visit: visitable('/conversations'),
-
-  conversations: collection({
-    itemScope: '.conversation-list-item',
-    item: conversationListItemWithProject
-  }),
-
+  conversations: collection('.conversation-list-item', conversationListItemWithProject),
   conversationThread
 });

--- a/tests/pages/github.js
+++ b/tests/pages/github.js
@@ -11,8 +11,5 @@ export default create({
   // but it doesn't really seem that flexible for testing
   // this gives us a collection, so we can check count, as well as text for
   // each of them.
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  })
+  flashMessages: collection('.flash-messages--full-width .flash-message')
 });

--- a/tests/pages/onboarding.js
+++ b/tests/pages/onboarding.js
@@ -41,47 +41,31 @@ export default create({
 
   imageDrop,
 
-  popularSkillsList: collection({
-    scope: '[data-test-popular-skills-list]',
-    itemScope: 'button',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  popularSkillsList: collection('[data-test-popular-skills-list] button', {
+    text: text(),
+    click: clickable()
   }),
 
-  roleColumns: collection({
-    itemScope: '.expertise__column',
+  roleColumns: collection('.expertise__column', {
+    hasClass,
 
-    item: {
-      hasClass,
+    header: {
+      scope: 'h3',
+      title: text()
+    },
 
-      header: {
-        scope: 'h3',
-        title: text()
-      },
-
-      roles: collection({
-        itemScope: '.role-item',
-
-        item: {
-          button: {
-            scope: 'button',
-            text: text(),
-            hasClass
-          }
-        }
-      })
-    }
+    roles: collection('.role-item', {
+      button: {
+        scope: 'button',
+        text: text(),
+        hasClass
+      }
+    })
   }),
 
-  userSkillsList: collection({
-    scope: '[data-test-user-skills-list]',
-    itemScope: 'button',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  userSkillsList: collection('[data-test-user-skills-list] button', {
+    text: text(),
+    click: clickable()
   }),
 
   // select and manipulate .skills-typeahead and various site-chrome nodes to

--- a/tests/pages/organization.js
+++ b/tests/pages/organization.js
@@ -16,12 +16,7 @@ export default create({
   description: fillable('[name=description]'),
   clickSave: clickable('.save'),
 
-  successAlerts: collection({
-    scope: '.flash-messages--full-width .alert-success',
-    item: {
-      scope: 'p'
-    }
-  }),
+  successAlerts: collection('.flash-messages--full-width .alert-success', { scope: 'p' }),
 
   clickSettingsMenuItem: clickable('.organization-menu li a:contains("Settings")'),
 
@@ -49,12 +44,8 @@ export default create({
     scope: 'p.description'
   },
 
-  projectListItems: collection({
-    scope: '.project-list .project-item',
-    itemScope: 'h4 a',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  projectListItems: collection('.project-list .project-item h4 a', {
+    text: text(),
+    click: clickable()
   })
 });

--- a/tests/pages/organizations/new.js
+++ b/tests/pages/organizations/new.js
@@ -13,19 +13,14 @@ import navigationMenu from 'code-corps-ember/tests/pages/components/navigation-m
 export default create({
   visit: visitable('organizations/new'),
 
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  }),
+  flashMessages: collection('.flash-messages--full-width .flash-message'),
 
   inviteCodeForm: {
     scope: '[data-test-invite-code-form]',
 
     clickSubmit: clickable('[data-test-submit]'),
 
-    errors: collection({
-      itemScope: '.input-group.has-error'
-    }),
+    errors: collection('.input-group.has-error'),
 
     inputCode: fillable('[name=code]')
   },
@@ -37,9 +32,7 @@ export default create({
 
     clickSubmit: clickable('[data-test-submit]'),
 
-    errors: collection({
-      itemScope: '.input-group.has-error'
-    }),
+    errors: collection('.input-group.has-error'),
 
     imageDrop,
 

--- a/tests/pages/project/conversations.js
+++ b/tests/pages/project/conversations.js
@@ -6,10 +6,7 @@ import statusSelect from 'code-corps-ember/tests/pages/components/conversations/
 export default create({
   visit: visitable(':organization/:project/conversations'),
 
-  conversations: collection({
-    itemScope: '.conversation-list-item',
-    item: conversationListItem
-  }),
+  conversations: collection('.conversation-list-item', conversationListItem),
 
   conversationThread,
 

--- a/tests/pages/project/people.js
+++ b/tests/pages/project/people.js
@@ -7,21 +7,20 @@ import {
 } from 'ember-cli-page-object';
 import userListItem from 'code-corps-ember/tests/pages/components/user-list-item';
 
-function peopleList(role) {
-  return collection({
-    scope: `.people-list--${role}`,
-    itemScope: 'li',
-    item: userListItem,
-
-    isEmpty: isVisible('.people-list--empty')
-  });
-}
-
 export default create({
   visit: visitable('/:project_organization_slug/:project_slug/people'),
 
-  admins: peopleList('admin'),
-  pendingContributors: peopleList('pending'),
+  adminSection: {
+    scope: '.people-list--admin',
+    users: collection('li', userListItem),
+    isEmpty: isVisible('.people-list--empty')
+  },
+
+  pendingSection: {
+    scope: '.people-list--pending',
+    users: collection('li', userListItem),
+    isEmpty: isVisible('.people-list--empty')
+  },
 
   projectMenu: {
     scope: '.project__menu',
@@ -32,6 +31,15 @@ export default create({
     }
   },
 
-  others: peopleList('contributor'),
-  owners: peopleList('owner')
+  contributorSection: {
+    scope: '.people-list--contributor',
+    users: collection('li', userListItem),
+    isEmpty: isVisible('.people-list--empty')
+  },
+
+  ownerSection: {
+    scope: '.people-list--owner',
+    users: collection('li', userListItem),
+    isEmpty: isVisible('.people-list--empty')
+  }
 });

--- a/tests/pages/project/settings/donations.js
+++ b/tests/pages/project/settings/donations.js
@@ -14,27 +14,14 @@ export default create({
 
   donationProgress,
 
-  donationGoals: collection({
-    itemScope: '.donation-goals .donation-goal',
-    item: {
-      clickEdit: clickable('.edit')
-    }
-  }),
+  donationGoals: collection('.donation-goals .donation-goal', { clickEdit: clickable('.edit') }),
 
-  editedDonationGoals: collection({
-    itemScope: '.donation-goals .donation-goal-edit',
-    item: {
-      amount: fillable('input[name=amount]'),
-      description: fillable('textarea[name=description]'),
-      clickSave: clickable('.save'),
-      clickCancel: clickable('.cancel'),
-      validationErrors: collection({
-        itemScope: '.input-error',
-        item: {
-          message: text('')
-        }
-      })
-    }
+  editedDonationGoals: collection('.donation-goals .donation-goal-edit', {
+    amount: fillable('input[name=amount]'),
+    description: fillable('textarea[name=description]'),
+    clickSave: clickable('.save'),
+    clickCancel: clickable('.cancel'),
+    validationErrors: collection('.input-error', { message: text('') })
   }),
 
   errorFormatter,

--- a/tests/pages/project/settings/integrations.js
+++ b/tests/pages/project/settings/integrations.js
@@ -11,14 +11,6 @@ export default create({
   },
 
   installLink,
-
-  connectedInstallations: collection({
-    itemScope: '.github-app-installation.connected',
-    item: connectedInstallation
-  }),
-
-  unconnectedInstallations: collection({
-    itemScope: '.github-app-installation.unconnected',
-    item: unconnectedInstallation
-  })
+  connectedInstallations: collection('.github-app-installation.connected', connectedInstallation),
+  unconnectedInstallations: collection('.github-app-installation.unconnected', unconnectedInstallation)
 });

--- a/tests/pages/project/settings/profile.js
+++ b/tests/pages/project/settings/profile.js
@@ -15,13 +15,9 @@ export default create({
   categoryCheckboxes,
   projectSettingsForm,
 
-  projectSkillsList: collection({
-    scope: '.project-skills-list',
-    itemScope: 'button',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  projectSkillsList: collection('.project-skills-list button', {
+    text: text(),
+    click: clickable()
   }),
 
   skillsTypeahead,

--- a/tests/pages/project/tasks/new.js
+++ b/tests/pages/project/tasks/new.js
@@ -16,9 +16,7 @@ export default create({
   clickPreviewTask: clickable('.preview'),
   clickSubmit: clickable('[name=submit]'),
 
-  errors: collection({
-    scope: '.error'
-  }),
+  errors: collection('.error'),
 
   githubRepo,
 
@@ -34,13 +32,9 @@ export default create({
 
   skillsTypeahead,
 
-  taskSkillsList: collection({
-    scope: '.task-skills-list',
-    itemScope: 'button',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  taskSkillsList: collection('.task-skills-list button', {
+    text: text(),
+    click: clickable()
   }),
 
   visit: visitable(':organization/:project/tasks/new')

--- a/tests/pages/project/tasks/task.js
+++ b/tests/pages/project/tasks/task.js
@@ -35,9 +35,7 @@ export default create({
     }
   },
 
-  errors: collection({
-    itemScope: '.error'
-  }),
+  errors: collection('.error'),
 
   skillsTypeahead,
 
@@ -65,13 +63,9 @@ export default create({
     }
   },
 
-  taskSkillsList: collection({
-    scope: '.task-skills-list',
-    itemScope: 'button',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  taskSkillsList: collection('.task-skills-list button', {
+    text: text(),
+    click: clickable()
   }),
 
   taskTitle: {

--- a/tests/pages/projects.js
+++ b/tests/pages/projects.js
@@ -7,9 +7,5 @@ import projectCard from './components/project-card';
 
 export default create({
   visit: visitable('/projects'),
-
-  projects: collection({
-    itemScope: '.project-card',
-    item: projectCard
-  })
+  projects: collection('.project-card', projectCard)
 });

--- a/tests/pages/projects/new.js
+++ b/tests/pages/projects/new.js
@@ -16,10 +16,7 @@ import skillsTypeahead from 'code-corps-ember/tests/pages/components/skills-type
 export default create({
   visit: visitable(':organization/projects/new'),
 
-  flashMessages: collection({
-    scope: '.flash-messages--full-width',
-    itemScope: '.flash-message'
-  }),
+  flashMessages: collection('.flash-messages--full-width .flash-message'),
 
   navigationMenu,
 
@@ -38,9 +35,7 @@ export default create({
 
     clickSubmit: clickable('[data-test-submit]'),
 
-    errors: collection({
-      itemScope: '.input-group.has-error'
-    }),
+    errors: collection('.input-group.has-error'),
 
     descriptionValue: value('[name=description]'),
 
@@ -49,13 +44,9 @@ export default create({
     inputDescription: fillable('[name=description]'),
     inputTitle: fillable('[name=title]'),
 
-    skillsList: collection({
-      scope: '.project-skills-list',
-      itemScope: 'button',
-      item: {
-        text: text(),
-        click: clickable()
-      }
+    skillsList: collection('.project-skills-list button', {
+      text: text(),
+      click: clickable()
     }),
 
     skillsTypeahead,

--- a/tests/pages/settings/profile.js
+++ b/tests/pages/settings/profile.js
@@ -22,12 +22,8 @@ export default create({
 
   userSettingsForm,
 
-  userSkillsList: collection({
-    scope: '.user-skills-list',
-    itemScope: 'button',
-    item: {
-      text: text(),
-      click: clickable()
-    }
+  userSkillsList: collection('.user-skills-list button', {
+    text: text(),
+    click: clickable()
   })
 });

--- a/tests/pages/team.js
+++ b/tests/pages/team.js
@@ -12,13 +12,13 @@ export default create({
     scope: '.company',
 
     header: text('h2'),
-    items: collection({ scope: 'li' })
+    items: collection('li')
   },
 
   contributors: {
     scope: '.contributors',
 
     header: text('h2'),
-    items: collection({ scope: 'li' })
+    items: collection('li')
   }
 });

--- a/tests/pages/user.js
+++ b/tests/pages/user.js
@@ -10,13 +10,9 @@ import userDetails from './components/user-details';
 export default create({
   visit: visitable(':username'),
 
-  projects: collection({
-    scope: '.user-projects-list li',
-    itemScope: 'h4 a',
-    item: {
-      click: clickable(),
-      href: attribute('href')
-    }
+  projects: collection('.user-projects-list li h4 a', {
+    click: clickable(),
+    href: attribute('href')
   }),
 
   userDetails

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,9 +2487,13 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^1.0.0, dotenv@^1.2.0:
+dotenv@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-1.2.0.tgz#7cd73e16e07f057c8072147a5bc3a8677f0ab5c6"
+
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2804,12 +2808,13 @@ ember-cli-deploy@1.0.2:
     rsvp "^3.3.3"
     silent-error "^1.0.0"
 
-ember-cli-dotenv@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-dotenv/-/ember-cli-dotenv-1.2.0.tgz#11aab75ee3d98305799778dad58072fca97c57f1"
+ember-cli-dotenv@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-dotenv/-/ember-cli-dotenv-2.0.0.tgz#2c09fc5f8b60f690c9e02428b4f4e3f0b8c64421"
   dependencies:
-    dotenv "^1.0.0"
-    exists-sync "0.0.3"
+    dotenv "^4.0.0"
+    ember-cli-babel "^6.6.0"
+    minimist "^1.2.0"
 
 ember-cli-eslint@^4.2.1:
   version "4.2.2"
@@ -3014,15 +3019,14 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-page-object@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.13.0.tgz#9ac9342d9f90a363c429fbb14f3ad5c0be11827a"
+ember-cli-page-object@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.14.1.tgz#2e3599c204c56440c6c8154fc686c603816f877a"
   dependencies:
     ceibo "~2.0.0"
     ember-cli-babel "^6.6.0"
     ember-cli-node-assets "^0.2.2"
     ember-native-dom-helpers "^0.5.3"
-    ember-test-helpers "^0.6.3"
     jquery "^3.2.1"
     rsvp "^4.7.0"
 
@@ -3298,13 +3302,6 @@ ember-data@~2.18.0:
     npm-git-info "^1.0.0"
     semver "^5.1.0"
     silent-error "^1.0.0"
-
-ember-deferred-content@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-deferred-content/-/ember-deferred-content-0.2.0.tgz#bc92bc99ff7b66c0bf10bedb343bff49a88d9956"
-  dependencies:
-    ember-cli-babel "^5.1.5"
-    ember-cli-htmlbars "^1.0.1"
 
 ember-disable-proxy-controllers@^1.0.1:
   version "1.0.1"
@@ -3725,10 +3722,6 @@ ember-stripe-service@7.0.0:
   resolved "https://registry.yarnpkg.com/ember-stripe-service/-/ember-stripe-service-7.0.0.tgz#da79bfbf1b4efe0cdeabaee90961a180884b7ab4"
   dependencies:
     ember-cli-babel "^5.1.7"
-
-ember-test-helpers@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
 ember-test-selectors@^0.3.4:
   version "0.3.7"


### PR DESCRIPTION
This is a big one, primarily due to changes in the `ember-cli-page-object` public API

The major things I had to change to avoid deprecations:

- `page.render` is deprecated, so `this.render` has to be used. That means I had to get rid of the `renderPage` function in all of our tests. The loss is that there is some code duplication now, but the gain is that the tests are far more explicit and easier to read through
- `collection` API has changed
  - `items().count` is now `items.length`
  - `items(index).foo` is now `items.objectAt(index).foo`

- the collection definition changed from 

```Javascript
items: collection({
  scope: '.foo',
  itemScope: '.bar',
  item: itemDefinitionObject
})
```

to 

```Javascript
items: collection('.foo .bar', itemDefinitionObject)
```