### PR TITLE
Added native dom helpers support for Ember CLI Page Objects

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,10 +3,12 @@ import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { useNativeEvents } from 'ember-cli-page-object/extend';
 import loadEmberExam from 'ember-exam/test-support/load';
 import './helpers/flash-message';
 
 loadEmberExam();
+useNativeEvents();
 run.later = run.next;
 setApplication(Application.create(config.APP));
 start();


### PR DESCRIPTION
Progress on: #1682

Switch Ember CLI Page Objects to use native dom helpers 

There are some failing tests, see this gist for a list

https://gist.github.com/jderr-mx/ac7023350c252e058dbe86a82c80ac6b

